### PR TITLE
Add machine ID and exception logging

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -186,11 +186,12 @@ This extension collect usage data in order to help us improve your experience. T
                 this._client.Context.Session.Id = CurrentSessionId;
                 this._client.Context.Device.OperatingSystem = RuntimeInformation.OSDescription;
 
-                this._commonProperties = new TelemetryCommonProperties(productVersion).GetTelemetryCommonProperties();
+                this._commonProperties = new TelemetryCommonProperties(productVersion, this._client).GetTelemetryCommonProperties();
                 this._commonMeasurements = new Dictionary<string, double>();
             }
             catch (Exception e)
             {
+                this._client.TrackException(e);
                 this._client = null;
                 // we don't want to fail the tool if telemetry fails.
                 Debug.Fail(e.ToString());

--- a/src/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Telemetry/TelemetryCommonProperties.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -14,18 +15,33 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
             string productVersion)
         {
             this._productVersion = productVersion;
+            this._userLevelCacheWriter = new UserLevelCacheWriter();
         }
+
+        private readonly UserLevelCacheWriter _userLevelCacheWriter;
 
         private const string OSVersion = "OSVersion";
         private const string ProductVersion = "ProductVersion";
+        private const string MachineId = "MachineId";
 
         public Dictionary<string, string> GetTelemetryCommonProperties()
         {
             return new Dictionary<string, string>
             {
                 {OSVersion, RuntimeInformation.OSDescription},
-                {ProductVersion, this._productVersion}
+                {ProductVersion, this._productVersion},
+                {MachineId, this.GetMachineId()},
             };
+        }
+
+        private string GetMachineId()
+        {
+            return this._userLevelCacheWriter.RunWithCache(MachineId, () =>
+            {
+                // For now just use random GUID. Typically hashed MAC address is used but that's not
+                // something we need currently - a GUID per user is sufficient.
+                return Guid.NewGuid().ToString();
+            });
         }
     }
 }

--- a/src/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Telemetry/TelemetryCommonProperties.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Microsoft.ApplicationInsights;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
 {
@@ -11,11 +12,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
     {
         private readonly string _productVersion;
 
-        public TelemetryCommonProperties(
-            string productVersion)
+        public TelemetryCommonProperties(string productVersion, TelemetryClient telemetryClient)
         {
             this._productVersion = productVersion;
-            this._userLevelCacheWriter = new UserLevelCacheWriter();
+            this._userLevelCacheWriter = new UserLevelCacheWriter(telemetryClient);
         }
 
         private readonly UserLevelCacheWriter _userLevelCacheWriter;

--- a/src/Telemetry/UserLevelCacheWriter.cs
+++ b/src/Telemetry/UserLevelCacheWriter.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
+{
+    public sealed class UserLevelCacheWriter
+    {
+        private const string AzureFunctionsSqlBindingsProfileDirectoryName = ".azurefunctions-sqlbindings";
+        private readonly string _azureFunctionsSqlBindingsTryUserProfileFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), AzureFunctionsSqlBindingsProfileDirectoryName);
+
+        public string RunWithCache(string cacheKey, Func<string> getValueToCache)
+        {
+            string cacheFilepath = this.GetCacheFilePath(cacheKey);
+            try
+            {
+                if (!File.Exists(cacheFilepath))
+                {
+                    if (!Directory.Exists(this._azureFunctionsSqlBindingsTryUserProfileFolderPath))
+                    {
+                        Directory.CreateDirectory(this._azureFunctionsSqlBindingsTryUserProfileFolderPath);
+                    }
+
+                    string runResult = getValueToCache();
+
+                    File.WriteAllText(cacheFilepath, runResult);
+                    return runResult;
+                }
+                else
+                {
+                    return File.ReadAllText(cacheFilepath);
+                }
+            }
+            catch (Exception ex)
+            {
+                if (ex is UnauthorizedAccessException
+                    || ex is PathTooLongException
+                    || ex is IOException)
+                {
+                    return getValueToCache();
+                }
+
+                throw;
+            }
+        }
+
+        private string GetCacheFilePath(string cacheKey)
+        {
+            return Path.Combine(this._azureFunctionsSqlBindingsTryUserProfileFolderPath, $"{cacheKey}.azureFunctionsSqlBindingsTryUserLevelCache");
+        }
+    }
+}

--- a/src/Telemetry/UserLevelCacheWriter.cs
+++ b/src/Telemetry/UserLevelCacheWriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using Microsoft.ApplicationInsights;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
 {
@@ -10,6 +11,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
     {
         private const string AzureFunctionsSqlBindingsProfileDirectoryName = ".azurefunctions-sqlbindings";
         private readonly string _azureFunctionsSqlBindingsTryUserProfileFolderPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), AzureFunctionsSqlBindingsProfileDirectoryName);
+        private readonly TelemetryClient _telemetryClient;
+
+        public UserLevelCacheWriter(TelemetryClient telemetryClient)
+        {
+            this._telemetryClient = telemetryClient;
+        }
 
         public string RunWithCache(string cacheKey, Func<string> getValueToCache)
         {
@@ -39,13 +46,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
                     || ex is PathTooLongException
                     || ex is IOException)
                 {
+                    this._telemetryClient.TrackException(ex);
                     return getValueToCache();
                 }
 
                 throw;
             }
         }
-
         private string GetCacheFilePath(string cacheKey)
         {
             return Path.Combine(this._azureFunctionsSqlBindingsTryUserProfileFolderPath, $"{cacheKey}.azureFunctionsSqlBindingsTryUserLevelCache");


### PR DESCRIPTION
Copied and simplified from https://github.com/dotnet/interactive/tree/main/src/Microsoft.DotNet.Interactive.Telemetry

I decided just to generate a random GUID for each user instead of trying to do any sort of MAC hashing - I didn't see the point in doing all the extra work here for that.

Also added some exception logging so we can track if there's issues with initializing the telemetry client. 