### PR TITLE
Update to .NET 5.0.x and latest AF package version

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -5,9 +5,9 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Install .NET Core SDK 3.1.x for Build'
+  displayName: 'Install .NET Core SDK for Build'
   inputs:
-    version: '3.1.x'
+    version: '5.0.x'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Restore'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -9,6 +9,11 @@ steps:
   inputs:
     version: '5.0.x'
 
+- task: UseDotNet@2
+  displayName: 'Install .NET Core 3.1 SDK for Azure Functions Build'
+  inputs:
+    version: '3.1.x'
+
 - task: DotNetCoreCLI@2
   displayName: '.NET Restore'
   inputs:

--- a/samples/SqlExtensionSamples/SqlExtensionSamples.csproj
+++ b/samples/SqlExtensionSamples/SqlExtensionSamples.csproj
@@ -1,19 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	
+
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
-	
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\SqlBinding\SqlBinding.csproj" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <None Update="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -23,5 +23,5 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
   </ItemGroup>
-	
+
 </Project>


### PR DESCRIPTION
This is necessary for the builds to fail when there are code analyzer issues, and in general using the latest SDK should be preferred. 

Note that we still need to install the 3.1 SDK until we update to target a newer version of the AF package - I tried doing that and it appears it'll take a bit more work so just leaving it with both SDK versions for now. 