### PR TITLE
Fix IDE0058

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,6 @@ dotnet_diagnostic.IDE0008.severity = silent
 dotnet_diagnostic.IDE0047.severity = silent
 dotnet_diagnostic.IDE0036.severity = silent
 dotnet_diagnostic.IDE0130.severity = silent
-dotnet_diagnostic.IDE0058.severity = silent
 dotnet_diagnostic.IDE0003.severity = silent
 dotnet_diagnostic.IDE0032.severity = silent
 dotnet_diagnostic.IDE0046.severity = silent

--- a/src/SqlBinding/SqlAsyncCollector.cs
+++ b/src/SqlBinding/SqlAsyncCollector.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 finally
                 {
-                    _rowLock.Release();
+                    _ = _rowLock.Release();
                 }
             }
         }
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             }
             finally
             {
-                _rowLock.Release();
+                _ = _rowLock.Release();
             }
         }
 
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 var par = cmd.Parameters.Add(RowDataParameter, SqlDbType.NVarChar, -1);
                 par.Value = rowData;
 
-                await cmd.ExecuteNonQueryAsync();
+                _ = await cmd.ExecuteNonQueryAsync();
             }
             await connection.CloseAsync();
         }
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 // we can assume that if two rows with the same primary key are in the list, they will collide
                 foreach (PropertyInfo primaryKey in table.PrimaryKeys)
                 {
-                    combinedPrimaryKey.Append(primaryKey.GetValue(row).ToString());
+                    _ = combinedPrimaryKey.Append(primaryKey.GetValue(row).ToString());
                 }
 
                 // If we have already seen this unique primary key, skip this update
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 			                    when DATA_TYPE in ('decimal', 'numeric') then '(' + cast(NUMERIC_PRECISION as varchar(9)) + ',' + + cast(NUMERIC_SCALE as varchar(9)) + ')'
 			                    else ''
 		                    end as {ColumnDefinition}
-                    from 
+                    from
 	                    INFORMATION_SCHEMA.COLUMNS c
                     where
 	                    c.TABLE_NAME = {quotedTableName}
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 var primaryKeyMatchingQuery = new StringBuilder($"ExistingData.{primaryKeys[0]} = NewData.{primaryKeys[0]}");
                 foreach (string primaryKey in primaryKeys.Skip(1))
                 {
-                    primaryKeyMatchingQuery.Append($" AND ExistingData.{primaryKey} = NewData.{primaryKey}");
+                    _ = primaryKeyMatchingQuery.Append($" AND ExistingData.{primaryKey} = NewData.{primaryKey}");
                 }
 
                 // Generate the UPDATE part of the merge query (all columns that should be updated)
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 var columnMatchingQueryBuilder = new StringBuilder();
                 foreach (string column in columnNamesFromSQL)
                 {
-                    columnMatchingQueryBuilder.Append($" ExistingData.{column} = NewData.{column},");
+                    _ = columnMatchingQueryBuilder.Append($" ExistingData.{column} = NewData.{column},");
                 }
 
                 string columnMatchingQuery = columnMatchingQueryBuilder.ToString().TrimEnd(',');

--- a/src/SqlBinding/SqlBindingConfigProvider.cs
+++ b/src/SqlBinding/SqlBindingConfigProvider.cs
@@ -48,10 +48,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             }
             var inputOutputRule = context.AddBindingRule<SqlAttribute>();
             var converter = new SqlConverter(_configuration);
-            inputOutputRule.BindToInput<SqlCommand>(converter);
-            inputOutputRule.BindToInput<string>(typeof(SqlGenericsConverter<string>), _configuration);
+            _ = inputOutputRule.BindToInput<SqlCommand>(converter);
+            _ = inputOutputRule.BindToInput<string>(typeof(SqlGenericsConverter<string>), _configuration);
             inputOutputRule.BindToCollector<OpenType>(typeof(SqlAsyncCollectorBuilder<>), _configuration, _loggerFactory);
-            inputOutputRule.BindToInput<OpenType>(typeof(SqlGenericsConverter<>), _configuration);
+            _ = inputOutputRule.BindToInput<OpenType>(typeof(SqlGenericsConverter<>), _configuration);
         }
     }
 }

