### PR TITLE
Auto version nuget package

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -14,7 +14,7 @@ variables:
   configuration: 'Release'  
   versionMajor: 0
   versionMinor: 1
-  versionPatch: $[counter(variables['versionMinor'], 0)] #this will reset when we bump minor version
+  versionPatch: $[counter(variables['versionMinor'], 0)] # This will reset when we bump minor version
   nugetVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
 
 stages:

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -11,8 +11,11 @@ schedules:
 
 variables:
   solution: '**/*.sln'
-  configuration: 'Release'
-  nugetVersion: '0.1.0-preview'
+  configuration: 'Release'  
+  versionMajor: 0
+  versionMinor: 1
+  versionPatch: $[counter(variables['versionMinor'], 0)] #this will reset when we bump minor version
+  nugetVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
 
 stages:
 - stage: BuildPublish

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -24,6 +24,7 @@ steps:
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
 
   # Above build task generates a nuget package, this extra step packs into a -preview nuget with same version #
+  # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
 - task: DotNetCoreCLI@2
   displayName: '.NET Pack Preview Nuget'
   inputs:

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -29,7 +29,7 @@ steps:
   inputs:
     command: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build /p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -29,7 +29,7 @@ steps:
   inputs:
     command: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build --version-suffix "preview" /p:PackageVersion="${{ parameters.nugetVersion }}"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build /p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -29,7 +29,7 @@ steps:
   inputs:
     command: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -29,7 +29,7 @@ steps:
   inputs:
     command: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:Version="${{ parameters.nugetVersion }}-preview"'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -23,13 +23,13 @@ steps:
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
 
-  # Above build task generates a nuget package automatically, this extra step packs into a -preview nuget with same version #
+  # Above build task generates a nuget package, this extra step packs into a -preview nuget with same version #
 - task: DotNetCoreCLI@2
   displayName: '.NET Pack Preview Nuget'
   inputs:
-    command: pack
+    command: custom
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build'
+    arguments: 'pack --configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -30,7 +30,7 @@ steps:
     command: custom
     custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build -p:GeneratePackageOnBuild=false'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -30,7 +30,7 @@ steps:
     command: custom
     custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -21,7 +21,7 @@ steps:
   inputs:
     command: build
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) /p:PackageVersion="${{ parameters.nugetVersion }}"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
 
   # Above build task generates a nuget package automatically, this extra step packs into a -preview nuget with same version #
 - task: DotNetCoreCLI@2
@@ -29,7 +29,7 @@ steps:
   inputs:
     command: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:Version="${{ parameters.nugetVersion }}-preview"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -30,7 +30,7 @@ steps:
     command: custom
     custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview"'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build -p:GeneratePackageOnBuild=false'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -28,8 +28,9 @@ steps:
   displayName: '.NET Pack Preview Nuget'
   inputs:
     command: custom
+    custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: 'pack --configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" --no-build'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -23,6 +23,14 @@ steps:
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) /p:PackageVersion="${{ parameters.nugetVersion }}"'
 
+  # Above build task generates a nuget package automatically, this extra step packs into a -preview nuget with same version #
+- task: DotNetCoreCLI@2
+  displayName: '.NET Pack Preview Nuget'
+  inputs:
+    command: pack
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build --version-suffix "preview" /p:PackageVersion="${{ parameters.nugetVersion }}"'
+
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'
   inputs:

--- a/src/SqlBinding/SqlBinding.csproj
+++ b/src/SqlBinding/SqlBinding.csproj
@@ -14,7 +14,6 @@
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Sql</PackageId>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <Version>1.0.0-preview3</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Automatic versioning of nuget package
  - Version major and minor are defined in release yaml
  - Version patch # is incremented every build
  - Version patch # resets to 0 when the minor version changes
- Also added a dotnet pack task to generate a preview nuget (every build will have 2 nupkgs)