### PR TITLE
Add initial set of telemetry events

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     { TelemetryMeasureName.TransactionDurationMs.ToString(), transactionSw.ElapsedMilliseconds },
                     { TelemetryMeasureName.CommandDurationMs.ToString(), commandSw.ElapsedMilliseconds }
                 };
-                TelemetryInstance.TrackEvent(TelemetryEventName.Upsert, props, measures);
+                TelemetryInstance.TrackEvent(TelemetryEventName.UpsertEnd, props, measures);
             }
             catch (Exception ex)
             {

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -10,6 +10,7 @@ using System.Runtime.Caching;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
 using Microsoft.Azure.WebJobs.Logging;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
@@ -17,6 +18,8 @@ using Microsoft.Extensions.Logging;
 using MoreLinq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry;
+using System.Diagnostics;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -74,6 +77,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             this._attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
             this._logger = loggerFactory?.CreateLogger(LogCategories.Bindings) ?? throw new ArgumentNullException(nameof(loggerFactory));
+            TelemetryInstance.TrackCreate(CreateType.SqlAsyncCollector);
         }
 
         /// <summary>
@@ -139,6 +143,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             using SqlConnection connection = SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, configuration);
             await connection.OpenAsync();
+            Dictionary<string, string> props = connection.AsConnectionProps();
 
             string fullTableName = attribute.CommandText;
 