--- a/src/SqlBinding/SqlBindingExtension.cs
+++ b/src/SqlBinding/SqlBindingExtension.cs
@@ -7,15 +7,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
     public static class SqlBindingExtension
     {
-        public static IWebJobsBuilder AddSql(this IWebJobsBuilder builder)
+        public static void AddSql(this IWebJobsBuilder builder)
         {
             if (builder == null)
             {
                 throw new ArgumentNullException(nameof(builder));
             }
 
-            builder.AddExtension<SqlBindingConfigProvider>();
-            return builder;
+            _ = builder.AddExtension<SqlBindingConfigProvider>();
         }
     }
 }

--- a/src/SqlBinding/SqlBindingUtilities.cs
+++ b/src/SqlBinding/SqlBindingUtilities.cs
@@ -88,14 +88,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     }
 
 
-                    if (items[1].Equals("null", StringComparison.OrdinalIgnoreCase))
-                    {
-                        command.Parameters.Add(new SqlParameter(items[0], DBNull.Value));
-                    }
-                    else
-                    {
-                        command.Parameters.Add(new SqlParameter(items[0], items[1]));
-                    }
+                    _ = items[1].Equals("null", StringComparison.OrdinalIgnoreCase)
+                        ? command.Parameters.Add(new SqlParameter(items[0], DBNull.Value))
+                        : command.Parameters.Add(new SqlParameter(items[0], items[1]));
 
                 }
             }

--- a/src/SqlBinding/SqlConverters.cs
+++ b/src/SqlBinding/SqlConverters.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 adapter.SelectCommand = command;
                 await connection.OpenAsync();
                 var dataTable = new DataTable();
-                adapter.Fill(dataTable);
+                _ = adapter.Fill(dataTable);
                 return JsonConvert.SerializeObject(dataTable);
             }
 

--- a/test/SqlExtension.Tests/SqlInputBindingTests.cs
+++ b/test/SqlExtension.Tests/SqlInputBindingTests.cs
@@ -25,44 +25,44 @@ namespace SqlExtension.Tests
         [Fact]
         public void TestNullConfiguration()
         {
-            Assert.Throws<ArgumentNullException>(() => new SqlBindingConfigProvider(null, loggerFactory.Object));
-            Assert.Throws<ArgumentNullException>(() => new SqlBindingConfigProvider(config.Object, null));
-            Assert.Throws<ArgumentNullException>(() => new SqlConverter(null));
-            Assert.Throws<ArgumentNullException>(() => new SqlGenericsConverter<string>(null));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlBindingConfigProvider(null, loggerFactory.Object));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlBindingConfigProvider(config.Object, null));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlConverter(null));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlGenericsConverter<string>(null));
         }
 
         [Fact]
         public void TestNullCommandText()
         {
-            Assert.Throws<ArgumentNullException>(() => new SqlAttribute(null));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlAttribute(null));
         }
 
         [Fact]
         public void TestNullContext()
         {
             var configProvider = new SqlBindingConfigProvider(config.Object, loggerFactory.Object);
-            Assert.Throws<ArgumentNullException>(() => configProvider.Initialize(null));
+            _ = Assert.Throws<ArgumentNullException>(() => configProvider.Initialize(null));
         }
 
         [Fact]
         public void TestNullBuilder()
         {
             IWebJobsBuilder builder = null;
-            Assert.Throws<ArgumentNullException>(() => builder.AddSql());
+            _ = Assert.Throws<ArgumentNullException>(() => builder.AddSql());
         }
 
         [Fact]
         public void TestNullCommand()
         {
-            Assert.Throws<ArgumentNullException>(() => SqlBindingUtilities.ParseParameters("", null));
+            _ = Assert.Throws<ArgumentNullException>(() => SqlBindingUtilities.ParseParameters("", null));
         }
 
         [Fact]
         public void TestNullArgumentsSqlAsyncEnumerableConstructor()
         {
 
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(connection, null));
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(null, new SqlAttribute("")));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(connection, null));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(null, new SqlAttribute("")));
         }
 
         [Fact]
