### PR TITLE
Generate platform independent debug symbols

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -11,7 +11,7 @@
     <DebugSymbols>true</DebugSymbols>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Sql</PackageId>
     <PackageTags>Microsoft Azure WebJobs AzureFunctions SQL AzureSQL</PackageTags>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Seeing this error when trying to debug the binding extension code : 

```
WARNING: Could not load symbols for 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'. 'C:\src\azure-functions-sql-extension\samples\bin\Debug\netcoreapp3.1\bin\Microsoft.Azure.WebJobs.Extensions.Sql.pdb' is a Windows PDB. These are not supported by the cross-platform .NET Core debugger.
Loaded 'C:\src\azure-functions-sql-extension\samples\bin\Debug\netcoreapp3.1\bin\Microsoft.Azure.WebJobs.Extensions.Sql.dll'. Cannot find or open the PDB file.
```

Per https://github.com/OmniSharp/omnisharp-vscode/wiki/Portable-PDBs#net-cli-projects-projectjson

`The new .NET debugger for Visual Studio Code only supports this new portable format.`

Note that we want to generate separate PDBs (instead of having symbols embedded) so we can generate a separate snupkg with the symbols for uploading separately to keep file size down.