### PR TITLE
Fail Build on Component Governance

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -234,3 +234,8 @@ steps:
     docker rm sql1
   displayName: 'Stop and Remove SQL Server Image'
   condition: eq(variables['Agent.OS'], 'linux')
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+  inputs:
+    failOnAlert: true


### PR DESCRIPTION
CG was previously auto-injected, but does not fail build by default. Adding this in explicitly to fail build on CG issues.