### PR TITLE
Add SupportedLanguages Attribute to run tests against all supported langs.

### DIFF
--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -6,4 +6,3 @@
 dotnet_diagnostic.CA1309.severity = silent # Use ordinal StringComparison - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
-dotnet_diagnostic.CA1051.severity = silent # Do not declare visible instance fields - this helps avoid creating properties when not needed and avoid clutter

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -6,3 +6,4 @@
 dotnet_diagnostic.CA1309.severity = silent # Use ordinal StringComparison - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
+dotnet_diagnostic.CA1051.severity = silent # Do not declare visible instance fields - this helps avoid creating properties when not needed and avoid clutter

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
     /// </summary>
     public class SqlInlineDataAttribute : DataAttribute
     {
-        protected readonly Dictionary<string, List<List<object>>> testData = new Dictionary<string, List<List<object>>>();
-        protected readonly string _propertyName = "data";
+        private readonly Dictionary<string, List<List<object>>> testData = new Dictionary<string, List<List<object>>>();
+        private readonly string _propertyName = "data";
 
         /// <summary>
         /// Load supported languages as test parameters data for the test.

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// <param name="args">The test parameters to insert inline for the test</param>
         public SqlInlineDataAttribute(params object[] args)
         {
+            // Add each supported language to the args and add the newly created list of args
+            // with the language parameter to the testData
             foreach (SupportedLanguages lang in Enum.GetValues(typeof(SupportedLanguages)))
             {
                 var listOfValues = new List<object>();

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using Xunit.Sdk;
+using System.Reflection;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
+{
+    public abstract class LanguageTestAttribute : DataAttribute
+    {
+        protected enum SupportedLanguages
+        {
+            CSharp
+            /*JavaScript,
+            Python,
+             TypeScript */
+        }
+        protected readonly Dictionary<string, List<List<object>>> testData = new Dictionary<string, List<List<object>>>();
+        protected readonly string _propertyName = "data";
+
+        /// <inheritDoc />
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            if (testMethod == null) { throw new ArgumentNullException(nameof(testMethod)); }
+
+            if (this.testData.Count == 0) { throw new EmptyException(nameof(testMethod)); }
+            string serializedData = JsonConvert.SerializeObject(this.testData);
+            var allData = JObject.Parse(serializedData);
+            JToken data = allData[this._propertyName];
+            return data.ToObject<List<object[]>>();
+        }
+
+    }
+    public class SupportedLanguagesAttribute : LanguageTestAttribute
+    {
+        /// <summary>
+        /// Load supported languages for inline data for a theory
+        /// </summary>
+        public SupportedLanguagesAttribute()
+        {
+            var langData = new List<List<object>>();
+            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
+            {
+                var listOfValues = new List<object>(1) { lang };
+                langData.Add(listOfValues);
+            }
+            this.testData.Add(this._propertyName, langData);
+        }
+        /// <summary>
+        /// Load data from a inline data for a theory
+        /// </summary>
+        /// <param name="n">The number of products to insert for the test</param>
+        /// <param name="cost">The cost of the products for the test</param>
+        public SupportedLanguagesAttribute(int n, int cost)
+        {
+            var langData = new List<List<object>>();
+            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
+            {
+                var listOfValues = new List<object>(3) { n, cost, lang };
+                langData.Add(listOfValues);
+            }
+            this.testData.Add(this._propertyName, langData);
+        }
+
+        /// <summary>
+        /// Load data from a inline data for a theory
+        /// </summary>
+        /// <param name="id">The id of products for the test</param>
+        /// <param name="name">The name of products for the test</param>
+        /// <param name="cost">The cost of the product for the test</param>
+        public SupportedLanguagesAttribute(int id, string name, int cost)
+        {
+            var langData = new List<List<object>>();
+            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
+            {
+                var listOfValues = new List<object>(4) { id, name, cost, lang };
+                langData.Add(listOfValues);
+            }
+            this.testData.Add(this._propertyName, langData);
+        }
+    }
+
+    public class UnsupportedLanguagesAttribute : LanguageTestAttribute
+    {
+        /// <summary>
+        /// Load supported languages for inline data for a theory
+        /// </summary>
+        public UnsupportedLanguagesAttribute(string[] args)
+        {
+            var langData = new List<List<object>>();
+            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
+            {
+                if (Array.IndexOf(args, lang) == -1)
+                {
+                    langData.Add(new List<object>(1) { lang });
+                }
+            }
+            this.testData.Add(this._propertyName, langData);
+        }
+    }
+}

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -6,17 +6,21 @@ using Xunit.Sdk;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 {
+    /// <summary>
+    /// Base attribute class for adding language parameter data to tests. This allows
+    /// tests to be run against all the supported languages list that are specified in the SupportedLanguages
+    /// list of this class (ex: CSharp, JavaScript)
+    /// </summary>
     public abstract class LanguageTestAttribute : DataAttribute
     {
+        // add all the list of supported languages.
         protected enum SupportedLanguages
         {
             CSharp
-            /*JavaScript,
-            Python,
-             TypeScript */
         }
         protected readonly Dictionary<string, List<List<object>>> testData = new Dictionary<string, List<List<object>>>();
         protected readonly string _propertyName = "data";
@@ -37,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
     public class SupportedLanguagesAttribute : LanguageTestAttribute
     {
         /// <summary>
-        /// Load supported languages for inline data for a theory
+        /// Load supported languages as test parameters data for the test.
         /// </summary>
         public SupportedLanguagesAttribute()
         {
@@ -50,33 +54,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
             this.testData.Add(this._propertyName, langData);
         }
         /// <summary>
-        /// Load data from a inline data for a theory
+        /// Load the test parameters data for each language for inline use of the test.
         /// </summary>
-        /// <param name="n">The number of products to insert for the test</param>
-        /// <param name="cost">The cost of the products for the test</param>
-        public SupportedLanguagesAttribute(int n, int cost)
+        /// <param name="args">The test parameters to insert inline for the test</param>
+        public SupportedLanguagesAttribute(params object[] args)
         {
             var langData = new List<List<object>>();
-            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
-            {
-                var listOfValues = new List<object>(3) { n, cost, lang };
-                langData.Add(listOfValues);
-            }
-            this.testData.Add(this._propertyName, langData);
-        }
+            var listOfValues = new List<object>();
 
-        /// <summary>
-        /// Load data from a inline data for a theory
-        /// </summary>
-        /// <param name="id">The id of products for the test</param>
-        /// <param name="name">The name of products for the test</param>
-        /// <param name="cost">The cost of the product for the test</param>
-        public SupportedLanguagesAttribute(int id, string name, int cost)
-        {
-            var langData = new List<List<object>>();
             foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
             {
-                var listOfValues = new List<object>(4) { id, name, cost, lang };
+                foreach (object val in args)
+                {
+                    listOfValues.Add(val);
+                }
+                listOfValues.Add(lang);
                 langData.Add(listOfValues);
             }
             this.testData.Add(this._propertyName, langData);
@@ -86,16 +78,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
     public class UnsupportedLanguagesAttribute : LanguageTestAttribute
     {
         /// <summary>
-        /// Load supported languages for inline data for a theory
+        /// Load only supported languages excluding the ones from the provided parameters.
         /// </summary>
-        public UnsupportedLanguagesAttribute(string[] args)
+        public UnsupportedLanguagesAttribute(params object[] argsWithUnsupportedLangs)
         {
             var langData = new List<List<object>>();
+            var listOfValues = new List<object>();
+
+            // get the unsupported list of languages from the argsWithUnsupportedLangs
+            string[] argsAsString = Array.ConvertAll(argsWithUnsupportedLangs, x => x.ToString());
+            IEnumerable<string> unsupportedList = argsAsString.Intersect(Enum.GetNames(typeof(SupportedLanguages)));
+            // get the actual parameters filtering out the unsupported language list.
+            object[] args = Array.FindAll(argsWithUnsupportedLangs, x => !unsupportedList.Contains(x));
             foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
             {
-                if (Array.IndexOf(args, lang) == -1)
+                if (!unsupportedList.Contains(lang))
                 {
-                    langData.Add(new List<object>(1) { lang });
+                    foreach (object val in args)
+                    {
+                        listOfValues.Add(val);
+                    }
+                    listOfValues.Add(lang);
+                    langData.Add(listOfValues);
                 }
             }
             this.testData.Add(this._propertyName, langData);

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         {
             // Add each supported language to the args and add the newly created list of args
             // with the language parameter to the testData
+            // [a, b, c] -> [[a, b, c, SupportedLang1], [a, b,  c, SupportedLang2], ..]
             foreach (SupportedLanguages lang in Enum.GetValues(typeof(SupportedLanguages)))
             {
                 var listOfValues = new List<object>();

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// <param name="args">The test parameters to insert inline for the test</param>
         public SqlInlineDataAttribute(params object[] args)
         {
-            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
+            foreach (SupportedLanguages lang in Enum.GetValues(typeof(SupportedLanguages)))
             {
                 var listOfValues = new List<object>();
                 foreach (object val in args)
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
             UnsupportedLanguagesAttribute unsupportedLangAttr = testMethod.GetCustomAttribute<UnsupportedLanguagesAttribute>();
             if (unsupportedLangAttr != null)
             {
-                foreach (string lang in unsupportedLangAttr.UnsuppportedLanguages)
+                foreach (SupportedLanguages lang in unsupportedLangAttr.UnsuppportedLanguages)
                 {
                     this.testData.RemoveAll(l => Array.IndexOf(l, lang) > -1);
                 }
@@ -56,16 +56,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
     [AttributeUsage(AttributeTargets.Method)]
     public class UnsupportedLanguagesAttribute : Attribute
     {
-        public List<string> UnsuppportedLanguages { get; set; } = new List<string>();
+        public List<SupportedLanguages> UnsuppportedLanguages { get; set; } = new List<SupportedLanguages>();
         /// <summary>
         /// Load only supported languages excluding the ones from the provided parameters.
         /// </summary>
         public UnsupportedLanguagesAttribute(params SupportedLanguages[] argsWithUnsupportedLangs)
         {
-            foreach (SupportedLanguages s in argsWithUnsupportedLangs)
-            {
-                this.UnsuppportedLanguages.Add(s.ToString());
-            }
+            this.UnsuppportedLanguages.AddRange(argsWithUnsupportedLangs);
         }
     }
     public enum SupportedLanguages

--- a/test/Common/SupportedLanguagesTestAttribute.cs
+++ b/test/Common/SupportedLanguagesTestAttribute.cs
@@ -6,44 +6,23 @@ using Xunit.Sdk;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
-using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 {
     /// <summary>
-    /// Base attribute class for adding language parameter data to tests. This allows
+    /// SqlInlineData attribute class for adding language parameter data to tests. This allows
     /// tests to be run against all the supported languages list that are specified in the SupportedLanguages
     /// list of this class (ex: CSharp, JavaScript)
     /// </summary>
-    public abstract class LanguageTestAttribute : DataAttribute
+    public class SqlInlineDataAttribute : DataAttribute
     {
-        // add all the list of supported languages.
-        protected enum SupportedLanguages
-        {
-            CSharp
-        }
         protected readonly Dictionary<string, List<List<object>>> testData = new Dictionary<string, List<List<object>>>();
         protected readonly string _propertyName = "data";
 
-        /// <inheritDoc />
-        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
-        {
-            if (testMethod == null) { throw new ArgumentNullException(nameof(testMethod)); }
-
-            if (this.testData.Count == 0) { throw new EmptyException(nameof(testMethod)); }
-            string serializedData = JsonConvert.SerializeObject(this.testData);
-            var allData = JObject.Parse(serializedData);
-            JToken data = allData[this._propertyName];
-            return data.ToObject<List<object[]>>();
-        }
-
-    }
-    public class SupportedLanguagesAttribute : LanguageTestAttribute
-    {
         /// <summary>
         /// Load supported languages as test parameters data for the test.
         /// </summary>
-        public SupportedLanguagesAttribute()
+        public SqlInlineDataAttribute()
         {
             var langData = new List<List<object>>();
             foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
@@ -52,18 +31,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                 langData.Add(listOfValues);
             }
             this.testData.Add(this._propertyName, langData);
+
         }
         /// <summary>
-        /// Load the test parameters data for each language for inline use of the test.
+        /// Load the test parameters data for all supported languages for inline use of the test.
         /// </summary>
         /// <param name="args">The test parameters to insert inline for the test</param>
-        public SupportedLanguagesAttribute(params object[] args)
+        public SqlInlineDataAttribute(params object[] args)
         {
             var langData = new List<List<object>>();
-            var listOfValues = new List<object>();
-
             foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
             {
+                var listOfValues = new List<object>();
                 foreach (object val in args)
                 {
                     listOfValues.Add(val);
@@ -73,36 +52,52 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
             }
             this.testData.Add(this._propertyName, langData);
         }
+
+        /// <inheritDoc />
+        public override IEnumerable<object[]> GetData(MethodInfo testMethod)
+        {
+            if (testMethod == null) { throw new ArgumentNullException(nameof(testMethod)); }
+            if (this.testData.Count == 0) { throw new EmptyException(nameof(testMethod)); }
+
+            UnsupportedLanguagesAttribute unsupportedLangAttr = testMethod.GetCustomAttribute<UnsupportedLanguagesAttribute>();
+            if (unsupportedLangAttr != null)
+            {
+                var unsupportedLanguages = new List<string>();
+                unsupportedLanguages.AddRange(unsupportedLangAttr.UnsuppportedLanguages);
+                foreach (string lang in unsupportedLanguages)
+                {
+                    List<List<object>> dataList = this.testData.GetValueOrDefault(this._propertyName);
+                    dataList.RemoveAll(l => l.Contains(lang));
+                    this.testData[this._propertyName] = dataList;
+                }
+            }
+
+            string serializedData = JsonConvert.SerializeObject(this.testData);
+            var allData = JObject.Parse(serializedData);
+            JToken data = allData[this._propertyName];
+            return data.ToObject<List<object[]>>();
+        }
     }
 
-    public class UnsupportedLanguagesAttribute : LanguageTestAttribute
+    [AttributeUsage(AttributeTargets.Method)]
+    public class UnsupportedLanguagesAttribute : Attribute
     {
+        public List<string> UnsuppportedLanguages { get; set; } = new List<string>();
         /// <summary>
         /// Load only supported languages excluding the ones from the provided parameters.
         /// </summary>
-        public UnsupportedLanguagesAttribute(params object[] argsWithUnsupportedLangs)
+        public UnsupportedLanguagesAttribute(params SupportedLanguages[] argsWithUnsupportedLangs)
         {
-            var langData = new List<List<object>>();
-            var listOfValues = new List<object>();
-
-            // get the unsupported list of languages from the argsWithUnsupportedLangs
-            string[] argsAsString = Array.ConvertAll(argsWithUnsupportedLangs, x => x.ToString());
-            IEnumerable<string> unsupportedList = argsAsString.Intersect(Enum.GetNames(typeof(SupportedLanguages)));
-            // get the actual parameters filtering out the unsupported language list.
-            object[] args = Array.FindAll(argsWithUnsupportedLangs, x => !unsupportedList.Contains(x));
-            foreach (string lang in Enum.GetNames(typeof(SupportedLanguages)))
+            foreach (SupportedLanguages s in argsWithUnsupportedLangs)
             {
-                if (!unsupportedList.Contains(lang))
-                {
-                    foreach (object val in args)
-                    {
-                        listOfValues.Add(val);
-                    }
-                    listOfValues.Add(lang);
-                    langData.Add(listOfValues);
-                }
+                this.UnsuppportedLanguages.Add(s.ToString());
             }
-            this.testData.Add(this._propertyName, langData);
         }
     }
+
+    [Flags]
+    public enum SupportedLanguages
+    {
+        CSharp
+    };
 }

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             string testServer = Environment.GetEnvironmentVariable("TEST_SERVER");
             if (string.IsNullOrEmpty(testServer))
             {
-                testServer = "localhost";
+                testServer = "localhost\\SQL2019";
             }
 
             // First connect to master to create the database

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             string testServer = Environment.GetEnvironmentVariable("TEST_SERVER");
             if (string.IsNullOrEmpty(testServer))
             {
-                testServer = "localhost\\SQL2019";
+                testServer = "localhost";
             }
 
             // First connect to master to create the database

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -164,9 +164,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// - The functionName is different than its route.<br/>
         /// - You can start multiple functions by passing in a space-separated list of function names.<br/>
         /// </remarks>
-        protected void StartFunctionHost(string functionName, string language, bool useTestFolder = false)
+        protected void StartFunctionHost(string functionName, SupportedLanguages language, bool useTestFolder = false)
         {
-            string workingDirectory = useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", language);
+            string workingDirectory = useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", Enum.GetName(typeof(SupportedLanguages), language));
             if (!Directory.Exists(workingDirectory))
             {
                 throw new FileNotFoundException("Working directory not found at " + workingDirectory);

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -164,9 +164,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// - The functionName is different than its route.<br/>
         /// - You can start multiple functions by passing in a space-separated list of function names.<br/>
         /// </remarks>
-        protected void StartFunctionHost(string functionName, bool useTestFolder = false)
+        protected void StartFunctionHost(string functionName, string language, bool useTestFolder = false)
         {
-            string workingDirectory = useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples");
+            string workingDirectory = useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", language);
             if (!Directory.Exists(workingDirectory))
             {
                 throw new FileNotFoundException("Working directory not found at " + workingDirectory);

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -29,9 +29,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages(0, 100)]
-        [SupportedLanguages(1, -500)]
-        [SupportedLanguages(100, 500)]
+        [SqlInlineData(0, 100)]
+        [SqlInlineData(1, -500)]
+        [SqlInlineData(100, 500)]
         public async void GetProductsTest(int n, int cost, string lang)
         {
             this.StartFunctionHost(nameof(GetProducts), lang);
@@ -51,9 +51,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages(0, 99)]
-        [SupportedLanguages(1, -999)]
-        [SupportedLanguages(100, 999)]
+        [SqlInlineData(0, 99)]
+        [SqlInlineData(1, -999)]
+        [SqlInlineData(100, 999)]
         public async void GetProductsStoredProcedureTest(int n, int cost, string lang)
         {
             this.StartFunctionHost(nameof(GetProductsStoredProcedure), lang);
@@ -73,9 +73,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages(0, 0)]
-        [SupportedLanguages(1, 20)]
-        [SupportedLanguages(100, 1000)]
+        [SqlInlineData(0, 0)]
+        [SqlInlineData(1, 20)]
+        [SqlInlineData(100, 1000)]
         public async void GetProductsNameEmptyTest(int n, int cost, string lang)
         {
             this.StartFunctionHost(nameof(GetProductsNameEmpty), lang);
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public async void GetProductsByCostTest(string lang)
         {
             this.StartFunctionHost(nameof(GetProductsStoredProcedureFromAppSetting), lang);
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public async void GetProductNamesViewTest(string lang)
         {
             this.StartFunctionHost(nameof(GetProductNamesView), lang);

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData(0, 100)]
         [SqlInlineData(1, -500)]
         [SqlInlineData(100, 500)]
-        public async void GetProductsTest(int n, int cost, string lang)
+        public async void GetProductsTest(int n, int cost, SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(GetProducts), lang);
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData(0, 99)]
         [SqlInlineData(1, -999)]
         [SqlInlineData(100, 999)]
-        public async void GetProductsStoredProcedureTest(int n, int cost, string lang)
+        public async void GetProductsStoredProcedureTest(int n, int cost, SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(GetProductsStoredProcedure), lang);
 
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData(0, 0)]
         [SqlInlineData(1, 20)]
         [SqlInlineData(100, 1000)]
-        public async void GetProductsNameEmptyTest(int n, int cost, string lang)
+        public async void GetProductsNameEmptyTest(int n, int cost, SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(GetProductsNameEmpty), lang);
 
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public async void GetProductsByCostTest(string lang)
+        public async void GetProductsByCostTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(GetProductsStoredProcedureFromAppSetting), lang);
 
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public async void GetProductNamesViewTest(string lang)
+        public async void GetProductNamesViewTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(GetProductNamesView), lang);
 

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples;
 using Xunit;
 using Xunit.Abstractions;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
@@ -28,12 +29,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [InlineData(0, 100)]
-        [InlineData(1, -500)]
-        [InlineData(100, 500)]
-        public async void GetProductsTest(int n, int cost)
+        [SupportedLanguages(0, 100)]
+        [SupportedLanguages(1, -500)]
+        [SupportedLanguages(100, 500)]
+        public async void GetProductsTest(int n, int cost, string lang)
         {
-            this.StartFunctionHost(nameof(GetProducts));
+            this.StartFunctionHost(nameof(GetProducts), lang);
 
             // Generate T-SQL to insert n rows of data with cost
             Product[] products = GetProductsWithSameCost(n, cost);
@@ -50,12 +51,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [InlineData(0, 99)]
-        [InlineData(1, -999)]
-        [InlineData(100, 999)]
-        public async void GetProductsStoredProcedureTest(int n, int cost)
+        [SupportedLanguages(0, 99)]
+        [SupportedLanguages(1, -999)]
+        [SupportedLanguages(100, 999)]
+        public async void GetProductsStoredProcedureTest(int n, int cost, string lang)
         {
-            this.StartFunctionHost(nameof(GetProductsStoredProcedure));
+            this.StartFunctionHost(nameof(GetProductsStoredProcedure), lang);
 
             // Generate T-SQL to insert n rows of data with cost
             Product[] products = GetProductsWithSameCost(n, cost);
@@ -72,12 +73,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [InlineData(0, 0)]
-        [InlineData(1, 20)]
-        [InlineData(100, 1000)]
-        public async void GetProductsNameEmptyTest(int n, int cost)
+        [SupportedLanguages(0, 0)]
+        [SupportedLanguages(1, 20)]
+        [SupportedLanguages(100, 1000)]
+        public async void GetProductsNameEmptyTest(int n, int cost, string lang)
         {
-            this.StartFunctionHost(nameof(GetProductsNameEmpty));
+            this.StartFunctionHost(nameof(GetProductsNameEmpty), lang);
 
             // Add a bunch of noise data
             this.InsertProducts(GetProductsWithSameCost(n * 2, cost));
@@ -98,10 +99,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             Assert.Equal(expectedResponse, actualResponse, StringComparer.OrdinalIgnoreCase);
         }
 
-        [Fact]
-        public async void GetProductsByCostTest()
+        [Theory]
+        [SupportedLanguages()]
+        public async void GetProductsByCostTest(string lang)
         {
-            this.StartFunctionHost(nameof(GetProductsStoredProcedureFromAppSetting));
+            this.StartFunctionHost(nameof(GetProductsStoredProcedureFromAppSetting), lang);
 
             // Generate T-SQL to insert n rows of data with cost
             Product[] products = GetProducts(3, 100);
@@ -118,10 +120,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             Assert.Equal(expectedResponse, actualResponse, StringComparer.OrdinalIgnoreCase);
         }
 
-        [Fact]
-        public async void GetProductNamesViewTest()
+        [Theory]
+        [SupportedLanguages()]
+        public async void GetProductNamesViewTest(string lang)
         {
-            this.StartFunctionHost(nameof(GetProductNamesView));
+            this.StartFunctionHost(nameof(GetProductNamesView), lang);
 
             // Insert one row of data into Product table
             Product[] products = GetProductsWithSameCost(1, 100);

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -43,9 +43,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages(1, "Test", 5)]
-        [SupportedLanguages(0, "", 0)]
-        [SupportedLanguages(-500, "ABCD", 580)]
+        [SqlInlineData(1, "Test", 5)]
+        [SqlInlineData(0, "", 0)]
+        [SqlInlineData(-500, "ABCD", 580)]
         public void AddProductTest(int id, string name, int cost, string lang)
         {
             this.StartFunctionHost(nameof(AddProduct), lang);
@@ -65,9 +65,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages(1, "Test", 5)]
-        [SupportedLanguages(0, "", 0)]
-        [SupportedLanguages(-500, "ABCD", 580)]
+        [SqlInlineData(1, "Test", 5)]
+        [SqlInlineData(0, "", 0)]
+        [SqlInlineData(-500, "ABCD", 580)]
         public void AddProductParamsTest(int id, string name, int cost, string lang)
         {
             this.StartFunctionHost(nameof(AddProductParams), lang);
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductArrayTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductsArray), lang);
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductsCollectorTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductsCollector), lang);
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void QueueTriggerProductsTest(string lang)
         {
             this.StartFunctionHost(nameof(QueueTriggerProducts), lang);
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void TimerTriggerProductsTest(string lang)
         {
             this.StartFunctionHost(nameof(TimerTriggerProducts), lang);
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductExtraColumnsTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductExtraColumns), lang, true);
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductMissingColumnsTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductMissingColumns), lang, true);
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductMissingColumnsNotNullTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductMissingColumnsExceptionFunction), lang, true);
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductNoPartialUpsertTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductsNoPartialUpsert), lang, true);
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// Tests that for tables with an identity column we are able to insert items.
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductWithIdentity(string lang)
         {
             this.StartFunctionHost(nameof(AddProductWithIdentityColumn), lang);
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// Tests that for tables with an identity column we are able to insert multiple items at once
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductsWithIdentityColumnArray(string lang)
         {
             this.StartFunctionHost(nameof(AddProductsWithIdentityColumnArray), lang);
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// insert items.
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductWithIdentity_MultiplePrimaryColumns(string lang)
         {
             this.StartFunctionHost(nameof(AddProductWithMultiplePrimaryColumnsAndIdentity), lang);
@@ -270,7 +270,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// by the function we handle inserting/updating that correctly.
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductWithIdentity_SpecifyIdentityColumn(string lang)
         {
             this.StartFunctionHost(nameof(AddProductWithIdentityColumnIncluded), lang);
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// Tests that when using a table with an identity column we can handle a null (missing) identity column
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductWithIdentity_NoIdentityColumn(string lang)
         {
             this.StartFunctionHost(nameof(AddProductWithIdentityColumnIncluded), lang);
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// keys an error is thrown if at least one of the primary keys is missing.
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductWithIdentity_MissingPrimaryColumn(string lang)
         {
             this.StartFunctionHost(nameof(AddProductWithMultiplePrimaryColumnsAndIdentity), lang);
@@ -349,7 +349,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// the POCO fields case and column names case do not match.
         /// </summary>
         [Theory]
-        [SupportedLanguages()]
+        [SqlInlineData()]
         public void AddProductCaseSensitiveTest(string lang)
         {
             this.StartFunctionHost(nameof(AddProductParams), lang);

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData(1, "Test", 5)]
         [SqlInlineData(0, "", 0)]
         [SqlInlineData(-500, "ABCD", 580)]
-        public void AddProductTest(int id, string name, int cost, string lang)
+        public void AddProductTest(int id, string name, int cost, SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProduct), lang);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData(1, "Test", 5)]
         [SqlInlineData(0, "", 0)]
         [SqlInlineData(-500, "ABCD", 580)]
-        public void AddProductParamsTest(int id, string name, int cost, string lang)
+        public void AddProductParamsTest(int id, string name, int cost, SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductParams), lang);
 
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void AddProductArrayTest(string lang)
+        public void AddProductArrayTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductsArray), lang);
 
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void AddProductsCollectorTest(string lang)
+        public void AddProductsCollectorTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductsCollector), lang);
 
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void QueueTriggerProductsTest(string lang)
+        public void QueueTriggerProductsTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(QueueTriggerProducts), lang);
 
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void TimerTriggerProductsTest(string lang)
+        public void TimerTriggerProductsTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(TimerTriggerProducts), lang);
 
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void AddProductExtraColumnsTest(string lang)
+        public void AddProductExtraColumnsTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductExtraColumns), lang, true);
 
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void AddProductMissingColumnsTest(string lang)
+        public void AddProductMissingColumnsTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductMissingColumns), lang, true);
 
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void AddProductMissingColumnsNotNullTest(string lang)
+        public void AddProductMissingColumnsNotNullTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductMissingColumnsExceptionFunction), lang, true);
 
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [Theory]
         [SqlInlineData()]
