### PR TITLE
Fix quoting in primary keys query

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     INNER JOIN
                         INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND ccu.TABLE_NAME = tc.TABLE_NAME
                     INNER JOIN
-                        sys.columns c ON c.object_id = OBJECT_ID({table.BracketQuotedFullName.AsSingleQuotedString()}) AND c.name = ccu.COLUMN_NAME
+                        sys.columns c ON c.object_id = OBJECT_ID({table.QuotedFullName}) AND c.name = ccu.COLUMN_NAME
                     WHERE
                         tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
                     and

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     INNER JOIN
                         INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu ON ccu.CONSTRAINT_NAME = tc.CONSTRAINT_NAME AND ccu.TABLE_NAME = tc.TABLE_NAME
                     INNER JOIN
-                        sys.columns c ON c.object_id = OBJECT_ID({table.QuotedFullName}) AND c.name = ccu.COLUMN_NAME
+                        sys.columns c ON c.object_id = OBJECT_ID({table.BracketQuotedFullName.AsSingleQuotedString()}) AND c.name = ccu.COLUMN_NAME
                     WHERE
                         tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
                     and

--- a/src/SqlObject.cs
+++ b/src/SqlObject.cs
@@ -36,8 +36,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         public readonly string FullName;
         /// <summary>
-        /// The full name of the object in the format 'SCHEMA.NAME' (or just 'NAME' if there is no specified schema), quoted and escaped with single quotes
+        /// The full name of the object in the format '[SCHEMA].[NAME]' (or just '[NAME]' if there is no specified schema), quoted and escaped with single quotes
         /// </summary>
+        /// <remarks>The schema and name are also bracket quoted to avoid issues when there are .'s in the object names</remarks>
         public readonly string QuotedFullName;
 
         /// <summary>
@@ -73,8 +74,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this.Name = visitor.objectName;
             this.QuotedName = this.Name.AsSingleQuotedString();
             this.FullName = this.Schema == SCHEMA_NAME_FUNCTION ? this.Name : $"{this.Schema}.{this.Name}";
-            this.QuotedFullName = this.FullName.AsSingleQuotedString();
             this.BracketQuotedFullName = this.Schema == SCHEMA_NAME_FUNCTION ? this.Name.AsBracketQuotedString() : $"{this.Schema.AsBracketQuotedString()}.{this.Name.AsBracketQuotedString()}";
+            this.QuotedFullName = this.BracketQuotedFullName.AsSingleQuotedString();
         }
 
         /// <summary>

--- a/test/Unit/SqlOutputBindingTests.cs
+++ b/test/Unit/SqlOutputBindingTests.cs
@@ -42,13 +42,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         }
 
         [Theory]
-        [InlineData("dbo.Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name
-        [InlineData("Products", "SCHEMA_NAME()", "SCHEMA_NAME()", "Products", "'Products'", "Products", "'Products'", "[Products]")] // Simple no schema
-        [InlineData("[dbo].[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name bracket quoted
-        [InlineData("[dbo].Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name only schema bracket quoted
-        [InlineData("dbo.[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'dbo.Products'", "[dbo].[Products]")] // Simple full name only name bracket quoted
-        [InlineData("[My'Schema].[Prod'ucts]", "My'Schema", "'My''Schema'", "Prod'ucts", "'Prod''ucts'", "My'Schema.Prod'ucts", "'My''Schema.Prod''ucts'", "[My'Schema].[Prod'ucts]")] // Full name with single quotes in schema and name
-        [InlineData("[My]]Schema].[My]]Object]", "My]Schema", "'My]Schema'", "My]Object", "'My]Object'", "My]Schema.My]Object", "'My]Schema.My]Object'", "[My]]Schema].[My]]Object]")] // Full name with brackets in schema and name
+        [InlineData("dbo.Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'[dbo].[Products]'", "[dbo].[Products]")] // Simple full name
+        [InlineData("Products", "SCHEMA_NAME()", "SCHEMA_NAME()", "Products", "'Products'", "Products", "'[Products]'", "[Products]")] // Simple no schema
+        [InlineData("[dbo].[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'[dbo].[Products]'", "[dbo].[Products]")] // Simple full name bracket quoted
+        [InlineData("[dbo].Products", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'[dbo].[Products]'", "[dbo].[Products]")] // Simple full name only schema bracket quoted
+        [InlineData("dbo.[Products]", "dbo", "'dbo'", "Products", "'Products'", "dbo.Products", "'[dbo].[Products]'", "[dbo].[Products]")] // Simple full name only name bracket quoted
+        [InlineData("[My'Schema].[Prod'ucts]", "My'Schema", "'My''Schema'", "Prod'ucts", "'Prod''ucts'", "My'Schema.Prod'ucts", "'[My''Schema].[Prod''ucts]'", "[My'Schema].[Prod'ucts]")] // Full name with single quotes in schema and name
+        [InlineData("[My]]Schema].[My]]Object]", "My]Schema", "'My]Schema'", "My]Object", "'My]Object'", "My]Schema.My]Object", "'[My]]Schema].[My]]Object]'", "[My]]Schema].[My]]Object]")] // Full name with brackets in schema and name
         public void TestSqlObject(string fullName,
             string expectedSchema,
             string expectedQuotedSchema,


### PR DESCRIPTION
We need to double-quote the name here, just quoting with single quotes can end up with a name like `'My.Schema.My.Table'` (if schema and table are `My.Schema` and `My.Table` respectively) which isn't what we want here (or ever so fixing it in the SqlObject class)