### PR TITLE
Use TrackException for errors

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.19.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.17.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.*" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     this._rows.Clear();
                 }
             }
+            catch (Exception ex)
+            {
+                TelemetryInstance.TrackException(TelemetryErrorName.FlushAsync, ex);
+                throw;
+            }
             finally
             {
                 this._rowLock.Release();
@@ -177,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 string message = $"The following properties in {typeof(T)} do not exist in the table {fullTableName}: {string.Join(", ", extraProperties.ToArray())}.";
                 var ex = new InvalidOperationException(message);
-                TelemetryInstance.TrackError(TelemetryErrorName.PropsNotExistOnTable, ex, props);
+                TelemetryInstance.TrackException(TelemetryErrorName.PropsNotExistOnTable, ex, props);
                 throw ex;
             }
 
@@ -214,12 +219,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 try
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.Upsert, ex, props);
+                    TelemetryInstance.TrackException(TelemetryErrorName.Upsert, ex, props);
                     transaction.Rollback();
                 }
                 catch (Exception ex2)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.UpsertRollback, ex2, props);
+                    TelemetryInstance.TrackException(TelemetryErrorName.UpsertRollback, ex2, props);
                     string message2 = $"Encountered exception during upsert and rollback.";
                     throw new AggregateException(message2, new List<Exception> { ex, ex2 });
                 }
@@ -467,7 +472,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     // Since this doesn't rethrow make sure we stop here too (don't use finally because we want the execution time to be the same here and in the 
                     // overall event but we also only want to send the GetCaseSensitivity event if it succeeds)
                     caseSensitiveSw.Stop();
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetCaseSensitivity, ex, sqlConnProps);
+                    TelemetryInstance.TrackException(TelemetryErrorName.GetCaseSensitivity, ex, sqlConnProps);
                     logger.LogWarning($"Encountered exception while retrieving database collation: {ex}. Case insensitive behavior will be used by default.");
                 }
 
@@ -490,7 +495,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitions, ex, sqlConnProps);
+                    TelemetryInstance.TrackException(TelemetryErrorName.GetColumnDefinitions, ex, sqlConnProps);
                     // Throw a custom error so that it's easier to decipher.
                     string message = $"Encountered exception while retrieving column names and types for table {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message, ex);
@@ -500,7 +505,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string message = $"Table {table} does not exist.";
                     var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetColumnDefinitionsTableDoesNotExist, ex, sqlConnProps);
+                    TelemetryInstance.TrackException(TelemetryErrorName.GetColumnDefinitionsTableDoesNotExist, ex, sqlConnProps);
                     throw ex;
                 }
 
@@ -521,7 +526,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    TelemetryInstance.TrackError(TelemetryErrorName.GetPrimaryKeys, ex, sqlConnProps);
+                    TelemetryInstance.TrackException(TelemetryErrorName.GetPrimaryKeys, ex, sqlConnProps);
                     // Throw a custom error so that it's easier to decipher.
                     string message = $"Encountered exception while retrieving primary keys for table {table}. Cannot generate upsert command without them.";
                     throw new InvalidOperationException(message, ex);
@@ -531,7 +536,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string message = $"Did not retrieve any primary keys for {table}. Cannot generate upsert command without them.";
                     var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackError(TelemetryErrorName.NoPrimaryKeys, ex, sqlConnProps);
+                    TelemetryInstance.TrackException(TelemetryErrorName.NoPrimaryKeys, ex, sqlConnProps);
                     throw ex;
                 }
 
@@ -548,7 +553,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromPOCO)}]";
                     var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackError(TelemetryErrorName.MissingPrimaryKeys, ex, sqlConnProps);
+                    TelemetryInstance.TrackException(TelemetryErrorName.MissingPrimaryKeys, ex, sqlConnProps);
                     throw ex;
                 }
 

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         { TelemetryPropertyName.Type.ToString(), ConvertType.SqlCommand.ToString() }
                     };
-                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
                 }
             }
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         { TelemetryPropertyName.Type.ToString(), ConvertType.IEnumerable.ToString() }
                     };
-                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
                 }
             }
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         { TelemetryPropertyName.Type.ToString(), ConvertType.Json.ToString() }
                     };
-                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
                 }
             }
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         { TelemetryPropertyName.Type.ToString(), ConvertType.IAsyncEnumerable.ToString() }
                     };
-                    TelemetryInstance.TrackError(TelemetryErrorName.Convert, ex, props);
+                    TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
                 }
             }


### PR DESCRIPTION
We get a lot more information for free by doing this (such as method name).

I still send the "TelemetryErroName" so we can easily tell exceptions that come from the same method apart (such as the Upsert method which does a bunch of error checking)

Looked over what is sent and the only paths that are sent up are the file paths from when the assembly was compiled - which will be the build machine so we should be fine on that front since no user information is included automatically. 

I also downgraded the version of the AI library we're using to match what Azure Functions uses - without doing that it wasn't possible to debug telemetry stuff since the assembly versions didn't match (and at runtime the assembly resolved to the runtimes version anyways)