### PR TITLE
fix casing issue when sql table is case insensitive

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -313,9 +313,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 else
                 {
                     // ToDo: add check for duplicate primary keys once we find a way to get primary keys.
+                    // lower case the json keys if sql table is case insensitive since the query we built expects everything lowercased.
                     if (table.Comparer == StringComparer.OrdinalIgnoreCase)
                     {
-                        ChangePropertiesToLowerCase(JObject.Parse(row.ToString()));
+                        ChangePropertiesToLowerCase(row as JObject);
                     }
                     rowsToUpsert.Add(row);
                 }

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             foreach (JProperty property in jsonObject.Properties().ToList())
             {
-                if (property.Value.Type == JTokenType.Object)
+                if (property.Value.GetType() == typeof(JObject))
                 {
                     ChangePropertiesToLowerCase((JObject)property.Value);
                 }

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
+using MoreLinq;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -58,6 +61,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     return false;
                 default:
                     return defaultValue;
+            }
+        }
+
+        /// <summary>
+        /// Recursively converts the property names for a JObject to lowercase
+        /// </summary>
+        /// <param name="obj">The JToken to convert</param>
+        public static void LowercasePropertyNames(this JToken token)
+        {
+            if (token is JObject jObj)
+            {
+                token.LowercasePropertyNames();
+            }
+            else if (token is JArray jArray)
+            {
+                token.ForEach(x => x.LowercasePropertyNames());
+            }
+        }
+
+        /// <summary>
+        /// Recursively converts the property names for a JObject to lowercase
+        /// </summary>
+        /// <param name="obj">The JObject to convert</param>
+        public static void LowercasePropertyNames(this JObject obj)
+        {
+            foreach (JProperty property in obj.Properties())
+            {
+                property.Value.LowercasePropertyNames();
+                // properties are read-only, so we have to replace them
+                property.Replace(new JProperty(property.Name.ToLowerInvariant(), property.Value));
             }
         }
     }

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using Microsoft.Extensions.Configuration;
 using MoreLinq;
 using Newtonsoft.Json.Linq;

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.Extensions.Configuration;
 using MoreLinq;
 using Newtonsoft.Json.Linq;
@@ -85,7 +86,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <param name="obj">The JObject to convert</param>
         public static void LowercasePropertyNames(this JObject obj)
         {
-            foreach (JProperty property in obj.Properties())
+            foreach (JProperty property in obj.Properties().ToList())
             {
                 property.Value.LowercasePropertyNames();
                 // properties are read-only, so we have to replace them


### PR DESCRIPTION
Fixes #232  where the column names are case insensitive, we are building the sql query converting the columns to lowercase but the javascript object keys are being passed as defined and the sql query is expecting lowercased values. 

Fix: Added an extra step to convert the JObjects keys to lower case and passed that to the sql query.
Tried using the JsonSerializerSettings and passing the NamingStrategy to convert property names to lowercase but that was not working and still returned keys as is. Alternatively manually updated the properties to lower case by iterating through them.