### PR TITLE
Update AddProduct.cs

### DIFF
--- a/samples/samples-csharp/OutputBindingSamples/AddProduct.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProduct.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
+using System.Data;
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
 {
     public static class AddProduct
@@ -12,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct")]
             [FromBody] Product prod,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out Product product)
+            [Sql("dbo.Products", CommandType = CommandType.TableDirect, ConnectionStringSetting = "SqlConnectionString")] out Product product)
         {
             product = prod;
             return new CreatedResult($"/api/addproduct", product);


### PR DESCRIPTION
With VS2022, Functions Runtime 4.3.2.18186 and .net 6, it is required to include CommandType; otherwise there is an error thrown.