@@ -150,8 +155,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
             if (tableInfo == null)
             {
+                TelemetryInstance.TrackEvent(TelemetryEventName.TableInfoCacheMiss, props);
                 tableInfo = await TableInformation.RetrieveTableInformationAsync(connection, fullTableName, this._logger);
-
                 var policy = new CacheItemPolicy
                 {
                     // Re-look up the primary key(s) after 10 minutes (they should not change very often!)
@@ -161,14 +166,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 this._logger.LogInformation($"DB and Table: {connection.Database}.{fullTableName}. Primary keys: [{string.Join(",", tableInfo.PrimaryKeys.Select(pk => pk.Name))}]. SQL Column and Definitions:  [{string.Join(",", tableInfo.ColumnDefinitions)}]");
                 cachedTables.Set(cacheKey, tableInfo, policy);
             }
+            else
+            {
+                TelemetryInstance.TrackEvent(TelemetryEventName.TableInfoCacheHit, props);
+            }
 
             IEnumerable<string> extraProperties = GetExtraProperties(tableInfo.Columns);
             if (extraProperties.Any())
             {
                 string message = $"The following properties in {typeof(T)} do not exist in the table {fullTableName}: {string.Join(", ", extraProperties.ToArray())}.";
-                throw new InvalidOperationException(message);
+                var ex = new InvalidOperationException(message);
+                TelemetryInstance.TrackError(TelemetryErrorName.PropsNotExistOnTable, TelemetryErrorType.User, ex, props);
+                throw ex;
             }
 
+            TelemetryInstance.TrackEvent(TelemetryEventName.UpsertStart, props);
+            var transactionSw = Stopwatch.StartNew();
             int batchSize = 1000;
             SqlTransaction transaction = connection.BeginTransaction();
             try
@@ -177,24 +190,35 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 command.Connection = connection;
                 command.Transaction = transaction;
                 SqlParameter par = command.Parameters.Add(RowDataParameter, SqlDbType.NVarChar, -1);
-
+                int batchCount = 0;
+                var commandSw = Stopwatch.StartNew();
                 foreach (IEnumerable<T> batch in rows.Batch(batchSize))
                 {
+                    batchCount++;
                     GenerateDataQueryForMerge(tableInfo, batch, out string newDataQuery, out string rowData);
                     command.CommandText = $"{newDataQuery} {tableInfo.Query};";
                     par.Value = rowData;
                     await command.ExecuteNonQueryAsync();
                 }
                 transaction.Commit();
+                var measures = new Dictionary<string, double>()
+                {
+                    { TelemetryMeasureName.BatchCount.ToString(), batchCount },
+                    { TelemetryMeasureName.TransactionDurationMs.ToString(), transactionSw.ElapsedMilliseconds },
+                    { TelemetryMeasureName.CommandDurationMs.ToString(), commandSw.ElapsedMilliseconds }
+                };
+                TelemetryInstance.TrackEvent(TelemetryEventName.Upsert, props, measures);
             }
             catch (Exception ex)
             {
                 try
                 {
+                    TelemetryInstance.TrackError(TelemetryErrorName.Upsert, TelemetryErrorType.System, ex, props);
                     transaction.Rollback();
                 }
                 catch (Exception ex2)
                 {
+                    TelemetryInstance.TrackError(TelemetryErrorName.UpsertRollback, TelemetryErrorType.System, ex, props);
                     string message2 = $"Encountered exception during upsert and rollback.";
                     throw new AggregateException(message2, new List<Exception> { ex, ex2 });
                 }
@@ -418,10 +442,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <returns>TableInformation object containing primary keys, column types, etc.</returns>
             public static async Task<TableInformation> RetrieveTableInformationAsync(SqlConnection sqlConnection, string fullName, ILogger logger)
             {
+                Dictionary<string, string> sqlConnProps = sqlConnection.AsConnectionProps();
+                TelemetryInstance.TrackEvent(TelemetryEventName.GetTableInfoStart, sqlConnProps);
                 var table = new SqlObject(fullName);
 
                 // Get case sensitivity from database collation (default to false if any exception occurs)
                 bool caseSensitive = false;
+                var tableInfoSw = Stopwatch.StartNew();
+                var caseSensitiveSw = Stopwatch.StartNew();
                 try
                 {
                     var cmdCollation = new SqlCommand(GetDatabaseCollationQuery(sqlConnection), sqlConnection);
@@ -430,9 +458,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         caseSensitive = GetCaseSensitivityFromCollation(rdr[Collation].ToString());
                     }
+                    caseSensitiveSw.Stop();
+                    TelemetryInstance.TrackDuration(TelemetryEventName.GetCaseSensitivity, caseSensitiveSw.ElapsedMilliseconds, sqlConnProps);
                 }
                 catch (Exception ex)
                 {
+                    // Since this doesn't rethrow make sure we stop here too (don't use finally because we want the execution time to be the same here and in the 
+                    // overall event but we also only want to send the GetCaseSensitivity event if it succeeds)
+                    caseSensitiveSw.Stop();
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetCaseSensitivity, TelemetryErrorType.System, ex, sqlConnProps);
                     logger.LogWarning($"Encountered exception while retrieving database collation: {ex}. Case insensitive behavior will be used by default.");
                 }
 
@@ -440,6 +474,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 // Get all column names and types
                 var columnDefinitionsFromSQL = new Dictionary<string, string>(comparer);
+                var columnDefinitionsSw = Stopwatch.StartNew();
                 try
                 {
                     var cmdColDef = new SqlCommand(GetColumnDefinitionsQuery(table), sqlConnection);
@@ -449,9 +484,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         string columnName = caseSensitive ? rdr[ColumnName].ToString() : rdr[ColumnName].ToString().ToLowerInvariant();
                         columnDefinitionsFromSQL.Add(columnName, rdr[ColumnDefinition].ToString());
                     }
+                    columnDefinitionsSw.Stop();
+                    TelemetryInstance.TrackDuration(TelemetryEventName.GetColumnDefinitions, columnDefinitionsSw.ElapsedMilliseconds, sqlConnProps);
                 }
                 catch (Exception ex)
                 {
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitions, TelemetryErrorType.System, ex, sqlConnProps);
                     // Throw a custom error so that it's easier to decipher.
                     string message = $"Encountered exception while retrieving column names and types for table {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message, ex);
