### PR TITLE
Add test for GetTableAndSchema

### DIFF
--- a/src/SqlBinding/SqlBindingUtilities.cs
+++ b/src/SqlBinding/SqlBindingUtilities.cs
@@ -207,12 +207,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
         public static void GetTableAndSchema(string fullName, out string schema, out string tableName)
         {
-            // defaults
-            tableName = fullName;
-            schema = "SCHEMA_NAME()"; // default to user schema
-
             // remove [ ] from name if necessary
             string cleanName = fullName.Replace("]", string.Empty).Replace("[", string.Empty);
+
+            // defaults
+            tableName = cleanName;
+            schema = "SCHEMA_NAME()"; // default to user schema
 
             // if in format schema.table, split into two parts for query
             string[] pieces = cleanName.Split('.');

--- a/test/SqlExtension.Tests/SqlOutputBindingTests.cs
+++ b/test/SqlExtension.Tests/SqlOutputBindingTests.cs
@@ -40,5 +40,23 @@ namespace SqlExtension.Tests
             };
             await collector.AddAsync(data);
         }
+
+        [Fact]
+        public void TestGetTableAndSchema()
+        {
+            var fullName = "[schema].[table]";
+            SqlBindingUtilities.GetTableAndSchema(fullName, out string schema, out string tableName);
+            Assert.Equal("'schema'", schema);
+            Assert.Equal("table", tableName);
+        }
+
+        [Fact]
+        public void TestGetTableAndSchemaWithNoSchema()
+        {
+            var fullName = "[table]";
+            SqlBindingUtilities.GetTableAndSchema(fullName, out string schema, out string tableName);
+            Assert.Equal("SCHEMA_NAME()", schema);
+            Assert.Equal("table", tableName);
+        }
     }
 }


### PR DESCRIPTION
Made a small fix in GetTableAndSchema where the brackets would not be removed if the fullName was not in schema.table format.