### PR TITLE
Fix SqlSamples paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "azureFunctions.projectSubpath": "samples/SqlExtensionSamples",
-    "azureFunctions.deploySubpath": "samples/SqlExtensionSamples/bin/Release/netcoreapp3.1/publish",
+    "azureFunctions.projectSubpath": "samples",
+    "azureFunctions.deploySubpath": "samples/bin/Release/netcoreapp3.1/publish",
     "azureFunctions.projectLanguage": "C#",
     "azureFunctions.projectRuntime": "~3",
     "debug.internalConsoleOptions": "neverOpen",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
 			"type": "process",
 			"problemMatcher": "$msCompile",
 			"options": {
-				"cwd": "${workspaceFolder}/samples/SqlExtensionSamples"
+				"cwd": "${workspaceFolder}/samples"
 			}
 		},
 		{
@@ -31,7 +31,7 @@
 			},
 			"problemMatcher": "$msCompile",
 			"options": {
-				"cwd": "${workspaceFolder}/samples/SqlExtensionSamples"
+				"cwd": "${workspaceFolder}/samples"
 			}
 		},
 		{
@@ -47,7 +47,7 @@
 			"type": "process",
 			"problemMatcher": "$msCompile",
 			"options": {
-				"cwd": "${workspaceFolder}/samples/SqlExtensionSamples"
+				"cwd": "${workspaceFolder}/samples"
 			}
 		},
 		{
@@ -64,14 +64,14 @@
 			"dependsOn": "clean release (functions)",
 			"problemMatcher": "$msCompile",
 			"options": {
-				"cwd": "${workspaceFolder}/samples/SqlExtensionSamples"
+				"cwd": "${workspaceFolder}/samples"
 			}
 		},
 		{
 			"type": "func",
 			"dependsOn": "build (functions)",
 			"options": {
-				"cwd": "${workspaceFolder}/samples/SqlExtensionSamples/bin/Debug/netcoreapp3.1"
+				"cwd": "${workspaceFolder}/samples/bin/Debug/netcoreapp3.1"
 			},
 			"command": "host start",
 			"isBackground": true,

--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ The following are valid binding types for the result of the query/stored procedu
 
 - **IEnumerable<T>**: Each element is a row of the result represented by `T`, where `T` is a user-defined POCO, or Plain Old C# Object. `T` should follow the structure of a row in the queried table. See the [Query String](#query-string) section for an example of what `T` should look like.
 - **IAsyncEnumerable<T>**: Each element is again a row of the result represented by `T`, but the rows are retrieved "lazily". A row of the result is only retrieved when `MoveNextAsync` is called on the enumerator. This is useful in the case that the query can return a very large amount of rows.
-- **String**: A JSON string representation of the rows of the result (an example is provided [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/SqlExtensionSamples/InputBindingSamples/GetProductsString.cs)).
-- **SqlCommand**: The SqlCommand is populated with the appropriate query and parameters, but the associated connection is not opened. It is the responsiblity of the user to execute the command and read in the results. This is useful in the case that the user wants more control over how the results are read in. An example is provided [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/SqlExtensionSamples/InputBindingSamples/GetProductsSqlCommand.cs).
+- **String**: A JSON string representation of the rows of the result (an example is provided [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/InputBindingSamples/GetProductsString.cs)).
+- **SqlCommand**: The SqlCommand is populated with the appropriate query and parameters, but the associated connection is not opened. It is the responsiblity of the user to execute the command and read in the results. This is useful in the case that the user wants more control over how the results are read in. An example is provided [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/InputBindingSamples/GetProductsSqlCommand.cs).
 
-The repo contains examples of each of these binding types [here](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/SqlExtensionSamples/InputBindingSamples). A few examples are also included below.
+The repo contains examples of each of these binding types [here](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/InputBindingSamples). A few examples are also included below.
 
 #### Query String
 
@@ -405,7 +405,7 @@ The following are valid binding types for the rows to be upserted into the table
 - **T**: Used when just one row is to be upserted into the table.
 - **T[]**: Each element is again a row of the result represented by `T`. This output binding type requires manual instantiation of the array in the function.
 
-The repo contains examples of each of these binding types [here](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/SqlExtensionSamples/OutputBindingSamples). A few examples are also included below.
+The repo contains examples of each of these binding types [here](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples/OutputBindingSamples). A few examples are also included below.
 
 #### ICollector<T>/IAsyncCollector<T>
 


### PR DESCRIPTION
Also filed https://github.com/Azure/azure-functions-sql-extension/issues/125 - similar to the integration tests we now need to have an emulator running locally or the task won't start. 