@@ -460,11 +498,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 if (columnDefinitionsFromSQL.Count == 0)
                 {
                     string message = $"Table {table} does not exist.";
-                    throw new InvalidOperationException(message);
+                    var ex = new InvalidOperationException(message);
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitionsTableDoesNotExist, TelemetryErrorType.User, ex, sqlConnProps);
+                    throw ex;
                 }
 
                 // Query SQL for table Primary Keys
                 var primaryKeys = new List<PrimaryKey>();
+                var primaryKeysSw = Stopwatch.StartNew();
                 try
                 {
                     var cmd = new SqlCommand(GetPrimaryKeysQuery(table), sqlConnection);
@@ -474,9 +515,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         string columnName = caseSensitive ? rdr[ColumnName].ToString() : rdr[ColumnName].ToString().ToLowerInvariant();
                         primaryKeys.Add(new PrimaryKey(columnName, bool.Parse(rdr[IsIdentity].ToString())));
                     }
+                    primaryKeysSw.Stop();
+                    TelemetryInstance.TrackDuration(TelemetryEventName.GetPrimaryKeys, primaryKeysSw.ElapsedMilliseconds, sqlConnProps);
                 }
                 catch (Exception ex)
                 {
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetPrimaryKeys, TelemetryErrorType.System, ex, sqlConnProps);
                     // Throw a custom error so that it's easier to decipher.
                     string message = $"Encountered exception while retrieving primary keys for table {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message, ex);
@@ -485,7 +529,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 if (!primaryKeys.Any())
                 {
                     string message = $"Did not retrieve any primary keys for {table}. Cannot generate upsert command without them.";
-                    throw new InvalidOperationException(message);
+                    var ex = new InvalidOperationException(message);
+                    TelemetryInstance.TrackError(TelemetryErrorName.NoPrimaryKeys, TelemetryErrorType.User, ex, sqlConnProps);
+                    throw ex;
                 }
 
                 // Match SQL Primary Key column names to POCO field/property objects. Ensure none are missing.
@@ -500,12 +546,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 if (!hasIdentityColumnPrimaryKeys && missingPrimaryKeysFromPOCO.Any())
                 {
                     string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromPOCO)}]";
-                    throw new InvalidOperationException(message);
+                    var ex = new InvalidOperationException(message);
+                    TelemetryInstance.TrackError(TelemetryErrorName.MissingPrimaryKeys, TelemetryErrorType.User, ex, sqlConnProps);
                 }
 
                 // If any identity columns aren't included in the object then we have to generate a basic insert since the merge statement expects all primary key
                 // columns to exist. (the merge statement can handle nullable columns though if those exist)
-                string query = hasIdentityColumnPrimaryKeys && missingPrimaryKeysFromPOCO.Any() ? GetInsertQuery(table) : GetMergeQuery(primaryKeys, table, comparison);
+                bool usingInsertQuery = hasIdentityColumnPrimaryKeys && missingPrimaryKeysFromPOCO.Any();
+                string query = usingInsertQuery ? GetInsertQuery(table) : GetMergeQuery(primaryKeys, table, comparison);
+
+                tableInfoSw.Stop();
+                var durations = new Dictionary<string, double>()
+                {
+                    { TelemetryMeasureName.GetCaseSensitivityDurationMs.ToString(), caseSensitiveSw.ElapsedMilliseconds },
+                    { TelemetryMeasureName.GetColumnDefinitionsDurationMs.ToString(), columnDefinitionsSw.ElapsedMilliseconds },
+                    { TelemetryMeasureName.GetPrimaryKeysDurationMs.ToString(), primaryKeysSw.ElapsedMilliseconds }
+                };
+                sqlConnProps.Add(TelemetryPropertyName.QueryType.ToString(), usingInsertQuery ? "insert" : "merge");
+                sqlConnProps.Add(TelemetryPropertyName.HasIdentityColumn.ToString(), hasIdentityColumnPrimaryKeys.ToString());
+                TelemetryInstance.TrackDuration(TelemetryEventName.GetTableInfoEnd, tableInfoSw.ElapsedMilliseconds, sqlConnProps, durations);
                 return new TableInformation(primaryKeyFields, columnDefinitionsFromSQL, comparer, query);
             }
         }

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex2)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.UpsertRollback, ex, props);
+                    TelemetryInstance.TrackError(TelemetryErrorName.UpsertRollback, ex2, props);
                     string message2 = $"Encountered exception during upsert and rollback.";
                     throw new AggregateException(message2, new List<Exception> { ex, ex2 });
                 }

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 string message = $"The following properties in {typeof(T)} do not exist in the table {fullTableName}: {string.Join(", ", extraProperties.ToArray())}.";
                 var ex = new InvalidOperationException(message);
