### PR TITLE
Capture SqlException Number

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -11,6 +11,7 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using System.Globalization;
+using Microsoft.Data.SqlClient;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
 {
@@ -27,7 +28,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         private ILogger _logger;
         private bool _initialized;
         private const string InstrumentationKey = "98697a1c-1416-486a-99ac-c6c74ebe5ebd";
-        private static readonly CultureInfo ENUSCultureInfo = new CultureInfo("en-US");
         /// <summary>
         /// The environment variable used for opting out of telemetry
         /// </summary>
@@ -280,15 +280,14 @@ This extension collect usage data in order to help us improve your experience. T
             }
         }
 
+        /// <summary>
+        /// Extract error code from known exception types
+        /// </summary>
         private static string ExtractErrorCode(Exception ex)
         {
-            if (ex == null)
+            if (ex != null && ex is SqlException)
             {
-                return string.Empty;
-            }
-            if (ex is Data.SqlClient.SqlException)
-            {
-                return (ex as Data.SqlClient.SqlException).ErrorCode.ToString(ENUSCultureInfo);
+                return (ex as SqlException).Number.ToString(CultureInfo.InvariantCulture);
             }
             return string.Empty;
         }


### PR DESCRIPTION
Extract SqlException number to help disambiguate SqlExceptions so that we can better fix customer issues with SqlClient.

I'm certainly unfamiliar here, so please feel free to take a hard look here. Should I still be adding the telemetry property if it's an empty string?