### PR TITLE
Add SqlObject helper class

### DIFF
--- a/samples/local.settings.json
+++ b/samples/local.settings.json
@@ -3,6 +3,6 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-    "SqlConnectionString": "Server=sqltools2019-3;Database=keep_chgagnon;Trusted_Connection=True;"
+    "SqlConnectionString": ""
 }
 }

--- a/samples/local.settings.json
+++ b/samples/local.settings.json
@@ -3,6 +3,6 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-    "SqlConnectionString": ""
+    "SqlConnectionString": "Server=sqltools2019-3;Database=keep_chgagnon;Trusted_Connection=True;"
 }
 }

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -296,9 +296,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     where
                         tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
                     and
-                        tc.TABLE_NAME = {table.QuotedSchema}
+                        tc.TABLE_NAME = {table.QuotedName}
                     and
-                        tc.TABLE_SCHEMA = {table.QuotedName}";
+                        tc.TABLE_SCHEMA = {table.QuotedSchema}";
             }
 
             /// <summary>

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.IO;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
-using Microsoft.SqlServer.TransactSql.ScriptDom;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -181,50 +179,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public static string AsQuotedString(this string s)
         {
             return $"'{s.Replace("'", "''")}'";
-        }
-
-        /// <summary>
-        /// Use ScriptDom to parse schema and tableName and return them with quotes.
-        /// If there is no schema in fullName, SCHEMA_NAME() is returned as schema.
-        /// </summary>
-        /// <param name="fullName">
-        /// Full name of table, including schema (if exists).
-        /// </param>
-        public static void GetTableAndSchema(string fullName, out string quotedSchema, out string quotedTableName)
-        {
-            var parser = new TSql150Parser(false);
-            var stringReader = new StringReader(fullName);
-            SchemaObjectName tree = parser.ParseSchemaObjectName(stringReader, out IList<ParseError> errors);
-
-            if (errors.Count > 0)
-            {
-                string errorMessages = "Encountered error(s) while parsing schema and table name:\n";
-                foreach (ParseError err in errors)
-                {
-                    errorMessages += $"{err.Message}\n";
-                }
-                throw new InvalidOperationException(errorMessages);
-            }
-
-            var visitor = new QuotedTSqlFragmentVisitor();
-            tree.Accept(visitor);
-            quotedSchema = visitor.quotedSchema;
-            quotedTableName = visitor.quotedTableName;
-        }
-
-        /// <summary>
-        /// Get the schema and table name with quotes from the SchemaObjectName.  
-        /// </summary>
-        private class QuotedTSqlFragmentVisitor : TSqlFragmentVisitor
-        {
-            internal string quotedSchema;
-            internal string quotedTableName;
-
-            public override void Visit(SchemaObjectName node)
-            {
-                this.quotedSchema = node.SchemaIdentifier != null ? node.SchemaIdentifier.Value.AsQuotedString() : "SCHEMA_NAME()";
-                this.quotedTableName = node.BaseIdentifier.Value.AsQuotedString();
-            }
         }
     }
 }

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <summary>
         /// Get the schema and object name from the SchemaObjectName.
         /// </summary>