-                TelemetryInstance.TrackError(TelemetryErrorName.PropsNotExistOnTable, TelemetryErrorType.User, ex, props);
+                TelemetryInstance.TrackError(TelemetryErrorName.PropsNotExistOnTable, ex, props);
                 throw ex;
             }
 
@@ -213,12 +213,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 try
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.Upsert, TelemetryErrorType.System, ex, props);
+                    TelemetryInstance.TrackError(TelemetryErrorName.Upsert, ex, props);
                     transaction.Rollback();
                 }
                 catch (Exception ex2)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.UpsertRollback, TelemetryErrorType.System, ex, props);
+                    TelemetryInstance.TrackError(TelemetryErrorName.UpsertRollback, ex, props);
                     string message2 = $"Encountered exception during upsert and rollback.";
                     throw new AggregateException(message2, new List<Exception> { ex, ex2 });
                 }
@@ -466,7 +466,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     // Since this doesn't rethrow make sure we stop here too (don't use finally because we want the execution time to be the same here and in the 
                     // overall event but we also only want to send the GetCaseSensitivity event if it succeeds)
                     caseSensitiveSw.Stop();
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetCaseSensitivity, TelemetryErrorType.System, ex, sqlConnProps);
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetCaseSensitivity, ex, sqlConnProps);
                     logger.LogWarning($"Encountered exception while retrieving database collation: {ex}. Case insensitive behavior will be used by default.");
                 }
 
@@ -489,7 +489,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitions, TelemetryErrorType.System, ex, sqlConnProps);
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitions, ex, sqlConnProps);
                     // Throw a custom error so that it's easier to decipher.
                     string message = $"Encountered exception while retrieving column names and types for table {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message, ex);
@@ -499,7 +499,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string message = $"Table {table} does not exist.";
                     var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitionsTableDoesNotExist, TelemetryErrorType.User, ex, sqlConnProps);
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitionsTableDoesNotExist, ex, sqlConnProps);
                     throw ex;
                 }
 
@@ -520,7 +520,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetPrimaryKeys, TelemetryErrorType.System, ex, sqlConnProps);
+                    TelemetryInstance.TrackError(TelemetryErrorName.GetPrimaryKeys, ex, sqlConnProps);
                     // Throw a custom error so that it's easier to decipher.
                     string message = $"Encountered exception while retrieving primary keys for table {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message, ex);
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string message = $"Did not retrieve any primary keys for {table}. Cannot generate upsert command without them.";
                     var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackError(TelemetryErrorName.NoPrimaryKeys, TelemetryErrorType.User, ex, sqlConnProps);
+                    TelemetryInstance.TrackError(TelemetryErrorName.NoPrimaryKeys, ex, sqlConnProps);
                     throw ex;
                 }
 
@@ -547,7 +547,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromPOCO)}]";
                     var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackError(TelemetryErrorName.MissingPrimaryKeys, TelemetryErrorType.User, ex, sqlConnProps);
+                    TelemetryInstance.TrackError(TelemetryErrorName.MissingPrimaryKeys, ex, sqlConnProps);
                 }
 
                 // If any identity columns aren't included in the object then we have to generate a basic insert since the merge statement expects all primary key

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -549,6 +549,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromPOCO)}]";
                     var ex = new InvalidOperationException(message);
                     TelemetryInstance.TrackError(TelemetryErrorName.MissingPrimaryKeys, ex, sqlConnProps);
