### PR TITLE
Enable code analysis for all projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,14 @@ root = true
 
 dotnet_analyzer_diagnostic.severity = error
 
+# Documentation related errors, remove once they are fixed
+dotnet_diagnostic.CS1591.severity = none
+dotnet_diagnostic.CS1573.severity = none
+dotnet_diagnostic.CS1572.severity = none
+dotnet_diagnostic.CS1570.severity = none
+dotnet_diagnostic.CS1574.severity = none
+dotnet_diagnostic.CS1584.severity = none
+
 #### Core EditorConfig Options ####
 
 # Indentation and spacing

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/samples/.editorconfig
+++ b/samples/.editorconfig
@@ -1,0 +1,6 @@
+# See https://github.com/dotnet/roslyn-analyzers/blob/main/.editorconfig for an example on different settings and how they're used
+
+[*.cs]
+# Disable these until they can be fixed
+dotnet_diagnostic.CA1305.severity = silent
+dotnet_diagnostic.CA1805.severity = silent

--- a/samples/Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj
@@ -1,11 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj
+++ b/samples/Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -18,6 +18,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -16,9 +16,6 @@
     <RootNamespace></RootNamespace>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,10 @@
+# See https://github.com/dotnet/roslyn-analyzers/blob/main/.editorconfig for an example on different settings and how they're used
+
+[*.cs]
+# Disable these until they can be fixed
+dotnet_diagnostic.CA1309.severity = silent
+dotnet_diagnostic.CA1822.severity = silent
+dotnet_diagnostic.CA1816.severity = silent
+dotnet_diagnostic.CA1305.severity = silent
+dotnet_diagnostic.CA1805.severity = silent
+dotnet_diagnostic.CA1711.severity = silent

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples;
 using Xunit;
 using Xunit.Abstractions;
-using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -1,11 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I noticed that there was an error displayed in the UI for an unused `using` but it wasn't failing the build - dug into it and found out that we hadn't actually fully enabled checks for the test and sample projects so adding those.

In addition I had to add `GenerateDocumentationFile` to all the projects due to https://github.com/dotnet/roslyn/issues/22579#issuecomment-855811516

I also combined the common project properties into a single props file at the root. (the targetframework for the binding project is still netstandard2.1 though - it overrides the default set)