### PR TITLE
Add integration test connection retry

### DIFF
--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
@@ -116,6 +117,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Retries the specified action, waiting for the specified duration in between each attempt
+        /// </summary>
+        /// <param name="action">The action to run</param>
+        /// <param name="maxRetries">The max number of retries to attempt</param>
+        /// <param name="waitDurationMs">The duration in milliseconds between each attempt</param>
+        /// <exception cref="AggregateException">Aggregate of all exceptions thrown if all retries failed</exception>
+        public static void Retry(Action action, int maxRetries = 3, int waitDurationMs = 10000)
+        {
+            var exceptions = new List<Exception>();
+            while (true)
+            {
+                try
+                {
+                    action();
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                    maxRetries--;
+                    if (maxRetries == 0)
+                    {
+                        throw new AggregateException($"Action failed all retries", exceptions);
+                    }
+                    Console.WriteLine($"Error running action, retrying after {waitDurationMs}ms. {maxRetries} retries left. {ex}");
+                    Thread.Sleep(waitDurationMs);
+                }
+            }
         }
     }
 }

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -123,10 +123,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// Retries the specified action, waiting for the specified duration in between each attempt
         /// </summary>
         /// <param name="action">The action to run</param>
-        /// <param name="maxRetries">The max number of retries to attempt</param>
+        /// <param name="retryCount">The max number of retries to attempt</param>
         /// <param name="waitDurationMs">The duration in milliseconds between each attempt</param>
         /// <exception cref="AggregateException">Aggregate of all exceptions thrown if all retries failed</exception>
-        public static void Retry(Action action, int maxRetries = 3, int waitDurationMs = 10000)
+        public static void Retry(Action action, int retryCount = 3, int waitDurationMs = 10000)
         {
             var exceptions = new List<Exception>();
             while (true)
@@ -139,12 +139,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                 catch (Exception ex)
                 {
                     exceptions.Add(ex);
-                    maxRetries--;
-                    if (maxRetries == 0)
+                    retryCount--;
+                    if (retryCount == 0)
                     {
                         throw new AggregateException($"Action failed all retries", exceptions);
                     }
-                    Console.WriteLine($"Error running action, retrying after {waitDurationMs}ms. {maxRetries} retries left. {ex}");
+                    Console.WriteLine($"Error running action, retrying after {waitDurationMs}ms. {retryCount} retries left. {ex}");
                     Thread.Sleep(waitDurationMs);
                 }
             }

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -105,12 +105,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.MasterConnectionString = connectionStringBuilder.ToString();
 
             // Create database
+            // Retry this in case the server isn't fully initialized yet
             this.DatabaseName = TestUtils.GetUniqueDBName("SqlBindingsTest");
-            using (var masterConnection = new SqlConnection(this.MasterConnectionString))
+            TestUtils.Retry(() =>
             {
+                using var masterConnection = new SqlConnection(this.MasterConnectionString);
                 masterConnection.Open();
                 TestUtils.ExecuteNonQuery(masterConnection, $"CREATE DATABASE [{this.DatabaseName}]");
-            }
+            });
 
             // Setup connection
             connectionStringBuilder.InitialCatalog = this.DatabaseName;


### PR DESCRIPTION
Make tests more robust, right now they occasionally fail on the pipeline runs because the docker servers aren't fully initialized yet when the tests start running. 