### PR TITLE
Integration Tests Redesign

### DIFF
--- a/test/SqlExtension.Tests/Integration Tests/IntegrationTestBase.cs
+++ b/test/SqlExtension.Tests/Integration Tests/IntegrationTestBase.cs
@@ -55,8 +55,6 @@ namespace SqlExtension.Tests.Integration
             this.TestOutput = output;
 
             this.SetupDatabase();
-
-            this.StartFunctionHost();
         }
 
         /// <remarks>
@@ -113,14 +111,18 @@ namespace SqlExtension.Tests.Integration
             Environment.SetEnvironmentVariable("SqlConnectionString", connectionStringBuilder.ToString());
         }
 
-        private void StartFunctionHost()
+        /// <summary>
+        /// This starts the Functions runtime with the specified function.
+        /// Note the functionName is different than the route.
+        /// </summary>
+        protected void StartFunctionHost(string functionName)
         {
             this.FunctionHost = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = this.GetFunctionsCoreToolsPath(),
-                    Arguments = $"start --verbose --port {this.Port}",
+                    Arguments = $"start --verbose --port {this.Port} --functions {functionName}",
                     WorkingDirectory = Path.Combine(this.GetPathToSamplesBin(), "SqlExtensionSamples"),
                     WindowStyle = ProcessWindowStyle.Hidden,
                     RedirectStandardOutput = true,
@@ -250,8 +252,11 @@ namespace SqlExtension.Tests.Integration
             {
                 this.Connection.Dispose();
 
-                this.FunctionHost.Kill();
-                this.FunctionHost.Dispose();
+                if (this.FunctionHost != null)
+                {
+                    this.FunctionHost.Kill();
+                    this.FunctionHost.Dispose();
+                }
             }
         }
     }

--- a/test/SqlExtension.Tests/Integration Tests/IntegrationTestBase.cs
+++ b/test/SqlExtension.Tests/Integration Tests/IntegrationTestBase.cs
@@ -252,11 +252,8 @@ namespace SqlExtension.Tests.Integration
             {
                 this.Connection.Dispose();
 
-                if (this.FunctionHost != null)
-                {
-                    this.FunctionHost.Kill();
-                    this.FunctionHost.Dispose();
-                }
+                this.FunctionHost?.Kill();
+                this.FunctionHost?.Dispose();
             }
         }
     }

--- a/test/SqlExtension.Tests/Integration Tests/SqlInputBindingIntegrationTests.cs
+++ b/test/SqlExtension.Tests/Integration Tests/SqlInputBindingIntegrationTests.cs
@@ -32,6 +32,8 @@ namespace SqlExtension.Tests.Integration
         [InlineData(100, 500)]
         public async void GetProductsTest(int n, int cost)
         {
+            this.StartFunctionHost(nameof(GetProducts));
+
             // Generate T-SQL to insert n rows of data with cost
             Product[] products = this.GetProductsWithSameCost(n, cost);
             this.InsertProducts(products);
@@ -52,6 +54,8 @@ namespace SqlExtension.Tests.Integration
         [InlineData(100, 999)]
         public async void GetProductsStoredProcedureTest(int n, int cost)
         {
+            this.StartFunctionHost(nameof(GetProductsStoredProcedure));
+
             // Generate T-SQL to insert n rows of data with cost
             Product[] products = this.GetProductsWithSameCost(n, cost);
             this.InsertProducts(products);
@@ -72,6 +76,8 @@ namespace SqlExtension.Tests.Integration
         [InlineData(100, 1000)]
         public async void GetProductsNameEmptyTest(int n, int cost)
         {
+            this.StartFunctionHost(nameof(GetProductsNameEmpty));
+
             // Add a bunch of noise data
             this.InsertProducts(this.GetProductsWithSameCost(n * 2, cost));
 

--- a/test/SqlExtension.Tests/Integration Tests/SqlOutputBindingIntegrationTests.cs
+++ b/test/SqlExtension.Tests/Integration Tests/SqlOutputBindingIntegrationTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.WebUtilities;
+using SqlExtensionSamples;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -36,6 +37,8 @@ namespace SqlExtension.Tests.Integration
         [InlineData(-500, "ABCD", 580)]
         public void AddProductTest(int id, string name, int cost)
         {
+            this.StartFunctionHost(nameof(AddProduct));
+
             var query = new Dictionary<string, string>()
             {
                 { "id", id.ToString() },
@@ -43,7 +46,7 @@ namespace SqlExtension.Tests.Integration
                 { "cost", cost.ToString() }
             };
 
-            this.SendOutputRequest(nameof(SqlExtensionSamples.AddProduct), query).Wait();
+            this.SendOutputRequest(nameof(AddProduct), query).Wait();
 
             // Verify result
             Assert.Equal(name, this.ExecuteScalar($"select Name from Products where ProductId={id}"));
@@ -53,6 +56,8 @@ namespace SqlExtension.Tests.Integration
         [Fact]
         public void AddProductArrayTest()
         {
+            this.StartFunctionHost(nameof(AddProductsArray));
+
             // First insert some test data
             this.ExecuteNonQuery("INSERT INTO Products VALUES (1, 'test', 100)");
             this.ExecuteNonQuery("INSERT INTO Products VALUES (2, 'test', 100)");
@@ -69,6 +74,8 @@ namespace SqlExtension.Tests.Integration
         [Fact]
         public void AddProductsCollectorTest()
         {
+            this.StartFunctionHost(nameof(AddProductsCollector));
+
             // Function should add 5000 rows to the table
             this.SendOutputRequest("addproducts-collector").Wait();
 
@@ -78,6 +85,8 @@ namespace SqlExtension.Tests.Integration
         [Fact]
         public void QueueTriggerProductsTest()
         {
+            this.StartFunctionHost(nameof(QueueTriggerProducts));
+
             string uri = $"http://localhost:{this.Port}/admin/functions/QueueTriggerProducts";
             string json = "{ 'input': 'Test Data' }";
 


### PR DESCRIPTION
This change leverages the --functions parameter of the Azure Functions CLI. Each test is now responsible of starting its own Functions runtime, but now each test should no longer be affected by other functions behaviors.