### PR TITLE
Add brackets around column name for merge query

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             rowData = JsonConvert.SerializeObject(rowsToUpsert, table.JsonSerializerSettings);
             IEnumerable<string> columnNamesFromPOCO = typeof(T).GetProperties().Select(prop => prop.Name);
             IEnumerable<string> bracketColumnDefinitionsFromPOCO = table.Columns.Where(c => columnNamesFromPOCO.Contains(c.Key, StringComparer.OrdinalIgnoreCase))
-                .Select(c => $"{SqlBindingUtilities.BracketQuoteIdentifier(c.Key)} {c.Value}");
+                .Select(c => $"{c.Key.AsBracketQuotedString()} {c.Value}");
             newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON({RowDataParameter}) WITH ({string.Join(",", bracketColumnDefinitionsFromPOCO)}) )";
         }
 
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// </summary>
             public static string GetMergeQuery(IList<string> primaryKeys, string fullTableName)
             {
-                IList<string> bracketedPrimaryKeys = primaryKeys.Select(p => SqlBindingUtilities.BracketQuoteIdentifier(p)).ToList();
+                IList<string> bracketedPrimaryKeys = primaryKeys.Select(p => p.AsBracketQuotedString()).ToList();
                 // Generate the ON part of the merge query (compares new data against existing data)
                 var primaryKeyMatchingQuery = new StringBuilder($"ExistingData.{bracketedPrimaryKeys[0]} = NewData.{bracketedPrimaryKeys[0]}");
                 foreach (string primaryKey in bracketedPrimaryKeys.Skip(1))
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
 
                 // Generate the UPDATE part of the merge query (all columns that should be updated)
-                IEnumerable<string> bracketedColumnNamesFromPOCO = typeof(T).GetProperties().Select(prop => SqlBindingUtilities.BracketQuoteIdentifier(prop.Name.ToLowerInvariant()));
+                IEnumerable<string> bracketedColumnNamesFromPOCO = typeof(T).GetProperties().Select(prop => prop.Name.ToLowerInvariant().AsBracketQuotedString());
                 var columnMatchingQueryBuilder = new StringBuilder();
                 foreach (string column in bracketedColumnNamesFromPOCO)
                 {

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -164,23 +164,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Escape any existing closing brackets and add brackets around the identifier.
+        /// Escape any existing closing brackets and add brackets around the string
         /// </summary>
-        /// <param name="identifier">The string to bracket quote.</param>
+        /// <param name="s">The string to bracket quote.</param>
         /// <returns>The escaped and bracket quoted string.</returns>
-        public static string BracketQuoteIdentifier(string identifier)
+        public static string AsBracketQuotedString(this string s)
         {
-            return $"[{identifier.Replace("]", "]]")}]";
+            return $"[{s.Replace("]", "]]")}]";
         }
 
         /// <summary>
-        /// Escape any existing quotes and add quotes around the identifier.
+        /// Escape any existing quotes and add quotes around the string.
         /// </summary>
-        /// <param name="identifier">The string to quote.</param>
+        /// <param name="s">The string to quote.</param>
         /// <returns>The escaped and quoted string.</returns>
-        public static string QuoteIdentifier(string identifier)
+        public static string AsQuotedString(this string s)
         {
-            return $"'{identifier.Replace("'", "''")}'";
+            return $"'{s.Replace("'", "''")}'";
         }
 
         /// <summary>
@@ -222,8 +222,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
             public override void Visit(SchemaObjectName node)
             {
-                this.quotedSchema = node.SchemaIdentifier != null ? QuoteIdentifier(node.SchemaIdentifier.Value) : "SCHEMA_NAME()";
-                this.quotedTableName = QuoteIdentifier(node.BaseIdentifier.Value);
+                this.quotedSchema = node.SchemaIdentifier != null ? node.SchemaIdentifier.Value.AsQuotedString() : "SCHEMA_NAME()";
+                this.quotedTableName = node.BaseIdentifier.Value.AsQuotedString();
             }
         }
     }

--- a/test/Unit/SqlOutputBindingTests.cs
+++ b/test/Unit/SqlOutputBindingTests.cs
@@ -70,9 +70,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [InlineData("columnName", "[columnName]")]
         [InlineData("column]Name", "[column]]Name]")]
         [InlineData("col[umn]Name", "[col[umn]]Name]")]
-        public void TestBracketQuoteIdentifier(string identifier, string expectedResult)
+        public void TestAsBracketQuotedString(string s, string expectedResult)
         {
-            string result = SqlBindingUtilities.BracketQuoteIdentifier(identifier);
+            string result = s.AsBracketQuotedString();
             Assert.Equal(expectedResult, result);
         }
     }


### PR DESCRIPTION
Example merge query:

```WITH cte AS ( SELECT * FROM OPENJSON(@rowData) WITH ([productid] int,[name] varchar(55),[cost] int) )
MERGE INTO dbo.Products WITH (HOLDLOCK)
AS ExistingData
USING cte 
AS NewData
ON
ExistingData.[productid] = NewData.[productid]
WHEN MATCHED THEN
UPDATE SET  ExistingData.[productid] = NewData.[productid], ExistingData.[name] = NewData.[name], ExistingData.[cost] = NewData.[cost]
WHEN NOT MATCHED THEN
INSERT ([productid],[name],[cost]) VALUES ([productid],[name],[cost]);```