### PR TITLE
Authenticode sign out DLLs

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -39,13 +39,13 @@ steps:
     command: restore
     projects: '${{ parameters.solution }}'
 
-  # Build outputs directly into staging directory
+  # Don't generate package so we can sign it before packaging
 - task: DotNetCoreCLI@2
   displayName: '.NET Build'
   inputs:
     command: build
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
+    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false'
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK 2.1.x for CodeSign'
@@ -56,7 +56,8 @@ steps:
   displayName: 'ESRP CodeSigning - Binaries'
   inputs:
     ConnectedServiceName: 'Code Signing'
-    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    FolderPath: '$(Build.SourcesDirectory)/bin/${{ parameters.configuration }}'
+    Pattern: '**/Microsoft.Azure.WebJobs.Extensions.Sql.dll'
     signConfigType: inlineSignParams
     inlineOperation: |
      [
@@ -104,7 +105,16 @@ steps:
     SessionTimeout: 600
     MaxConcurrency: 5
 
-  # Above build task generates a nuget package, this extra step packs into a -preview nuget with same version #
+  # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
+- task: DotNetCoreCLI@2
+  displayName: '.NET Pack Nuget'
+  inputs:
+    command: custom
+    custom: pack
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
+
+  # Build preview version of nuget with same version
   # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
 - task: DotNetCoreCLI@2
   displayName: '.NET Pack Preview Nuget'
@@ -112,7 +122,7 @@ steps:
     command: custom
     custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -57,7 +57,7 @@ steps:
   inputs:
     ConnectedServiceName: 'Code Signing'
     FolderPath: '$(Build.SourcesDirectory)/bin/${{ parameters.configuration }}'
-    Pattern: '**/Microsoft.Azure.WebJobs.Extensions.Sql.dll'
+    Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
     signConfigType: inlineSignParams
     inlineOperation: |
      [

--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -56,7 +56,7 @@ steps:
   displayName: 'ESRP CodeSigning - Binaries'
   inputs:
     ConnectedServiceName: 'Code Signing'
-    FolderPath: '$(Build.SourcesDirectory)/bin/${{ parameters.configuration }}'
+    FolderPath: '$(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}'
     Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
     signConfigType: inlineSignParams
     inlineOperation: |

--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -21,7 +21,7 @@ steps:
   inputs:
     dockerVersion: 17.09.0-ce
     releaseType: stable
-        
+
 - script: docker pull mcr.microsoft.com/mssql/server:2019-latest
   displayName: Pull MSSQL Docker Image
 
@@ -46,6 +46,63 @@ steps:
     command: build
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
+
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK 2.1.x for CodeSign'
+  inputs:
+    version: '2.1.x'
+
+- task: EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning - Binaries'
+  inputs:
+    ConnectedServiceName: 'Code Signing'
+    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolSign",
+         "parameters": [
+         {
+           "parameterName": "OpusName",
+           "parameterValue": "Azure Functions SQL Extension"
+         },
+         {
+           "parameterName": "OpusInfo",
+           "parameterValue": "https://github.com/Azure/azure-functions-sql-extension"
+         },
+         {
+           "parameterName": "PageHash",
+           "parameterValue": "/NPH"
+         },
+         {
+           "parameterName": "FileDigest",
+           "parameterValue": "/fd sha256"
+         },
+         {
+           "parameterName": "TimeStamp",
+           "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+         }
+         ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       },
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolVerify",
+         "parameters": [
+         {
+           "parameterName": "VerifyAll",
+           "parameterValue": "/all"
+         }
+             ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       }
+     ]
+    SessionTimeout: 600
+    MaxConcurrency: 5
 
   # Above build task generates a nuget package, this extra step packs into a -preview nuget with same version #
   # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -51,7 +51,7 @@ steps:
   displayName: 'ESRP CodeSigning - Binaries'
   inputs:
     ConnectedServiceName: 'Code Signing'
-    FolderPath: '$(Build.SourcesDirectory)/bin/${{ parameters.configuration }}'
+    FolderPath: '$(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}'
     Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
     signConfigType: inlineSignParams
     inlineOperation: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -42,6 +42,63 @@ steps:
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
 
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK 2.1.x for CodeSign'
+  inputs:
+    version: '2.1.x'
+
+- task: EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning - Binaries'
+  inputs:
+    ConnectedServiceName: 'Code Signing'
+    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolSign",
+         "parameters": [
+         {
+           "parameterName": "OpusName",
+           "parameterValue": "Azure Functions SQL Extension"
+         },
+         {
+           "parameterName": "OpusInfo",
+           "parameterValue": "https://github.com/Azure/azure-functions-sql-extension"
+         },
+         {
+           "parameterName": "PageHash",
+           "parameterValue": "/NPH"
+         },
+         {
+           "parameterName": "FileDigest",
+           "parameterValue": "/fd sha256"
+         },
+         {
+           "parameterName": "TimeStamp",
+           "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+         }
+         ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       },
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolVerify",
+         "parameters": [
+         {
+           "parameterName": "VerifyAll",
+           "parameterValue": "/all"
+         }
+             ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       }
+     ]
+    SessionTimeout: 600
+    MaxConcurrency: 5
+    
   # Above build task generates a nuget package, this extra step packs into a -preview nuget with same version #
   # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
 - task: DotNetCoreCLI@2

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -34,13 +34,13 @@ steps:
     command: restore
     projects: '${{ parameters.solution }}'
 
-  # Build outputs directly into staging directory
+  # Don't generate package so we can sign it before packaging
 - task: DotNetCoreCLI@2
   displayName: '.NET Build'
   inputs:
     command: build
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}"'
+    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false'
 
 - task: UseDotNet@2
   displayName: 'Install .NET Core SDK 2.1.x for CodeSign'
@@ -51,7 +51,8 @@ steps:
   displayName: 'ESRP CodeSigning - Binaries'
   inputs:
     ConnectedServiceName: 'Code Signing'
-    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    FolderPath: '$(Build.SourcesDirectory)/bin/${{ parameters.configuration }}'
+    Pattern: '**/Microsoft.Azure.WebJobs.Extensions.Sql.dll'
     signConfigType: inlineSignParams
     inlineOperation: |
      [
@@ -98,8 +99,17 @@ steps:
      ]
     SessionTimeout: 600
     MaxConcurrency: 5
-    
-  # Above build task generates a nuget package, this extra step packs into a -preview nuget with same version #
+
+  # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
+- task: DotNetCoreCLI@2
+  displayName: '.NET Pack Nuget'
+  inputs:
+    command: custom
+    custom: pack
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
+
+  # Build preview version of nuget with same version
   # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
 - task: DotNetCoreCLI@2
   displayName: '.NET Pack Preview Nuget'
@@ -107,7 +117,7 @@ steps:
     command: custom
     custom: pack
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -52,7 +52,7 @@ steps:
   inputs:
     ConnectedServiceName: 'Code Signing'
     FolderPath: '$(Build.SourcesDirectory)/bin/${{ parameters.configuration }}'
-    Pattern: '**/Microsoft.Azure.WebJobs.Extensions.Sql.dll'
+    Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
     signConfigType: inlineSignParams
     inlineOperation: |
      [

--- a/builds/azure-pipelines/template-steps-publish.yml
+++ b/builds/azure-pipelines/template-steps-publish.yml
@@ -9,14 +9,14 @@ steps:
     version: '2.1.x'
 
 - task: EsrpCodeSigning@1
-  displayName: 'Nuget Code Signing'
+  displayName: 'ESRP Code Signing - Nuget Package'
   inputs:
     ConnectedServiceName: 'Code Signing'
     FolderPath: '$(Build.ArtifactStagingDirectory)'
     Pattern: '*.nupkg'
     signConfigType: 'inlineSignParams'
     inlineOperation: |
-      [ 
+      [
           {
               "keyCode": "CP-401405",
               "operationSetCode": "NuGetSign",
@@ -39,5 +39,5 @@ steps:
 - task: PublishPipelineArtifact@1
   displayName: 'Publish Pipeline Artifact'
   inputs:
-    targetPath: '$(Build.ArtifactStagingDirectory)' 
+    targetPath: '$(Build.ArtifactStagingDirectory)'
     artifactName: 'drop'


### PR DESCRIPTION
We were signing the nuget packages but not the DLLs

`dotnet pack` doesn't seem to be able to specify a "root" location for where the files it packs are located, so I removed the build option to output directly to the artifacts folder. This means that the output artifacts will only contain the nuget package now. I see this as being fine - I don't know of any good reason why we'd need any of the other files currently. And if we do then we can add them at that point.

Currently the signing tasks are specifying the DLL directly (`Microsoft.Azure.WebJobs.Extensions.Sql.dll`). This means that if we ever add more DLLs we'll need to update this task. Given the low likely hood of that happening I thought this good to do so we aren't accidently signing stuff that isn't ours.

I might also come back and re-arrange the tasks, it's kind of weird that we build + sign + pack the assemblies all in the build + test stage, and then for publish we only sign the nuget packages. (plus then we end up having to duplicate the tasks as I did which isn't great). But for now I opted to move things around as little as possible. 

Also note this is NOT strong name signing the DLLs. Only authenticode signing. 

https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=124909&view=artifacts&pathAsName=false&type=publishedArtifacts

![image](https://user-images.githubusercontent.com/28519865/137818469-bd536ccf-f61a-42c4-8c55-65c982d28459.png)
