### PR TITLE
Fix CA1816 in tests

### DIFF
--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -2,10 +2,9 @@
 
 [*.cs]
 # Disable these until they can be fixed
-dotnet_diagnostic.CA1816.severity = silent
-dotnet_diagnostic.CA1305.severity = silent
 dotnet_diagnostic.CA1805.severity = silent
 dotnet_diagnostic.CA1711.severity = silent
 
 # Disabled
 dotnet_diagnostic.CA1309.severity = silent # Use ordinal StringComparison - this isn't important for tests and just adds clutter
+dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn't important for tests and just adds clutter

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -303,6 +303,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 this.AzuriteHost?.Kill();
                 this.AzuriteHost?.Dispose();
             }
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
Call GC.SuppressFinalize correctly https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1816

Also leaving CA1305 as disabled - it's similar to CA1309 and doesn't seem to provide much value for tests currently.