### PR TITLE
Only generate one nuget package

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -16,7 +16,7 @@ variables:
   versionMajor: 0
   versionMinor: 1
   versionPatch: $[counter(variables['versionMinor'], 0)] # This will reset when we bump minor version
-  nugetVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
+  nugetVersion: '$(versionMajor).$(versionMinor).$(versionPatch)-preview'
 
 stages:
 - stage: BuildPublish

--- a/builds/azure-pipelines/template-steps-build-test-linux.yml
+++ b/builds/azure-pipelines/template-steps-build-test-linux.yml
@@ -114,16 +114,6 @@ steps:
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
 
-  # Build preview version of nuget with same version
-  # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
-- task: DotNetCoreCLI@2
-  displayName: '.NET Pack Preview Nuget'
-  inputs:
-    command: custom
-    custom: pack
-    projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
-
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'
   env:

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -109,16 +109,6 @@ steps:
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
 
-  # Build preview version of nuget with same version
-  # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
-- task: DotNetCoreCLI@2
-  displayName: '.NET Pack Preview Nuget'
-  inputs:
-    command: custom
-    custom: pack
-    projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}-preview" -p:GeneratePackageOnBuild=false'
-
 - task: DotNetCoreCLI@2
   displayName: '.NET Test'
   env:


### PR DESCRIPTION
No reason to build two packages, we should only be using one at a time. 