### PR TITLE
Check program files for AF core tools

### DIFF
--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -227,7 +227,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             if (!File.Exists(funcPath))
             {
-                throw new FileNotFoundException("Azure Function Core Tools not found at " + funcPath);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    // Search Program Files folder as well
+                    string programFilesFuncPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft", "Azure Functions Core Tools", funcExe);
+                    if (File.Exists(programFilesFuncPath))
+                    {
+                        return programFilesFuncPath;
+                    }
+                    throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath} or {programFilesFuncPath}");
+                }
+                throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath}");
             }
 
             return funcPath;


### PR DESCRIPTION
We were only checking the npm location, but users on Windows can install it using an MSI as well. This only really matters for local runs since the pipeline runs install it using npm. 

I'm not bothering to add x86 since that isn't something we should generally be using anyways. 

Didn't check whether other platforms might have a similar issue, but I figure we can add that later on if needed. 