### PR TITLE
Fix datetime/date/smalldatetime precision

### DIFF
--- a/src/SqlBinding/SqlAsyncCollector.cs
+++ b/src/SqlBinding/SqlAsyncCollector.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 		                    case 
 			                    when CHARACTER_MAXIMUM_LENGTH = -1 then '(max)'
 			                    when CHARACTER_MAXIMUM_LENGTH <> -1 then '(' + cast(CHARACTER_MAXIMUM_LENGTH as varchar(4)) + ')'
-                                when DATETIME_PRECISION is not null and DATA_TYPE <> 'datetime' then '(' + cast(DATETIME_PRECISION as varchar(1)) + ')'
+                                when DATETIME_PRECISION is not null and DATA_TYPE not in ('datetime', 'date', 'smalldatetime') then '(' + cast(DATETIME_PRECISION as varchar(1)) + ')'
 			                    when DATA_TYPE in ('decimal', 'numeric') then '(' + cast(NUMERIC_PRECISION as varchar(9)) + ',' + + cast(NUMERIC_SCALE as varchar(9)) + ')'
 			                    else ''
 		                    end as {ColumnDefinition}	

--- a/src/SqlBinding/SqlAsyncCollector.cs
+++ b/src/SqlBinding/SqlAsyncCollector.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 		                    case 
 			                    when CHARACTER_MAXIMUM_LENGTH = -1 then '(max)'
 			                    when CHARACTER_MAXIMUM_LENGTH <> -1 then '(' + cast(CHARACTER_MAXIMUM_LENGTH as varchar(4)) + ')'
-                                when DATETIME_PRECISION is not null then '(' + cast(DATETIME_PRECISION as varchar(1)) + ')'
+                                when DATETIME_PRECISION is not null and DATA_TYPE <> 'datetime' then '(' + cast(DATETIME_PRECISION as varchar(1)) + ')'
 			                    when DATA_TYPE in ('decimal', 'numeric') then '(' + cast(NUMERIC_PRECISION as varchar(9)) + ',' + + cast(NUMERIC_SCALE as varchar(9)) + ')'
 			                    else ''
 		                    end as {ColumnDefinition}	


### PR DESCRIPTION
Addresses #36 functionally; I put some details in the issue, but this comes down to the fact that you can specify a precision for `datetime2` but not `datetime`.

After integration tests are in, I would like for us to plan for how to best handle this class of issue and certainly have some automation for this particular case.

Edit: date/smalldatetime also had the same issue