### PR TITLE
Skip Samples Namespace for Code Coverage

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -64,7 +64,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[samples]*"'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[[*]Microsoft.Azure.WebJobs.Extensions.Sql.Samples.*]*"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage Results'

--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -64,7 +64,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[[*]Microsoft.Azure.WebJobs.Extensions.Sql.Samples.*]*"'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[*]Microsoft.Azure.WebJobs.Extensions.Sql.Samples.*"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage Results'

--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -64,7 +64,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[SqlExtensionSamples]*"'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[samples]*"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage Results'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -60,7 +60,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[samples]*"'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[[*]Microsoft.Azure.WebJobs.Extensions.Sql.Samples.*]*"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage Results'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -60,7 +60,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[[*]Microsoft.Azure.WebJobs.Extensions.Sql.Samples.*]*"'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[*]Microsoft.Azure.WebJobs.Extensions.Sql.Samples.*"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage Results'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -60,7 +60,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[SqlExtensionSamples]*"'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.ArtifactStagingDirectory)\TestResults\coverage\ /p:Exclude="[samples]*"'
 
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish Code Coverage Results'


### PR DESCRIPTION
Was looking at test dashboards and noticed that, after the latest refactor, our code coverage took into account the samples files again. Excluding the test namespace now.