+                    throw ex;
                 }
 
                 // If any identity columns aren't included in the object then we have to generate a basic insert since the merge statement expects all primary key

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             if (item != null)
             {
                 await this._rowLock.WaitAsync(cancellationToken);
-
+                TelemetryInstance.TrackEvent(TelemetryEventName.AddAsync);
                 try
                 {
                     this._rows.Add(item);
@@ -120,6 +120,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 if (this._rows.Count != 0)
                 {
+                    TelemetryInstance.TrackEvent(TelemetryEventName.FlushAsync);
                     await this.UpsertRowsAsync(this._rows, this._attribute, this._configuration);
                     this._rows.Clear();
                 }

--- a/src/SqlBindingConfigProvider.cs
+++ b/src/SqlBindingConfigProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            Telemetry.Telemetry.Instance.Initialize(this._configuration, this._loggerFactory);
+            Telemetry.Telemetry.TelemetryInstance.Initialize(this._configuration, this._loggerFactory);
 #pragma warning disable CS0618 // Fine to use this for our stuff
             FluentBindingRule<SqlAttribute> inputOutputRule = context.AddBindingRule<SqlAttribute>();
             var converter = new SqlConverter(this._configuration);

--- a/src/SqlBindingConfigProvider.cs
+++ b/src/SqlBindingConfigProvider.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Azure.WebJobs.Description;
 using static Microsoft.Azure.WebJobs.Extensions.Sql.SqlConverters;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
 using Microsoft.Azure.WebJobs.Host.Bindings;
 using Microsoft.Azure.WebJobs.Host.Config;
 using Microsoft.Extensions.Configuration;
@@ -45,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 throw new ArgumentNullException(nameof(context));
             }
-            Telemetry.Telemetry.TelemetryInstance.Initialize(this._configuration, this._loggerFactory);
+            TelemetryInstance.Initialize(this._configuration, this._loggerFactory);
 #pragma warning disable CS0618 // Fine to use this for our stuff
             FluentBindingRule<SqlAttribute> inputOutputRule = context.AddBindingRule<SqlAttribute>();
             var converter = new SqlConverter(this._configuration);

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
@@ -28,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             public SqlConverter(IConfiguration configuration)
             {
                 this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+                TelemetryInstance.TrackCreate(CreateType.SqlConverter);
             }
 
             /// <summary>
@@ -62,6 +65,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             public SqlGenericsConverter(IConfiguration configuration)
             {
                 this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+                TelemetryInstance.TrackCreate(CreateType.SqlGenericsConverter);
             }
 
             /// <summary>

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -43,8 +43,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <returns>The SqlCommand</returns>
             public SqlCommand Convert(SqlAttribute attribute)
             {
-                return SqlBindingUtilities.BuildCommand(attribute, SqlBindingUtilities.BuildConnection(
-                    attribute.ConnectionStringSetting, this._configuration));
+                TelemetryInstance.TrackConvert(ConvertType.SqlCommand);
+                try
+                {
+                    return SqlBindingUtilities.BuildCommand(attribute, SqlBindingUtilities.BuildConnection(
+                                       attribute.ConnectionStringSetting, this._configuration));
+                }
+                catch (Exception ex)
+                {
+                    var props = new Dictionary<string, string>()
+                    {
+                        { TelemetryPropertyName.Type.ToString(), ConvertType.SqlCommand.ToString() }
+                    };
+                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    throw;
+                }
             }
 
         }
