### PR TITLE
Fix lint error

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -67,14 +67,14 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.9' 
-    addToPath: true 
+    versionSpec: '3.9'
+    addToPath: true
     architecture: 'x64'
 
 - script: |
-    pip3 install pylint
+    pip3 install pylint_runner
     pip3 install pylintfileheader
-    pylint --recursive=y .
+    pylint_runner
   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
   displayName: Lint samples-python
 

--- a/samples/samples-python/.pylintrc
+++ b/samples/samples-python/.pylintrc
@@ -13,4 +13,4 @@ file-header=# Copyright \(c\) Microsoft Corporation\. All rights reserved\.[\r\n
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable= R0801, W0108, W0613, C0103, C0114, C0115, C0116, E0401
+disable= R0801, W0108, W0613, C0103, C0114, C0115, C0116, E0401, C0301

--- a/samples/samples-python/GetProductsStoredProcedure/__init__.py
+++ b/samples/samples-python/GetProductsStoredProcedure/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import azure.functions as func
 import json
+import azure.functions as func
 
 def main(req: func.HttpRequest, products: func.SqlRowList) -> func.HttpResponse:
     rows = list(map(lambda r: json.loads(r.to_json()), products))


### PR DESCRIPTION
Turns out that pylint by default doesn't scan all subdirectories - it requires you to specify each module folder (folder with an __init__.py in it) separately. 

https://github.com/PyCQA/pylint/issues/352

I have no idea why this suddenly started failing (or working depending on how you looked at it...) on Linux though. Possibly some updated version of the package or something for Linux only? Not going to dig into that at this moment though.

Luckily there's a helpful package pylint_runner that will do this for us though so switching to use that instead. Now when I run pylint_runner locally I was able to repro the error and fix it. 

(also disabled `C0301 - line too long` since that isn't something we really need to care about right now)