### PR TITLE
Fix invalid CommandType error string

### DIFF
--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -125,8 +125,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             }
             else if (attribute.CommandType != CommandType.Text)
             {
-                throw new ArgumentException("The Type of the SQL attribute for an input binding must be either CommandType.Text for a plain text" +
-                    "SQL query, or CommandType.StoredProcedure for a stored procedure.");
+                throw new ArgumentException("The type of the SQL attribute for an input binding must be either CommandType.Text for a direct SQL query, or CommandType.StoredProcedure for a stored procedure.");
             }
             ParseParameters(attribute.Parameters, command);
             return command;


### PR DESCRIPTION
The string doesn't have a space between text and SQL

![image](https://user-images.githubusercontent.com/28519865/167935529-f60b135a-ae74-4319-86d0-eef34008d62b.png)

Also slightly reworded it - I don't really like the use of `plain text` here since that typically is used in the context of encrypted/secret strings. 