@@ -78,8 +91,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <returns>An IEnumerable containing the rows read from the user's database in the form of the user-defined POCO</returns>
             public async Task<IEnumerable<T>> ConvertAsync(SqlAttribute attribute, CancellationToken cancellationToken)
             {
-                string json = await this.BuildItemFromAttributeAsync(attribute);
-                return JsonConvert.DeserializeObject<IEnumerable<T>>(json);
+                TelemetryInstance.TrackConvert(ConvertType.IEnumerable);
+                try
+                {
+                    string json = await this.BuildItemFromAttributeAsync(attribute);
+                    return JsonConvert.DeserializeObject<IEnumerable<T>>(json);
+                }
+                catch (Exception ex)
+                {
+                    var props = new Dictionary<string, string>()
+                    {
+                        { TelemetryPropertyName.Type.ToString(), ConvertType.IEnumerable.ToString() }
+                    };
+                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    throw;
+                }
             }
 
             /// <summary>
@@ -96,7 +122,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// </returns>
             async Task<string> IAsyncConverter<SqlAttribute, string>.ConvertAsync(SqlAttribute attribute, CancellationToken cancellationToken)
             {
-                return await this.BuildItemFromAttributeAsync(attribute);
+                TelemetryInstance.TrackConvert(ConvertType.Json);
+                try
+                {
+                    return await this.BuildItemFromAttributeAsync(attribute);
+                }
+                catch (Exception ex)
+                {
+                    var props = new Dictionary<string, string>()
+                    {
+                        { TelemetryPropertyName.Type.ToString(), ConvertType.Json.ToString() }
+                    };
+                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    throw;
+                }
             }
 
             /// <summary>
@@ -124,8 +163,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
             IAsyncEnumerable<T> IConverter<SqlAttribute, IAsyncEnumerable<T>>.Convert(SqlAttribute attribute)
             {
-                return new SqlAsyncEnumerable<T>(SqlBindingUtilities.BuildConnection(
-                    attribute.ConnectionStringSetting, this._configuration), attribute);
+                TelemetryInstance.TrackConvert(ConvertType.IAsyncEnumerable);
+                try
+                {
+                    return new SqlAsyncEnumerable<T>(SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, this._configuration), attribute);
+                }
+                catch (Exception ex)
+                {
+                    var props = new Dictionary<string, string>()
+                    {
+                        { TelemetryPropertyName.Type.ToString(), ConvertType.IAsyncEnumerable.ToString() }
+                    };
+                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    throw;
+                }
             }
         }
     }

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -290,7 +290,7 @@ This extension collect usage data in order to help us improve your experience. T
         GetTableInfoStart,
         TableInfoCacheHit,
         TableInfoCacheMiss,
-        Upsert,
+        UpsertEnd,
         UpsertStart,
     }
 

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -267,8 +267,8 @@ This extension collect usage data in order to help us improve your experience. T
     /// </summary>
     public enum ConvertType
     {
-        IEnumerable,
         IAsyncEnumerable,
+        IEnumerable,
         Json,
         SqlCommand
     }
@@ -278,18 +278,20 @@ This extension collect usage data in order to help us improve your experience. T
     /// </summary>
     public enum TelemetryEventName
     {
+        AddAsync,
         Create,
         Convert,
         Error,
-        TableInfoCacheHit,
-        TableInfoCacheMiss,
-        GetTableInfoStart,
-        GetTableInfoEnd,
-        UpsertStart,
-        Upsert,
+        FlushAsync,
         GetCaseSensitivity,
         GetColumnDefinitions,
-        GetPrimaryKeys
+        GetPrimaryKeys,
+        GetTableInfoEnd,
+        GetTableInfoStart,
+        TableInfoCacheHit,
+        TableInfoCacheMiss,
+        Upsert,
+        UpsertStart,
     }
 
     /// <summary>
@@ -297,12 +299,12 @@ This extension collect usage data in order to help us improve your experience. T
     /// </summary>
     public enum TelemetryPropertyName
     {
-        Type,
         ErrorName,
         ExceptionType,
-        ServerVersion,
+        HasIdentityColumn,
         QueryType,
-        HasIdentityColumn
+        ServerVersion,
+        Type
     }
 
     /// <summary>