-        private class TSqlObjectFragmentVisitor : SqlServer.TransactSql.ScriptDom.TSqlFragmentVisitor
+        private class TSqlObjectFragmentVisitor : TSqlFragmentVisitor
         {
             public string schemaName;
             public string objectName;

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.SqlServer.TransactSql.ScriptDom;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql
+{
+    /// <summary>
+    /// Parses the schema and object name for the given object.
+    /// If there is no schema in fullName, SCHEMA_NAME() is returned as schema.
+    /// </summary>
+    /// <param name="fullName">Full name of object, including schema (if it exists).</param>
+    internal class SqlObject
+    {
+        private static readonly string SCHEMA_NAME_FUNCTION = "SCHEMA_NAME()";
+
+        /// <summary>
+        /// The name of the object
+        /// </summary>
+        public readonly string Name;
+        /// <summary>
+        /// The name of the object, quoted and escaped with single quotes
+        /// </summary>
+        public readonly string QuotedName;
+        /// <summary>
+        /// The schema of the object
+        /// </summary>
+        public readonly string Schema;
+        /// <summary>
+        /// The name of the object, quoted and escaped with single quotes
+        /// </summary>
+        public readonly string QuotedSchema;
+
+        public SqlObject(string fullName)
+        {
+            var parser = new TSql150Parser(false);
+            var stringReader = new StringReader(fullName);
+            SchemaObjectName tree = parser.ParseSchemaObjectName(stringReader, out IList<ParseError> errors);
+
+            if (errors.Count > 0)
+            {
+                string errorMessages = "Encountered error(s) while parsing schema and object name:\n";
+                foreach (ParseError err in errors)
+                {
+                    errorMessages += $"{err.Message}\n";
+                }
+                throw new InvalidOperationException(errorMessages);
+            }
+
+            var visitor = new QuotedTSqlFragmentVisitor();
+            tree.Accept(visitor);
+            this.Schema = visitor.schemaName;
+            this.QuotedSchema = this.Schema == SCHEMA_NAME_FUNCTION ? this.Schema : this.Schema.AsQuotedString();
+            this.Name = visitor.objectName;
+            this.QuotedName = this.Name.AsQuotedString();
+        }
+
+        public override string ToString()
+        {
+            return $"{this.Schema}.{this.Name}";
+        }
+
+        /// <summary>
+        /// Get the schema and object name from the SchemaObjectName.
+        /// </summary>
+        private class QuotedTSqlFragmentVisitor : TSqlFragmentVisitor
+        {
+            public string schemaName;
+            public string objectName;
+
+            public override void Visit(SchemaObjectName node)
+            {
+                this.schemaName = node.SchemaIdentifier != null ? node.SchemaIdentifier.Value : SCHEMA_NAME_FUNCTION;
+                this.objectName = node.BaseIdentifier.Value;
+            }
+        }
+    }
+
+}

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         public readonly string Name;
         /// <summary>
-        /// The name of the object, quoted and escaped with single quotes
+        /// The name of the object, quoted and escaped with single quotes if it's not the default SCHEMA_NAME() function
         /// </summary>
         public readonly string QuotedName;
         /// <summary>
-        /// The schema of the object
+        /// The schema of the object, defaulting to the SCHEMA_NAME() function if the full name doesn't include a schema
         /// </summary>
         public readonly string Schema;
         /// <summary>

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -9,10 +9,8 @@ using Microsoft.SqlServer.TransactSql.ScriptDom;
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
     /// <summary>
-    /// Parses the schema and object name for the given object.
-    /// If there is no schema in fullName, SCHEMA_NAME() is returned as schema.
+    /// Helper class for working with SQL object names.
     /// </summary>
-    /// <param name="fullName">Full name of object, including schema (if it exists).</param>
     internal class SqlObject
     {
         private static readonly string SCHEMA_NAME_FUNCTION = "SCHEMA_NAME()";
@@ -22,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         public readonly string Name;
         /// <summary>
-        /// The name of the object, quoted and escaped with single quotes if it's not the default SCHEMA_NAME() function
+        /// The name of the object, quoted and escaped with single quotes
         /// </summary>
         public readonly string QuotedName;
         /// <summary>
@@ -30,10 +28,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         public readonly string Schema;
         /// <summary>
-        /// The name of the object, quoted and escaped with single quotes
+        /// The name of the object, quoted and escaped with single quotes if it's not the default SCHEMA_NAME() function
         /// </summary>
         public readonly string QuotedSchema;
 
+        /// <summary>
+        /// A SqlObject which contains information about the name and schema of the given object full name.
+        /// </summary>
+        /// <param name="fullName">Full name of object, including schema (if it exists).</param>
+        /// <exception cref="InvalidOperationException">If the name can't be parsed</exception>
         public SqlObject(string fullName)
         {
             var parser = new TSql150Parser(false);
@@ -58,6 +61,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this.QuotedName = this.Name.AsQuotedString();
         }
 
+        /// <summary>
+        /// Returns the full name of the object, including the schema if it was specified, in the format {Schema}.{Name}
+        /// </summary>
+        /// <returns></returns>
         public override string ToString()
         {
             return $"{this.Schema}.{this.Name}";

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 throw new InvalidOperationException(errorMessages);
             }
 
-            var visitor = new QuotedTSqlFragmentVisitor();
+            var visitor = new TSqlObjectFragmentVisitor();
             tree.Accept(visitor);
             this.Schema = visitor.schemaName;
             this.QuotedSchema = this.Schema == SCHEMA_NAME_FUNCTION ? this.Schema : this.Schema.AsQuotedString();
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <summary>
         /// Get the schema and object name from the SchemaObjectName.
         /// </summary>
-        private class QuotedTSqlFragmentVisitor : TSqlFragmentVisitor
+        private class TSqlObjectFragmentVisitor : SqlServer.TransactSql.ScriptDom.TSqlFragmentVisitor
         {
             public string schemaName;
             public string objectName;


### PR DESCRIPTION
This will make it a lot easier/safer to work with the object names in the code.

It might be a good idea to even require that the parameter to the attribute is of this type - at least for output bindings. Something to keep an eye on as we continue to make improvements. 