### PR TITLE
Publish code coverage results in test pipeline

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -39,3 +39,9 @@ steps:
     command: test
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\'
+
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish Code Coverage Results'
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Build.ArtifactStagingDirectory)\TestResults\coverage\coverage.cobertura.xml'

--- a/builds/azure-pipelines/template-steps-publish.yml
+++ b/builds/azure-pipelines/template-steps-publish.yml
@@ -41,9 +41,3 @@ steps:
   inputs:
     targetPath: '$(Build.ArtifactStagingDirectory)' 
     artifactName: 'drop'
-
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish Code Coverage Results'
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Build.ArtifactStagingDirectory)\TestResults\coverage\coverage.cobertura.xml'


### PR DESCRIPTION
Moving the publish code coverage results step to template-steps-build-test.yml so that it also gets run in the PR validation pipeline