### PR TITLE
Fix IDE0008

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,6 @@ dotnet_analyzer_diagnostic.category-Style.severity = error
 dotnet_analyzer_diagnostic.category-CodeQuality.severity = error
 # Disable warnings from existing issues until we can go through and fix them
 dotnet_diagnostic.IDE0130.severity = silent
-dotnet_diagnostic.IDE0008.severity = silent
 dotnet_diagnostic.IDE0047.severity = silent
 dotnet_diagnostic.IDE0036.severity = silent
 dotnet_diagnostic.IDE0130.severity = silent

--- a/samples/SqlExtensionSamples/OutputBindingSamples/AddProductsAsyncCollector.cs
+++ b/samples/SqlExtensionSamples/OutputBindingSamples/AddProductsAsyncCollector.cs
@@ -20,7 +20,7 @@ namespace SqlExtensionSamples
             [Sql("Products", ConnectionStringSetting = "SqlConnectionString")] IAsyncCollector<Product> products)
         {
             List<Product> newProducts = GetNewProducts(5000);
-            foreach (var product in newProducts)
+            foreach (Product product in newProducts)
             {
                 await products.AddAsync(product);
             }
@@ -28,7 +28,7 @@ namespace SqlExtensionSamples
             await products.FlushAsync();
 
             newProducts = GetNewProducts(5000);
-            foreach (var product in newProducts)
+            foreach (Product product in newProducts)
             {
                 await products.AddAsync(product);
             }

--- a/samples/SqlExtensionSamples/OutputBindingSamples/AddProductsCollector.cs
+++ b/samples/SqlExtensionSamples/OutputBindingSamples/AddProductsCollector.cs
@@ -19,7 +19,7 @@ namespace SqlExtensionSamples
             [Sql("Products", ConnectionStringSetting = "SqlConnectionString")] ICollector<Product> products)
         {
             List<Product> newProducts = GetNewProducts(5000);
-            foreach (var product in newProducts)
+            foreach (Product product in newProducts)
             {
                 products.Add(product);
             }

--- a/samples/SqlExtensionSamples/OutputBindingSamples/QueueTriggerProducts.cs
+++ b/samples/SqlExtensionSamples/OutputBindingSamples/QueueTriggerProducts.cs
@@ -24,7 +24,7 @@ namespace SqlExtensionSamples.OutputBindingSamples
             sw.Start();
 
             List<Product> newProducts = GetNewProducts(totalUpserts, 2 * 100);
-            foreach (var product in newProducts)
+            foreach (Product product in newProducts)
             {
                 products.Add(product);
             }

--- a/samples/SqlExtensionSamples/OutputBindingSamples/TimerTriggerProducts.cs
+++ b/samples/SqlExtensionSamples/OutputBindingSamples/TimerTriggerProducts.cs
@@ -25,7 +25,7 @@ namespace SqlExtensionSamples.TriggerBindingSamples
             sw.Start();
 
             List<Product> newProducts = GetNewProducts(totalUpserts, _executionNumber * 100);
-            foreach (var product in newProducts)
+            foreach (Product product in newProducts)
             {
                 products.Add(product);
             }

--- a/src/SqlBinding/SqlAsyncCollector.cs
+++ b/src/SqlBinding/SqlAsyncCollector.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 GenerateDataQueryForMerge(tableInfo, batch, out string newDataQuery, out string rowData);
                 var cmd = new SqlCommand($"{newDataQuery} {tableInfo.MergeQuery};", connection);
-                var par = cmd.Parameters.Add(RowDataParameter, SqlDbType.NVarChar, -1);
+                SqlParameter par = cmd.Parameters.Add(RowDataParameter, SqlDbType.NVarChar, -1);
                 par.Value = rowData;
 
                 await cmd.ExecuteNonQueryAsync();
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 // 3. Match SQL Primary Key column names to POCO field/property objects. Ensure none are missing.
                 IEnumerable<MemberInfo> primaryKeyFields = typeof(T).GetMembers().Where(f => primaryKeys.Contains(f.Name, StringComparer.OrdinalIgnoreCase));
                 IEnumerable<string> primaryKeysFromPOCO = primaryKeyFields.Select(f => f.Name);
-                var missingFromPOCO = primaryKeys.Except(primaryKeysFromPOCO, StringComparer.OrdinalIgnoreCase);
+                IEnumerable<string> missingFromPOCO = primaryKeys.Except(primaryKeysFromPOCO, StringComparer.OrdinalIgnoreCase);
                 if (missingFromPOCO.Any())
                 {
                     string message = $"All primary keys for SQL table '{tableName}' and schema '{schema}' need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingFromPOCO)}]";
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     if (properties.ContainsKey(column.Key))
                     {
                         // Lower-case the property name during serialization to match SQL casing
-                        var sqlColumn = properties[column.Key];
+                        JsonProperty sqlColumn = properties[column.Key];
                         sqlColumn.PropertyName = sqlColumn.PropertyName.ToLowerInvariant();
                         propertiesToSerialize.Add(sqlColumn);
                     }

--- a/src/SqlBinding/SqlBindingConfigProvider.cs
+++ b/src/SqlBinding/SqlBindingConfigProvider.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            var inputOutputRule = context.AddBindingRule<SqlAttribute>();
+#pragma warning disable CS0618 // Fine to use this for our stuff
+            FluentBindingRule<SqlAttribute> inputOutputRule = context.AddBindingRule<SqlAttribute>();
             var converter = new SqlConverter(_configuration);
             inputOutputRule.BindToInput<SqlCommand>(converter);
             inputOutputRule.BindToInput<string>(typeof(SqlGenericsConverter<string>), _configuration);

--- a/src/SqlBinding/SqlBindingUtilities.cs
+++ b/src/SqlBinding/SqlBindingUtilities.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 // I.e., ",,@param1=param1,,@param2=param2,,," will be parsed just like "@param1=param1,@param2=param2" is.
                 string[] paramPairs = parameters.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
 
-                foreach (var pair in paramPairs)
+                foreach (string pair in paramPairs)
                 {
                     // Note that we don't throw away empty entries here, so a parameter pair that looks like "=@param1=param1"
                     // or "@param2=param2=" is considered malformed
@@ -145,14 +145,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             if (cols.Count == 0)
             {
-                for (var i = 0; i < reader.FieldCount; i++)
+                for (int i = 0; i < reader.FieldCount; i++)
                 {
                     cols.Add(reader.GetName(i));
                 }
             }
 
             var result = new Dictionary<string, string>();
-            foreach (var col in cols)
+            foreach (string col in cols)
             {
                 result.Add(col, reader[col].ToString());
             }

--- a/test/SqlExtension.Tests/SqlInputBindingTests.cs
+++ b/test/SqlExtension.Tests/SqlInputBindingTests.cs
@@ -69,7 +69,7 @@ namespace SqlExtension.Tests
         public void TestNullCurrentValueEnumerator()
         {
             var enumerable = new SqlAsyncEnumerable<string>(connection, new SqlAttribute(""));
-            var enumerator = enumerable.GetAsyncEnumerator();
+            IAsyncEnumerator<string> enumerator = enumerable.GetAsyncEnumerator();
             Assert.Null(enumerator.Current);
         }
 
@@ -101,14 +101,14 @@ namespace SqlExtension.Tests
         [Fact]
         public void TestValidCommandType()
         {
-            var query = "select * from Products";
+            string query = "select * from Products";
             var attribute = new SqlAttribute(query);
             attribute.CommandType = System.Data.CommandType.Text;
-            var command = SqlBindingUtilities.BuildCommand(attribute, null);
+            SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, null);
             Assert.Equal(System.Data.CommandType.Text, command.CommandType);
             Assert.Equal(query, command.CommandText);
 
-            var procedure = "StoredProceudre";
+            string procedure = "StoredProceudre";
             attribute = new SqlAttribute(procedure);
             attribute.CommandType = System.Data.CommandType.StoredProcedure;
             command = SqlBindingUtilities.BuildCommand(attribute, null);


### PR DESCRIPTION
Use explicit types instead of var https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008

Opposite of the previous one, use explicit type where the type isn't apparent.

(The string ones are questionable IMO, but it's a very minor difference so I'm willing to just go along with what they have)