### PR TITLE
Add default CommandType

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="3.1.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.17.0" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.31" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="3.0.1" />

--- a/samples/samples-csharp/packages.lock.json
+++ b/samples/samples-csharp/packages.lock.json
@@ -14,9 +14,9 @@
       },
       "Microsoft.NET.Sdk.Functions": {
         "type": "Direct",
-        "requested": "[3.0.13, )",
-        "resolved": "3.0.13",
-        "contentHash": "8BEt6I6OLm7fo9bh8VGI7Mkc7xs/vI/KDira8MQcfZIA+K+lmDRb2PAL/+728eYfXI4SVrGs4MLhUZvKtpWfvQ==",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "sPPLAjDYroeuIDKwff5B1XrwvGzJm9K9GabXurmfpaXa3M4POy7ngLcG5mm+2pwjTA7e870pIjt1N2DqVQS4yA==",
         "dependencies": {
           "Microsoft.Azure.Functions.Analyzers": "[1.0.0, 2.0.0)",
           "Microsoft.Azure.WebJobs": "[3.0.23, 3.1.0)",

--- a/src/SqlAttribute.cs
+++ b/src/SqlAttribute.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.WebJobs
         /// Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string.
         /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter
         /// </summary>
-        public CommandType CommandType { get; set; }
+        public CommandType CommandType { get; set; } = CommandType.Text;
 
         /// <summary>
         /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandText"/>.

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -95,11 +95,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
                 CommandType = System.Data.CommandType.TableDirect
             };
             Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
+        }
 
+        [Fact]
+        public void TestDefaultCommandType()
+        {
+            string query = "select * from Products";
+            var attribute = new SqlAttribute(query);
+            SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, null);
+            // CommandType should default to Text
+            Assert.Equal(System.Data.CommandType.Text, command.CommandType);
+            Assert.Equal(query, command.CommandText);
 
-            // Don't specify a type at all
-            attribute = new SqlAttribute("");
-            Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
         }
 
         [Fact]

--- a/test/packages.lock.json
+++ b/test/packages.lock.json
@@ -4,9 +4,9 @@
     ".NETCoreApp,Version=v3.1": {
       "Microsoft.NET.Sdk.Functions": {
         "type": "Direct",
-        "requested": "[3.0.13, )",
-        "resolved": "3.0.13",
-        "contentHash": "8BEt6I6OLm7fo9bh8VGI7Mkc7xs/vI/KDira8MQcfZIA+K+lmDRb2PAL/+728eYfXI4SVrGs4MLhUZvKtpWfvQ==",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "sPPLAjDYroeuIDKwff5B1XrwvGzJm9K9GabXurmfpaXa3M4POy7ngLcG5mm+2pwjTA7e870pIjt1N2DqVQS4yA==",
         "dependencies": {
           "Microsoft.Azure.Functions.Analyzers": "[1.0.0, 2.0.0)",
           "Microsoft.Azure.WebJobs": "[3.0.23, 3.1.0)",
@@ -1938,9 +1938,9 @@
       "microsoft.azure.webjobs.extensions.sql.samples": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.Azure.WebJobs.Extensions.Sql": "1.0.0",
+          "Microsoft.Azure.WebJobs.Extensions.Sql": "99.99.99",
           "Microsoft.Azure.WebJobs.Extensions.Storage": "5.0.0",
-          "Microsoft.NET.Sdk.Functions": "3.0.13"
+          "Microsoft.NET.Sdk.Functions": "3.1.1"
         }
       },
       "Microsoft.ApplicationInsights": {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/263

Starting with the newer versions of the SDK it will create an attribute object and then pull the values of the various fields from that. Since this is an enum the default value is "0" - which CommandType doesn't define and so it errors out (null isn't valid). 

Having this property be nullable would have been slightly preferable since it isn't actually required, but attribute parameters can't be nullable (https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/attributes/#attribute-parameters). So just setting default to Text instead, which also has the small benefit of making input bindings not need to specify the CommandType if it's text. 