### PR TITLE
Add note about output requiring select perms

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ public static async Task<IActionResult> Run(
 
 The output binding takes a list of rows to be upserted into a user table. If the primary key value of the row already exists in the table, the row is interpreted as an update, meaning that the values of the other columns in the table for that primary key are updated. If the primary key value does not exist in the table, the row is interpreted as an insert. The upserting of the rows is batched by the output binding code.
 
+  > **NOTE:** By default the Output binding uses the T-SQL [MERGE](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql) statement which requires [SELECT](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql#permissions) permissions on the target database. 
+  
 The output binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs):
 
 - **CommandText**: Passed as a constructor argument to the binding. Represents the name of the table into which rows will be upserted.


### PR DESCRIPTION
Customer asked about this in https://github.com/Azure/azure-functions-sql-extension/issues/271 - we should make it clearly documented. It would be good to go through and get the full list of permissions required for each type of binding to run, but this is a good starting point. 