### PR TITLE
Stage change to properly reset patch version counter

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -13,7 +13,7 @@ schedules:
 variables:
   solution: '**/*.sln'
   configuration: 'Release'
-  versionMajor: 0 # TODO When this is bumped have versionPatch counter use versionMajorMinor instead
+  versionMajor: 0 # TODO When this is bumped have versionPatch counter use versionMajorMinor instead https://github.com/Azure/azure-functions-sql-extension/issues/173
   versionMinor: 1
   versionMajorMinor: '$(versionMajor).$(versionMinor)'  # This variable is only used for the counter so we reset properly when either major or minor is bumped
   versionPatch: $[counter(variables['versionMinor'], 0)] # This will reset when we bump minor version

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -13,8 +13,9 @@ schedules:
 variables:
   solution: '**/*.sln'
   configuration: 'Release'
-  versionMajor: 0
+  versionMajor: 0 # TODO When this is bumped have versionPatch counter use versionMajorMinor instead
   versionMinor: 1
+  versionMajorMinor: '$(versionMajor).$(versionMinor)'  # This variable is only used for the counter so we reset properly when either major or minor is bumped
   versionPatch: $[counter(variables['versionMinor'], 0)] # This will reset when we bump minor version
   nugetVersion: '$(versionMajor).$(versionMinor).$(versionPatch)-preview'
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/173 (sorta)

I don't want to actually use it right now since doing so would reset the counter. We could set the seed to the current version point but then we'd have to remember to reset it later. So this seems like a good enough workaround and then we can fully fix it when we eventually release and bump to version 1.x