### PR TITLE
Update version info and enable SourceLink

### DIFF
--- a/src/SqlBinding/SqlBinding.csproj
+++ b/src/SqlBinding/SqlBinding.csproj
@@ -8,19 +8,19 @@
     <Product>SQL Binding Extension</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-	<DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>true</DebugSymbols>
     <IncludeSymbols>false</IncludeSymbols>
     <DebugType>embedded</DebugType>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Sql</PackageId>
-	<PublishRepositoryUrl>true</PublishRepositoryUrl>
-	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Version>1.0.0-preview2</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.*" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.*" />
-	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>SqlExtension.Tests</_Parameter1>
     </AssemblyAttribute>

--- a/src/SqlBinding/SqlBinding.csproj
+++ b/src/SqlBinding/SqlBinding.csproj
@@ -1,28 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Description>SQL binding extension for Azure Functions</Description>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Product>SQL Binding Extension</Product>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-	<IncludeSymbols>true</IncludeSymbols>
-	<DebugType>embedded</DebugType>
-	<PackageId>Microsoft.Azure.WebJobs.Extensions.Sql</PackageId>
-	<Version>1.0.0-preview1</Version>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+	<DebugSymbols>true</DebugSymbols>
+    <IncludeSymbols>false</IncludeSymbols>
+    <DebugType>embedded</DebugType>
+    <PackageId>Microsoft.Azure.WebJobs.Extensions.Sql</PackageId>
+	<PublishRepositoryUrl>true</PublishRepositoryUrl>
+	<EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Version>1.0.0-preview2</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.16" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
-	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-	    <_Parameter1>SqlExtension.Tests</_Parameter1>
-	</AssemblyAttribute>
-	<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-		  <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
-	</AssemblyAttribute>
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.*" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.*" />
+	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>SqlExtension.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates the nuget package to 1.0.0-preview2, which includes the SQL trigger.

I also enabled SourceLink, so that customers can debug our source code if they want (a very convenient feature).