### PR TITLE
Update nightly SQL bindings build to run always

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -8,6 +8,7 @@ schedules:
     branches:
       include:
         - dev
+    always: true
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
Apparently always tag is defaulted to false, causing nightly build to only be scheduled when there are code changes.