@@ -310,13 +312,13 @@ This extension collect usage data in order to help us improve your experience. T
     /// </summary>
     public enum TelemetryMeasureName
     {
-        DurationMs,
         BatchCount,
-        TransactionDurationMs,
         CommandDurationMs,
+        DurationMs,
         GetCaseSensitivityDurationMs,
         GetColumnDefinitionsDurationMs,
-        GetPrimaryKeysDurationMs
+        GetPrimaryKeysDurationMs,
+        TransactionDurationMs
     }
 
     /// <summary>
@@ -325,15 +327,15 @@ This extension collect usage data in order to help us improve your experience. T
     public enum TelemetryErrorName
     {
         Convert,
-        Upsert,
-        UpsertRollback,
         GetCaseSensitivity,
         GetColumnDefinitions,
         GetColumnDefinitionsTableDoesNotExist,
         GetPrimaryKeys,
         NoPrimaryKeys,
         MissingPrimaryKeys,
-        PropsNotExistOnTable
+        PropsNotExistOnTable,
+        Upsert,
+        UpsertRollback,
     }
 }
 

--- a/src/Telemetry/TelemetryUtils.cs
+++ b/src/Telemetry/TelemetryUtils.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Data.SqlClient;
 
@@ -13,9 +14,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         /// </summary>
         /// <param name="props">The property bag to add our connection properties to</param>
         /// <param name="conn">The connection to add properties of</param>
-        public static void AddConnectionProps(this Dictionary<string, string> props, SqlConnection conn)
+        public static void AddConnectionProps(this IDictionary<string, string> props, SqlConnection conn)
         {
-            props.Add(nameof(SqlConnection.ServerVersion), conn.ServerVersion);
+            props.Add(TelemetryPropertyName.ServerVersion.ToString(), conn.ServerVersion);
+        }
+
+        /// <summary>
+        /// Adds common exception properties to the property bag for a telemetry event.
+        /// </summary>
+        /// <param name="props"></param>
+        /// <param name="ex">The exception to add properties of</param>
+        public static void AddExceptionProps(this IDictionary<string, string> props, Exception ex)
+        {
+            props.Add(TelemetryPropertyName.ExceptionType.ToString(), ex?.GetType().Name ?? "");
+        }
+
+        /// <summary>
+        /// Returns a dictionary with common connection properties for the specified connection.
+        /// </summary>
+        /// <param name="conn">The connection to get properties of</param>
+        /// <returns>The property dictionary</returns>
+        public static Dictionary<string, string> AsConnectionProps(this SqlConnection conn)
+        {
+            var props = new Dictionary<string, string>();
+            props.AddConnectionProps(conn);
+            return props;
         }
     }
 }

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 
                     cmd.CommandText = commandText;
                     cmd.CommandType = CommandType.Text;
-                    Console.WriteLine($"Executing non-query ${commandText}");
+                    Console.WriteLine($"Executing non-query {commandText}");
                     return cmd.ExecuteNonQuery();
                 }
                 catch (Exception ex)
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                 {
                     cmd.CommandText = commandText;
                     cmd.CommandType = CommandType.Text;
-                    Console.WriteLine($"Executing scalar ${commandText}");
+                    Console.WriteLine($"Executing scalar {commandText}");
                     return cmd.ExecuteScalar();
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Added initial set of events - focusing on a few key metrics : 

- Overall and feature-specific usage
- Query performance
- Errors*

*Note that for errors all we capture is the name of exception type (e.g. `InvalidOperationException`). No PII is gathered for any of the events.

List of the non-Error events added : 

- Creation of handlers (one is created once per binding)
- Input conversions being performed (maps to number of invocations of the binding)
- Output binding table info cache hit/miss
- Output binding execution trace and timings - one event for each sub-query (case sensitivity, column definitions, primary keys)
- Output binding upsert perf (including # of batches inserted)