-        public void AddProductNoPartialUpsertTest(string lang)
+        public void AddProductNoPartialUpsertTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductsNoPartialUpsert), lang, true);
 
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductWithIdentity(string lang)
+        public void AddProductWithIdentity(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithIdentityColumn), lang);
             // Identity column (ProductID) is left out for new items
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductsWithIdentityColumnArray(string lang)
+        public void AddProductsWithIdentityColumnArray(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductsWithIdentityColumnArray), lang);
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithIdentity"));
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductWithIdentity_MultiplePrimaryColumns(string lang)
+        public void AddProductWithIdentity_MultiplePrimaryColumns(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithMultiplePrimaryColumnsAndIdentity), lang);
             var query = new Dictionary<string, string>()
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductWithIdentity_SpecifyIdentityColumn(string lang)
+        public void AddProductWithIdentity_SpecifyIdentityColumn(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithIdentityColumnIncluded), lang);
             var query = new Dictionary<string, string>()
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductWithIdentity_NoIdentityColumn(string lang)
+        public void AddProductWithIdentity_NoIdentityColumn(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithIdentityColumnIncluded), lang);
             var query = new Dictionary<string, string>()
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductWithIdentity_MissingPrimaryColumn(string lang)
+        public void AddProductWithIdentity_MissingPrimaryColumn(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithMultiplePrimaryColumnsAndIdentity), lang);
             var query = new Dictionary<string, string>()
@@ -350,7 +350,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        public void AddProductCaseSensitiveTest(string lang)
+        public void AddProductCaseSensitiveTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductParams), lang);
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <_CopyItems Include="..\samples\samples-csharp\bin\$(Configuration)\$(TargetFramework)\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(OutDir)\SqlExtensionSamples\%(RecursiveDir)" />
+    <Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(OutDir)\SqlExtensionSamples\CSharp\%(RecursiveDir)" />
     <Message Text="Copied Samples output to $(OutDir)\SqlExtensionSamples" Importance="high" />
   </Target>
 


### PR DESCRIPTION
Added the following : SqlInlineDataAttributebase class overriding the xunit DataAttribute and has the GetData method implemented that adds the supported languages data to the tests.
UnsupportedLanguagesAttribute class that has the list of language(s) to be excluded from test runs.

For adding new languages following steps are required:
1. Add a Copy step to the CopySamples Target in the csprpj file to copy the language specific samples to the output bin under <b>SqlExtensionSamples\\\<languageName\></b> folder.
2. Add the language to the SupportedLanguages  enum.
