### PR TITLE
Add environment and has website instance ID flag to events

### DIFF
--- a/src/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Telemetry/TelemetryCommonProperties.cs
@@ -5,17 +5,22 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.ApplicationInsights;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
 {
     public class TelemetryCommonProperties
     {
         private readonly string _productVersion;
+        private readonly string _azureFunctionsEnvironment;
+        private readonly bool _hasWebsiteInstanceId;
 
-        public TelemetryCommonProperties(string productVersion, TelemetryClient telemetryClient)
+        public TelemetryCommonProperties(string productVersion, TelemetryClient telemetryClient, IConfiguration config)
         {
             this._productVersion = productVersion;
             this._userLevelCacheWriter = new UserLevelCacheWriter(telemetryClient);
+            this._azureFunctionsEnvironment = config.GetValue(AZURE_FUNCTIONS_ENVIRONMENT_KEY, "");
+            this._hasWebsiteInstanceId = config.GetValue(WEBSITE_INSTANCE_ID_KEY, "") != "";
         }
 
         private readonly UserLevelCacheWriter _userLevelCacheWriter;
@@ -23,6 +28,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         private const string OSVersion = "OSVersion";
         private const string ProductVersion = "ProductVersion";
         private const string MachineId = "MachineId";
+        private const string AzureFunctionsEnvironment = "AzureFunctionsEnvironment";
+        private const string HasWebsiteInstanceId = "HasWebsiteInstanceId";
+
+        private const string AZURE_FUNCTIONS_ENVIRONMENT_KEY = "AZURE_FUNCTIONS_ENVIRONMENT";
+        private const string WEBSITE_INSTANCE_ID_KEY = "WEBSITE_INSTANCE_ID";
 
         public Dictionary<string, string> GetTelemetryCommonProperties()
         {
@@ -31,6 +41,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
                 {OSVersion, RuntimeInformation.OSDescription},
                 {ProductVersion, this._productVersion},
                 {MachineId, this.GetMachineId()},
+                {AzureFunctionsEnvironment, this._azureFunctionsEnvironment},
+                {HasWebsiteInstanceId, this._hasWebsiteInstanceId.ToString()}
             };
         }
 


### PR DESCRIPTION
These both will be used to determine whether the functions are running locally or in Azure. 

The presence of a website instance ID indicates that it's running in Azure (this is what functions use internally). This is likely the only thing we need to use currently.

The environment is nice to have though as it also then differs between Production and Staging (3 possible values are Development, Staging and Production). 