### PR TITLE
Fix IDE0046

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,6 @@ dotnet_analyzer_diagnostic.category-CodeQuality.severity = error
 dotnet_diagnostic.IDE0130.severity = silent
 dotnet_diagnostic.IDE0058.severity = silent
 dotnet_diagnostic.IDE0003.severity = silent
-dotnet_diagnostic.IDE0046.severity = silent
 dotnet_diagnostic.IDE0001.severity = silent
 dotnet_diagnostic.IDE0002.severity = silent
 
@@ -63,7 +62,7 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 dotnet_style_prefer_auto_properties = true
 dotnet_style_prefer_compound_assignment = true
 dotnet_style_prefer_conditional_expression_over_assignment = true
-dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_conditional_expression_over_return = false
 dotnet_style_prefer_inferred_anonymous_type_member_names = true
 dotnet_style_prefer_inferred_tuple_names = true
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true


### PR DESCRIPTION
Use conditional expression for return - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0046

I decided to change this to false since having this be true just resulted in some messy looking conditional return statements and don't really seem like something that would actually help avoid any errors. 