### PR TITLE
Fix IDE0019 pattern matching issue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,6 @@ dotnet_diagnostic.IDE0017.severity = silent
 dotnet_diagnostic.IDE0044.severity = silent
 dotnet_diagnostic.IDE0001.severity = silent
 dotnet_diagnostic.IDE0002.severity = silent
-dotnet_diagnostic.IDE0019.severity = silent
 
 #### Core EditorConfig Options ####
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,7 +26,6 @@ dotnet_diagnostic.IDE0017.severity = silent
 dotnet_diagnostic.IDE0044.severity = silent
 dotnet_diagnostic.IDE0001.severity = silent
 dotnet_diagnostic.IDE0002.severity = silent
-dotnet_diagnostic.IDE0019.severity = silent
 
 #### Core EditorConfig Options ####
 
@@ -36,7 +35,6 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = false
 
 #### .NET Coding Conventions ####

--- a/.editorconfig
+++ b/.editorconfig
@@ -26,6 +26,7 @@ dotnet_diagnostic.IDE0017.severity = silent
 dotnet_diagnostic.IDE0044.severity = silent
 dotnet_diagnostic.IDE0001.severity = silent
 dotnet_diagnostic.IDE0002.severity = silent
+dotnet_diagnostic.IDE0019.severity = silent
 
 #### Core EditorConfig Options ####
 

--- a/samples/SqlExtensionSamples/SqlExtensionSamples.csproj
+++ b/samples/SqlExtensionSamples/SqlExtensionSamples.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/samples/SqlExtensionSamples/SqlExtensionSamples.csproj
+++ b/samples/SqlExtensionSamples/SqlExtensionSamples.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/test/SqlExtension.Tests/SqlExtension.Tests.csproj
+++ b/test/SqlExtension.Tests/SqlExtension.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/SqlExtension.Tests/SqlExtension.Tests.csproj
+++ b/test/SqlExtension.Tests/SqlExtension.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/SqlExtension.Tests/TestData.cs
+++ b/test/SqlExtension.Tests/TestData.cs
@@ -2,7 +2,9 @@
 
 namespace SqlExtension.Tests
 {
+    #pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public class TestData
+    #pragma warning restore CS0659
     {
         public int ID { get; set; }
 
@@ -20,11 +22,6 @@ namespace SqlExtension.Tests
             }
             return this.ID == otherData.ID && this.Cost == otherData.Cost && ((this.Name == null && otherData.Name == null) ||
                 string.Equals(this.Name, otherData.Name, StringComparison.OrdinalIgnoreCase)) && this.Timestamp.Equals(otherData.Timestamp);
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(ID, Name, Cost, Timestamp);
         }
     }
 }

--- a/test/SqlExtension.Tests/TestData.cs
+++ b/test/SqlExtension.Tests/TestData.cs
@@ -2,9 +2,7 @@
 
 namespace SqlExtension.Tests
 {
-    #pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public class TestData
-    #pragma warning restore CS0659
     {
         public int ID { get; set; }
 
@@ -22,6 +20,11 @@ namespace SqlExtension.Tests
             }
             return this.ID == otherData.ID && this.Cost == otherData.Cost && ((this.Name == null && otherData.Name == null) ||
                 string.Equals(this.Name, otherData.Name, StringComparison.OrdinalIgnoreCase)) && this.Timestamp.Equals(otherData.Timestamp);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(ID, Name, Cost, Timestamp);
         }
     }
 }

--- a/test/SqlExtension.Tests/TestData.cs
+++ b/test/SqlExtension.Tests/TestData.cs
@@ -16,8 +16,7 @@ namespace SqlExtension.Tests
 
         public override bool Equals(object obj)
         {
-            var otherData = obj as TestData;
-            if (otherData == null)
+            if (!(obj is TestData otherData))
             {
                 return false;
             }

--- a/test/SqlExtension.Tests/TestData.cs
+++ b/test/SqlExtension.Tests/TestData.cs
@@ -2,9 +2,7 @@
 
 namespace SqlExtension.Tests
 {
-    #pragma warning disable CS0659 // Type overrides Object.Equals(object o) but does not override Object.GetHashCode()
     public class TestData
-    #pragma warning restore CS0659
     {
         public int ID { get; set; }
 
@@ -16,13 +14,17 @@ namespace SqlExtension.Tests
 
         public override bool Equals(object obj)
         {
-            var otherData = obj as TestData;
-            if (otherData == null)
+            if (!(obj is TestData otherData))
             {
                 return false;
             }
             return this.ID == otherData.ID && this.Cost == otherData.Cost && ((this.Name == null && otherData.Name == null) ||
                 string.Equals(this.Name, otherData.Name, StringComparison.OrdinalIgnoreCase)) && this.Timestamp.Equals(otherData.Timestamp);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(ID, Name, Cost, Timestamp);
         }
     }
 }

--- a/test/SqlExtension.Tests/TestData.cs
+++ b/test/SqlExtension.Tests/TestData.cs
@@ -16,7 +16,8 @@ namespace SqlExtension.Tests
 
         public override bool Equals(object obj)
         {
-            if (!(obj is TestData otherData))
+            var otherData = obj as TestData;
+            if (otherData == null)
             {
                 return false;
             }


### PR DESCRIPTION
    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

wasn't included in all of the .csproj files.

Happy to split that out if we want into a separate PR. Could also put this in a .props file, but that seemed a bit silly for one property. Happy to hear opinions here.

Finally, I'm unclear why it shows every line as changed. Is that because line endings are defined as clrf? It only shows a couple of lines as changed for me in VS Code:

![image](https://user-images.githubusercontent.com/40371649/135537482-a8e00f89-a14e-4cbd-9fe4-f6dfc393ae09.png)

