### PR TITLE
Handle identity column

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Further information on the Azure SQL binding for Azure Functions is also availab
       - [ICollector<T>/IAsyncCollector<T>](#icollectortiasynccollectort)
       - [Array](#array)
       - [Single Row](#single-row)
+      - [Primary Keys and Identity Columns](#primary-keys-and-identity-columns)
   - [Known Issues](#known-issues)
   - [Trademarks](#trademarks)
 
@@ -505,6 +506,23 @@ public static IActionResult Run(
     return new CreatedResult($"/api/addproduct", product);
 }
 ```
+
+#### Primary Keys and Identity Columns
+
+Normally Output Bindings require two things :
+
+1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
+2. Each of those columns must be present in the POCO object used in the attribute
+
+If either of these are false then an error will be thrown.
+
+This changes if one of the primary key columns is an identity column though. In that case a MERGE is not performed, only a direct insert. The rules for this are
+
+1. There must still be a primary key (which includes the identity column)
+2. Any other non-identity columns in the primary key constraint must still exist in the output POCO object.
+
+But the identity column itself should not be included in the POCO object - if it is included then it will be ignored as the engine handles generating the value for that column.
+
 ## Known Issues
 
 - Output bindings against tables with columns of data types `NTEXT`, `TEXT`, or `IMAGE` are not supported and data upserts will fail. These types [will be removed](https://docs.microsoft.com/sql/t-sql/data-types/ntext-text-and-image-transact-sql) in a future version of SQL Server and are not compatible with the `OPENJSON` function used by this Azure Functions binding.

--- a/samples/Database/ProductsWithIdentity.sql
+++ b/samples/Database/ProductsWithIdentity.sql
@@ -1,0 +1,5 @@
+﻿CREATE TABLE [ProductsWithIdentity] (
+	[ProductId] [int] PRIMARY KEY NOT NULL IDENTITY(1,1),
+	[Name] [nvarchar](100) NULL,
+	[Cost] [int] NULL
+)

--- a/samples/Database/ProductsWithMultiplePrimaryColumnsAndIdentity.sql
+++ b/samples/Database/ProductsWithMultiplePrimaryColumnsAndIdentity.sql
@@ -1,0 +1,7 @@
+﻿CREATE TABLE [ProductsWithMultiplePrimaryColumnsAndIdentity] (
+	[ProductId] [int] NOT NULL IDENTITY(1,1),
+	[ExternalId] [int] NOT NULL,
+	[Name] [nvarchar](100) NULL,
+	[Cost] [int] NULL,
+	PRIMARY KEY (ProductId, ExternalId)
+)

--- a/samples/OutputBindingSamples/AddProductWithIdentityColumn.cs
+++ b/samples/OutputBindingSamples/AddProductWithIdentityColumn.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
+{
+    public class ProductWithoutId
+    {
+
+        public string Name { get; set; }
+
+        public int Cost { get; set; }
+    }
+
+    public static class AddProductWithIdentityColumn
+    {
+        /// <summary>
+        /// This shows an example of a SQL Output binding where the target table has a primary key 
+        /// which is an identity column. In such a case the primary key is not required to be in 
+        /// the object used by the binding - it will insert a row with the other values and the 
+        /// ID will be generated upon insert.
+        /// </summary>
+        /// <param name="req">The original request that triggered the function</param>
+        /// <param name="product">The created Product object</param>
+        /// <returns>The CreatedResult containing the new object that was inserted</returns>
+        [FunctionName(nameof(AddProductWithIdentityColumn))]
+        public static IActionResult Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithidentitycolumn")]
+            HttpRequest req,
+            [Sql("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")] out ProductWithoutId product)
+        {
+            product = new ProductWithoutId
+            {
+                Name = req.Query["name"],
+                Cost = int.Parse(req.Query["cost"])
+            };
+            return new CreatedResult($"/api/addproductwithidentitycolumn", product);
+        }
+    }
+}

--- a/samples/OutputBindingSamples/AddProductWithIdentityColumn.cs
+++ b/samples/OutputBindingSamples/AddProductWithIdentityColumn.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
 {
     public class ProductWithoutId
     {
-
         public string Name { get; set; }
 
         public int Cost { get; set; }
@@ -18,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
     public static class AddProductWithIdentityColumn
     {
         /// <summary>
-        /// This shows an example of a SQL Output binding where the target table has a primary key 
-        /// which is an identity column. In such a case the primary key is not required to be in 
-        /// the object used by the binding - it will insert a row with the other values and the 
+        /// This shows an example of a SQL Output binding where the target table has a primary key
+        /// which is an identity column. In such a case the primary key is not required to be in
+        /// the object used by the binding - it will insert a row with the other values and the
         /// ID will be generated upon insert.
         /// </summary>
         /// <param name="req">The original request that triggered the function</param>

--- a/samples/OutputBindingSamples/AddProductWithMultiplePrimaryColumnsAndIdentity.cs
+++ b/samples/OutputBindingSamples/AddProductWithMultiplePrimaryColumnsAndIdentity.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
+{
+    public class MultiplePrimaryKeyProductWithoutId
+    {
+        public int ExternalId { get; set; }
+
+        public string Name { get; set; }
+
+        public int Cost { get; set; }
+    }
+
+    public static class AddProductWithMultiplePrimaryColumnsAndIdentity
+    {
+        /// <summary>
+        /// This shows an example of a SQL Output binding where the target table has a primary key 
+        /// which is comprised of multiple columns, with one of them being an identity column. In 
+        /// such a case the identity column is not required to be in the object used by the binding 
+        /// - it will insert a row with the other values and the ID will be generated upon insert.
+        /// All other primary key columns are required to be in the object.
+        /// </summary>
+        /// <param name="req">The original request that triggered the function</param>
+        /// <param name="product">The created Product object</param>
+        /// <returns>The CreatedResult containing the new object that was inserted</returns>
+        [FunctionName(nameof(AddProductWithMultiplePrimaryColumnsAndIdentity))]
+        public static IActionResult Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithmultipleprimarycolumnsandidentity")]
+            HttpRequest req,
+            [Sql("dbo.ProductsWithMultiplePrimaryColumnsAndIdentity", ConnectionStringSetting = "SqlConnectionString")] out MultiplePrimaryKeyProductWithoutId product)
+        {
+            product = new MultiplePrimaryKeyProductWithoutId
+            {
+                ExternalId = int.Parse(req.Query["externalId"]),
+                Name = req.Query["name"],
+                Cost = int.Parse(req.Query["cost"])
+            };
+            return new CreatedResult($"/api/addproductwithmultipleprimarycolumnsandidentity", product);
+        }
+    }
+}

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -180,8 +180,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     GenerateDataQueryForMerge(tableInfo, batch, out string newDataQuery, out string rowData);
                     command.CommandText = $"{newDataQuery} {tableInfo.Query};";
                     par.Value = rowData;
-                    Console.WriteLine(command.CommandText); // TODO remove
-                    Console.WriteLine(rowData); // TODO remove
                     await command.ExecuteNonQueryAsync();
                 }
                 transaction.Commit();
@@ -258,7 +256,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             IEnumerable<string> bracketColumnDefinitionsFromPOCO = table.Columns.Where(c => columnNamesFromPOCO.Contains(c.Key, StringComparer.OrdinalIgnoreCase))
                 .Select(c => $"{c.Key.AsBracketQuotedString()} {c.Value}");
             newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON({RowDataParameter}) WITH ({string.Join(",", bracketColumnDefinitionsFromPOCO)}) )";
-            Console.WriteLine(newDataQuery); // TODO remove
         }
 
         public class TableInformation
@@ -304,7 +301,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// </summary>
             public static string GetPrimaryKeysQuery(SqlObject table)
             {
-                // TODO handle no schema
                 return $@"
                     SELECT
                         {ColumnName}, c.is_identity
@@ -433,7 +429,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     await sqlConnection.OpenAsync();
                     var cmd = new SqlCommand(GetPrimaryKeysQuery(table), sqlConnection);
-                    Console.WriteLine(cmd.CommandText); // TODO REMOVE
                     using SqlDataReader rdr = await cmd.ExecuteReaderAsync();
                     while (await rdr.ReadAsync())
                     {
@@ -471,7 +466,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
 
                 string query = missingPrimaryKeysFromPOCO.Any() ? GetInsertQuery(table) : GetMergeQuery(primaryKeys, table);
-                Console.WriteLine(query); // TODO remove
                 return new TableInformation(primaryKeyFields, columnDefinitionsFromSQL, query);
             }
         }

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -20,12 +20,28 @@ using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
+
+    internal class PrimaryKey
+    {
+        public readonly string Name;
+
+        public readonly bool IsIdentity;
+
+        public PrimaryKey(string name, bool isIdentity)
+        {
+            this.Name = name;
+            this.IsIdentity = isIdentity;
+        }
+    }
+
     /// <typeparam name="T">A user-defined POCO that represents a row of the user's table</typeparam>
     internal class SqlAsyncCollector<T> : IAsyncCollector<T>, IDisposable
     {
         private const string RowDataParameter = "@rowData";
         private const string ColumnName = "COLUMN_NAME";
         private const string ColumnDefinition = "COLUMN_DEFINITION";
+
+        private const string IsIdentity = "is_identity";
         private const string CteName = "cte";
 
         private readonly IConfiguration _configuration;
@@ -120,17 +136,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private async Task UpsertRowsAsync(IEnumerable<T> rows, SqlAttribute attribute, IConfiguration configuration)
         {
             using SqlConnection connection = SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, configuration);
-            string fullDatabaseAndTableName = attribute.CommandText;
+            string fullTableName = attribute.CommandText;
 
             // Include the connection string hash as part of the key in case this customer has the same table in two different Sql Servers
-            string cacheKey = $"{connection.ConnectionString.GetHashCode()}-{fullDatabaseAndTableName}";
+            string cacheKey = $"{connection.ConnectionString.GetHashCode()}-{fullTableName}";
 
             ObjectCache cachedTables = MemoryCache.Default;
             var tableInfo = cachedTables[cacheKey] as TableInformation;
 
             if (tableInfo == null)
             {
-                tableInfo = await TableInformation.RetrieveTableInformationAsync(connection, fullDatabaseAndTableName);
+                tableInfo = await TableInformation.RetrieveTableInformationAsync(connection, fullTableName);
 
                 var policy = new CacheItemPolicy
                 {
@@ -138,14 +154,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     AbsoluteExpiration = DateTimeOffset.Now.AddMinutes(10)
                 };
 
-                this._logger.LogInformation($"DB and Table: {fullDatabaseAndTableName}. Primary keys: [{string.Join(",", tableInfo.PrimaryKeys.Select(pk => pk.Name))}]. SQL Column and Definitions:  [{string.Join(",", tableInfo.ColumnDefinitions)}]");
+                this._logger.LogInformation($"DB and Table: {connection.Database}.{fullTableName}. Primary keys: [{string.Join(",", tableInfo.PrimaryKeys.Select(pk => pk.Name))}]. SQL Column and Definitions:  [{string.Join(",", tableInfo.ColumnDefinitions)}]");
                 cachedTables.Set(cacheKey, tableInfo, policy);
             }
 
             IEnumerable<string> extraProperties = GetExtraProperties(tableInfo.Columns);
             if (extraProperties.Any())
             {
-                string message = $"The following properties in {typeof(T)} do not exist in the table {fullDatabaseAndTableName}: {string.Join(", ", extraProperties.ToArray())}.";
+                string message = $"The following properties in {typeof(T)} do not exist in the table {fullTableName}: {string.Join(", ", extraProperties.ToArray())}.";
                 throw new InvalidOperationException(message);
             }
 
@@ -162,9 +178,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 foreach (IEnumerable<T> batch in rows.Batch(batchSize))
                 {
                     GenerateDataQueryForMerge(tableInfo, batch, out string newDataQuery, out string rowData);
-                    command.CommandText = $"{newDataQuery} {tableInfo.MergeQuery};";
+                    command.CommandText = $"{newDataQuery} {tableInfo.Query};";
                     par.Value = rowData;
-
+                    Console.WriteLine(command.CommandText); // TODO remove
+                    Console.WriteLine(rowData); // TODO remove
                     await command.ExecuteNonQueryAsync();
                 }
                 transaction.Commit();
@@ -241,6 +258,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             IEnumerable<string> bracketColumnDefinitionsFromPOCO = table.Columns.Where(c => columnNamesFromPOCO.Contains(c.Key, StringComparer.OrdinalIgnoreCase))
                 .Select(c => $"{c.Key.AsBracketQuotedString()} {c.Value}");
             newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON({RowDataParameter}) WITH ({string.Join(",", bracketColumnDefinitionsFromPOCO)}) )";
+            Console.WriteLine(newDataQuery); // TODO remove
         }
 
         public class TableInformation
@@ -258,10 +276,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             public IEnumerable<string> ColumnDefinitions => this.Columns.Select(c => $"{c.Key} {c.Value}");
 
             /// <summary>
-            /// T-SQL merge statement generated from primary keys
+            /// T-SQL merge or insert statement generated from primary keys
             /// and column names for a specific table.
             /// </summary>
-            public string MergeQuery { get; }
+            public string Query { get; }
 
             /// <summary>
             /// Settings to use when serializing the POCO into SQL.
@@ -269,11 +287,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// </summary>
             public JsonSerializerSettings JsonSerializerSettings { get; }
 
-            public TableInformation(IEnumerable<MemberInfo> primaryKeys, IDictionary<string, string> columns, string mergeQuery)
+            public TableInformation(IEnumerable<MemberInfo> primaryKeys, IDictionary<string, string> columns, string query)
             {
                 this.PrimaryKeys = primaryKeys;
                 this.Columns = columns;
-                this.MergeQuery = mergeQuery;
+                this.Query = query;
 
                 this.JsonSerializerSettings = new JsonSerializerSettings
                 {
@@ -286,14 +304,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// </summary>
             public static string GetPrimaryKeysQuery(SqlObject table)
             {
+                // TODO handle no schema
                 return $@"
-                    select
-                        {ColumnName}
-                    from
+                    SELECT
+                        {ColumnName}, c.is_identity
+                    FROM
                         INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-                    inner join
-                        INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu on ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND ccu.TABLE_NAME = tc.TABLE_NAME
-                    where
+                    INNER JOIN
+                        INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND ccu.TABLE_NAME = tc.TABLE_NAME
+                    INNER JOIN
+                        sys.columns c ON c.object_id = OBJECT_ID({table.QuotedFullName}) AND c.name = ccu.COLUMN_NAME
+                    WHERE
                         tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
                     and
                         tc.TABLE_NAME = {table.QuotedName}
@@ -324,12 +345,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         c.TABLE_SCHEMA = {table.QuotedSchema}";
             }
 
+            public static string GetInsertQuery(SqlObject table)
+            {
+                IEnumerable<string> bracketedColumnNamesFromPOCO = typeof(T).GetProperties().Select(prop => prop.Name.ToLowerInvariant().AsBracketQuotedString());
+                return $"INSERT INTO {table.BracketQuotedFullName} SELECT * FROM {CteName}";
+            }
+
             /// <summary>
             /// Generates reusable SQL query that will be part of every upsert command.
             /// </summary>
-            public static string GetMergeQuery(IList<string> primaryKeys, string fullTableName)
+            public static string GetMergeQuery(IList<PrimaryKey> primaryKeys, SqlObject table)
             {
-                IList<string> bracketedPrimaryKeys = primaryKeys.Select(p => p.AsBracketQuotedString()).ToList();
+                IList<string> bracketedPrimaryKeys = primaryKeys.Select(p => p.Name.AsBracketQuotedString()).ToList();
                 // Generate the ON part of the merge query (compares new data against existing data)
                 var primaryKeyMatchingQuery = new StringBuilder($"ExistingData.{bracketedPrimaryKeys[0]} = NewData.{bracketedPrimaryKeys[0]}");
                 foreach (string primaryKey in bracketedPrimaryKeys.Skip(1))
@@ -347,7 +374,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 string columnMatchingQuery = columnMatchingQueryBuilder.ToString().TrimEnd(',');
                 return @$"
-                    MERGE INTO {fullTableName} WITH (HOLDLOCK)
+                    MERGE INTO {table.BracketQuotedFullName} WITH (HOLDLOCK)
                         AS ExistingData
                     USING {CteName}
                         AS NewData
@@ -401,15 +428,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
 
                 // 2. Query SQL for table Primary Keys
-                var primaryKeys = new List<string>();
+                var primaryKeys = new List<PrimaryKey>();
                 try
                 {
                     await sqlConnection.OpenAsync();
                     var cmd = new SqlCommand(GetPrimaryKeysQuery(table), sqlConnection);
+                    Console.WriteLine(cmd.CommandText); // TODO REMOVE
                     using SqlDataReader rdr = await cmd.ExecuteReaderAsync();
                     while (await rdr.ReadAsync())
                     {
-                        primaryKeys.Add(rdr[ColumnName].ToString().ToLowerInvariant());
+                        primaryKeys.Add(new PrimaryKey(rdr[ColumnName].ToString().ToLowerInvariant(), bool.Parse(rdr[IsIdentity].ToString())));
                     }
                 }
                 catch (Exception ex)
@@ -423,23 +451,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     await sqlConnection.CloseAsync();
                 }
 
-                if (!primaryKeys.Any())
+                if (!primaryKeys.Any(k => k.IsIdentity) && !primaryKeys.Any())
                 {
                     string message = $"Did not retrieve any primary keys for {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message);
                 }
 
                 // 3. Match SQL Primary Key column names to POCO field/property objects. Ensure none are missing.
-                IEnumerable<MemberInfo> primaryKeyFields = typeof(T).GetMembers().Where(f => primaryKeys.Contains(f.Name, StringComparer.OrdinalIgnoreCase));
+                IEnumerable<MemberInfo> primaryKeyFields = typeof(T).GetMembers().Where(f => primaryKeys.Any(k => string.Equals(k.Name, f.Name, StringComparison.OrdinalIgnoreCase)));
                 IEnumerable<string> primaryKeysFromPOCO = primaryKeyFields.Select(f => f.Name);
-                IEnumerable<string> missingFromPOCO = primaryKeys.Except(primaryKeysFromPOCO, StringComparer.OrdinalIgnoreCase);
-                if (missingFromPOCO.Any())
+                IEnumerable<PrimaryKey> missingPrimaryKeysFromPOCO = primaryKeys
+                    .Where(k => !primaryKeysFromPOCO.Contains(k.Name, StringComparer.OrdinalIgnoreCase));
+                // If none of the primary keys are an identity column then we require that all primary keys be present in the POCO so we can
+                // generate the MERGE statement correctly
+                if (!primaryKeys.Any(k => k.IsIdentity) && missingPrimaryKeysFromPOCO.Any(k => !k.IsIdentity))
                 {
-                    string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingFromPOCO)}]";
+                    string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromPOCO)}]";
                     throw new InvalidOperationException(message);
                 }
 
-                return new TableInformation(primaryKeyFields, columnDefinitionsFromSQL, GetMergeQuery(primaryKeys, fullName));
+                string query = missingPrimaryKeysFromPOCO.Any() ? GetInsertQuery(table) : GetMergeQuery(primaryKeys, table);
+                Console.WriteLine(query); // TODO remove
+                return new TableInformation(primaryKeyFields, columnDefinitionsFromSQL, query);
             }
         }
 
@@ -451,6 +484,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 // we only want to serialize POCO properties that correspond to SQL columns
                 this._propertiesToSerialize = sqlColumns;
+                foreach (KeyValuePair<string, string> kv in this._propertiesToSerialize)
+                {
+                    Console.WriteLine($"{kv.Key}:{kv.Value}");
+                }
             }
 
             protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -36,9 +36,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         public readonly string FullName;
         /// <summary>
-        /// The full name of the object in the format SCHEMA.NAME (or just NAME if there is no specified schema), quoted and escaped with single quotes
+        /// The full name of the object in the format 'SCHEMA.NAME' (or just 'NAME' if there is no specified schema), quoted and escaped with single quotes
         /// </summary>
         public readonly string QuotedFullName;
+
+        /// <summary>
+        /// The full name of the objected in the format [SCHEMA].[NAME] (or just [NAME] if there is no specified schema), quoted and escaped with square brackets.
+        /// </summary>
+        public readonly string BracketQuotedFullName;
 
         /// <summary>
         /// A SqlObject which contains information about the name and schema of the given object full name.
@@ -69,6 +74,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this.QuotedName = this.Name.AsSingleQuotedString();
             this.FullName = this.Schema == SCHEMA_NAME_FUNCTION ? this.Name : $"{this.Schema}.{this.Name}";
             this.QuotedFullName = this.FullName.AsSingleQuotedString();
+            this.BracketQuotedFullName = this.Schema == SCHEMA_NAME_FUNCTION ? this.Name.AsBracketQuotedString() : $"{this.Schema.AsBracketQuotedString()}.{this.Name.AsBracketQuotedString()}";
         }
 
         /// <summary>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -5,3 +5,4 @@
 # Disabled
 dotnet_diagnostic.CA1309.severity = silent # Use ordinal StringComparison - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn't important for tests and just adds clutter
+dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable

--- a/test/Common/ProductExtraColumns.cs
+++ b/test/Common/ProductExtraColumns.cs
@@ -15,4 +15,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 
         public string ExtraString { get; set; }
     }
+
+    public class ProductIncludeIdentity
+    {
+        public int ProductID { get; set; }
+
+        public string Name { get; set; }
+
+        public int Cost { get; set; }
+    }
 }

--- a/test/Integration/AddProductIncludeIdentity.cs
+++ b/test/Integration/AddProductIncludeIdentity.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
+{
+    public static class AddProductIncludeIdentity
+    {
+
+        /// <summary>
+        /// This output binding should throw an Exception because the table specifies ProductID
+        /// as an identity column and so can't be included in the object being added.
+        /// </summary>
+        /// <param name="req"></param>
+        /// <param name="product"></param>
+        /// <returns></returns>
+        [FunctionName(nameof(AddProductIncludeIdentity))]
+        public static IActionResult Run(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = nameof(AddProductIncludeIdentity))]
+            HttpRequest req,
+            [Sql("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")] out ProductIncludeIdentity product)
+        {
+            product = new ProductIncludeIdentity
+            {
+                Name = req.Query["name"],
+                ProductID = int.Parse(req.Query["productId"]),
+                Cost = int.Parse(req.Query["cost"]),
+            };
+            return new CreatedResult($"/api/addproduct-includeidentity", product);
+        }
+    }
+}

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -175,8 +175,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             Assert.Equal(1, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithIdentity"));
         }
 
-        // TODO Add functionality to update existing rows in tables with identity column
-
         /// <summary>
         /// Tests that for tables with multiple primary columns (including an itemtity column) we are able to
         /// insert items.

--- a/test/Unit/SqlOutputBindingTests.cs
+++ b/test/Unit/SqlOutputBindingTests.cs
@@ -41,20 +41,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         }
 
         [Theory]
-        [InlineData("dbo.Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'")] // Simple full name
-        [InlineData("Products", "SCHEMA_NAME()", "SCHEMA_NAME()", "Products", "'Products'", "Products", "'Products'")] // Simple no schema
-        [InlineData("[dbo].[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'")] // Simple full name bracket quoted
-        [InlineData("[dbo].Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'")] // Simple full name only schema bracket quoted
-        [InlineData("dbo.[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'")] // Simple full name only name bracket quoted
-        [InlineData("[My'Schema].[Prod'ucts]", "My'Schema", "'My''Schema'", "Prod'ucts", "'Prod''ucts'", "My'Schema.Prod'ucts", "'My''Schema.Prod''ucts'")] // Full name with single quotes in schema and name
-        [InlineData("[My]]Schema].[My]]Object]", "My]Schema", "'My]Schema'", "My]Object", "'My]Object'", "My]Schema.My]Object", "'My]Schema.My]Object'")] // Full name with brackets in schema and name
+        [InlineData("dbo.Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name
+        [InlineData("Products", "SCHEMA_NAME()", "SCHEMA_NAME()", "Products", "'Products'", "Products", "'Products'", "[Products]")] // Simple no schema
+        [InlineData("[dbo].[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name bracket quoted
+        [InlineData("[dbo].Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name only schema bracket quoted
+        [InlineData("dbo.[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name only name bracket quoted
+        [InlineData("[My'Schema].[Prod'ucts]", "My'Schema", "'My''Schema'", "Prod'ucts", "'Prod''ucts'", "My'Schema.Prod'ucts", "'My''Schema.Prod''ucts'", "[My'Schema].[Prod'ucts]")] // Full name with single quotes in schema and name
+        [InlineData("[My]]Schema].[My]]Object]", "My]Schema", "'My]Schema'", "My]Object", "'My]Object'", "My]Schema.My]Object", "'My]Schema.My]Object'", "[My]]Schema].[My]]Object]")] // Full name with brackets in schema and name
         public void TestSqlObject(string fullName,
             string expectedSchema,
             string expectedQuotedSchema,
             string expectedTableName,
             string expectedSchemaTableName,
             string expectedFullName,
-            string expectedQuotedFullName)
+            string expectedQuotedFullName,
+            string expectedBracketQuotedFullName)
         {
             var sqlObj = new SqlObject(fullName);
             Assert.Equal(expectedSchema, sqlObj.Schema);
@@ -63,6 +64,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             Assert.Equal(expectedSchemaTableName, sqlObj.QuotedName);
             Assert.Equal(expectedFullName, sqlObj.FullName);
             Assert.Equal(expectedQuotedFullName, sqlObj.QuotedFullName);
+            Assert.Equal(expectedBracketQuotedFullName, sqlObj.BracketQuotedFullName);
         }
 
         [Theory]


### PR DESCRIPTION
This is the initial work for https://github.com/Azure/azure-functions-sql-extension/issues/37

With this we now handle an identity column being included in the primary key (either as the sole column or part of a composite primary key). If an identity column is present then we will always generate an insert statement instead - since the column value is generated by the engine and can't be inserted directly.

There's still some other cases I want to revisit for making the experience better. Specifically : 

1. If an identity column is present in the POCO object but it's null/empty we should treat it like it isn't there when constructing the query
2. If an identity column is specified then we should treat it as an update instead of an insert. We might even be able to use the merge statement for this.
2. Investigate if we can somehow return the ID of the created object back to the calling function so that it can be returned as part of the response