### PR TITLE
Enable IDE0017 - Use object initializers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,7 +16,6 @@ dotnet_diagnostic.IDE0058.severity = silent
 dotnet_diagnostic.IDE0003.severity = silent
 dotnet_diagnostic.IDE0032.severity = silent
 dotnet_diagnostic.IDE0046.severity = silent
-dotnet_diagnostic.IDE0017.severity = silent
 dotnet_diagnostic.IDE0044.severity = silent
 dotnet_diagnostic.IDE0001.severity = silent
 dotnet_diagnostic.IDE0002.severity = silent

--- a/src/SqlBinding/SqlBindingUtilities.cs
+++ b/src/SqlBinding/SqlBindingUtilities.cs
@@ -114,9 +114,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <returns>The built SqlCommand</returns>
         public static SqlCommand BuildCommand(SqlAttribute attribute, SqlConnection connection)
         {
-            var command = new SqlCommand();
-            command.Connection = connection;
-            command.CommandText = attribute.CommandText;
+            var command = new SqlCommand
+            {
+                Connection = connection,
+                CommandText = attribute.CommandText
+            };
             if (attribute.CommandType == CommandType.StoredProcedure)
             {
                 command.CommandType = CommandType.StoredProcedure;

--- a/test/SqlExtension.Tests/SqlInputBindingTests.cs
+++ b/test/SqlExtension.Tests/SqlInputBindingTests.cs
@@ -79,8 +79,10 @@ namespace SqlExtension.Tests
             var attribute = new SqlAttribute("");
             Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, config.Object));
 
-            attribute = new SqlAttribute("");
-            attribute.ConnectionStringSetting = "ConnectionStringSetting";
+            attribute = new SqlAttribute("")
+            {
+                ConnectionStringSetting = "ConnectionStringSetting"
+            };
             Assert.Throws<ArgumentNullException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, null));
         }
 
@@ -88,8 +90,10 @@ namespace SqlExtension.Tests
         public void TestInvalidCommandType()
         {
             // Specify an invalid type
-            var attribute = new SqlAttribute("");
-            attribute.CommandType = System.Data.CommandType.TableDirect;
+            var attribute = new SqlAttribute("")
+            {
+                CommandType = System.Data.CommandType.TableDirect
+            };
             Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
 
 
@@ -102,15 +106,19 @@ namespace SqlExtension.Tests
         public void TestValidCommandType()
         {
             string query = "select * from Products";
-            var attribute = new SqlAttribute(query);
-            attribute.CommandType = System.Data.CommandType.Text;
+            var attribute = new SqlAttribute(query)
+            {
+                CommandType = System.Data.CommandType.Text
+            };
             SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, null);
             Assert.Equal(System.Data.CommandType.Text, command.CommandType);
             Assert.Equal(query, command.CommandText);
 
             string procedure = "StoredProceudre";
-            attribute = new SqlAttribute(procedure);
-            attribute.CommandType = System.Data.CommandType.StoredProcedure;
+            attribute = new SqlAttribute(procedure)
+            {
+                CommandType = System.Data.CommandType.StoredProcedure
+            };
             command = SqlBindingUtilities.BuildCommand(attribute, null);
             Assert.Equal(System.Data.CommandType.StoredProcedure, command.CommandType);
             Assert.Equal(procedure, command.CommandText);


### PR DESCRIPTION
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0017

Totally get that lines are being added, but I find this much clearer to inspect initial property values.