@@ -77,11 +77,11 @@ namespace SqlExtension.Tests
         public void TestInvalidArgumentsBuildConnection()
         {
             var attribute = new SqlAttribute("");
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, config.Object));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, config.Object));
 
             attribute = new SqlAttribute("");
             attribute.ConnectionStringSetting = "ConnectionStringSetting";
-            Assert.Throws<ArgumentNullException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, null));
+            _ = Assert.Throws<ArgumentNullException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, null));
         }
 
         [Fact]
@@ -90,12 +90,12 @@ namespace SqlExtension.Tests
             // Specify an invalid type
             var attribute = new SqlAttribute("");
             attribute.CommandType = System.Data.CommandType.TableDirect;
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
 
 
             // Don't specify a type at all
             attribute = new SqlAttribute("");
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
         }
 
         [Fact]
@@ -122,21 +122,21 @@ namespace SqlExtension.Tests
             var command = new SqlCommand();
             // Second param name doesn't start with "@"
             string parameters = "@param1=param1,param2=param2";
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
 
             // Second param not separated by "=", or contains extra "="
             parameters = "@param1=param1,@param2==param2";
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
             parameters = "@param1=param1,@param2;param2";
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
             parameters = "@param1=param1,@param2=param2=";
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
 
             // Params list not separated by "," correctly
             parameters = "@param1=param1;@param2=param2";
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
             parameters = "@param1=param1,@par,am2=param2";
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
+            _ = Assert.Throws<ArgumentException>(() => SqlBindingUtilities.ParseParameters(parameters, command));
         }
 
         [Fact]
@@ -215,7 +215,7 @@ namespace SqlExtension.Tests
             var converter = new Mock<SqlGenericsConverter<TestData>>(config.Object);
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Cost\":32.5,\"Timestamp\":\"2019-11-22T06:32:15\"},{ \"ID\":2,\"Name\":\"Brush\",\"Cost\":12.3," +
                 "\"Timestamp\":\"2017-01-27T03:13:11\"},{ \"ID\":3,\"Name\":\"Comb\",\"Cost\":100.12,\"Timestamp\":\"1997-05-03T10:11:56\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            _ = converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
             var list = new List<TestData>();
             var data1 = new TestData
             {
@@ -253,7 +253,7 @@ namespace SqlExtension.Tests
 
             // SQL data is missing a field
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Timestamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            _ = converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
             var list = new List<TestData>();
             var data = new TestData
             {
@@ -268,7 +268,7 @@ namespace SqlExtension.Tests
 
             // SQL data's columns are named differently than the POCO's fields
             json = "[{ \"ID\":1,\"Product Name\":\"Broom\",\"Price\":32.5,\"Timessstamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            _ = converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
             list = new List<TestData>();
             data = new TestData
             {
@@ -282,7 +282,7 @@ namespace SqlExtension.Tests
 
             // Confirm that the JSON fields are case-insensitive (technically malformed string, but still works)
             json = "[{ \"id\":1,\"nAme\":\"Broom\",\"coSt\":32.5,\"TimEStamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            _ = converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
             list = new List<TestData>();
             data = new TestData
             {

--- a/test/SqlExtension.Tests/SqlOutputBindingTests.cs
+++ b/test/SqlExtension.Tests/SqlOutputBindingTests.cs
@@ -20,8 +20,8 @@ namespace SqlExtension.Tests
         public void TestNullCollectorConstructorArguments()
         {
             var arg = new SqlAttribute(string.Empty);
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncCollector<string>(config.Object, null, NullLoggerFactory.Instance));
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncCollector<string>(null, arg, NullLoggerFactory.Instance));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlAsyncCollector<string>(config.Object, null, NullLoggerFactory.Instance));
+            _ = Assert.Throws<ArgumentNullException>(() => new SqlAsyncCollector<string>(null, arg, NullLoggerFactory.Instance));
         }
 
         [Fact]


### PR DESCRIPTION
Fix unused expression errors - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0058

I have mixed feelings about this one...none of these were actually issues and some of them are pretty weird to be returning values anyways (why does the query builder return itself when appending?)

But not using return values can sometimes indicate a bug (such as not updating a string when doing replace) so I think it's better to have this enabled and deal with a little bit of extra discard code. 