### PR TITLE
Update 'BuildDictionaryFromSqlRow' utility method

### DIFF
--- a/src/SqlAsyncEnumerable.cs
+++ b/src/SqlAsyncEnumerable.cs
@@ -47,7 +47,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             private readonly SqlConnection _connection;
             private readonly SqlAttribute _attribute;
             private SqlDataReader _reader;
-            private readonly List<string> _cols;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="SqlAsyncEnumerator<typeparamref name="T"/>"/> class.
@@ -61,7 +60,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 this._connection = connection ?? throw new ArgumentNullException(nameof(connection));
                 this._attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
-                this._cols = new List<string>();
             }
 
             /// <summary>
@@ -128,7 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <returns>JSON string version of the SQL row</returns>
             private string SerializeRow()
             {
-                return JsonConvert.SerializeObject(SqlBindingUtilities.BuildDictionaryFromSqlRow(this._reader, this._cols));
+                return JsonConvert.SerializeObject(SqlBindingUtilities.BuildDictionaryFromSqlRow(this._reader));
             }
         }
     }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 
@@ -96,7 +97,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         command.Parameters.Add(new SqlParameter(items[0], items[1]));
                     }
-
                 }
             }
         }
@@ -134,30 +134,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <summary>
         /// Returns a dictionary where each key is a column name and each value is the SQL row's value for that column
         /// </summary>
-        /// <param name="reader">
-        /// Used to determine the columns of the table as well as the next SQL row to process
-        /// </param>
-        /// <param name="cols">
-        /// Filled with the columns of the table if empty, otherwise assumed to be populated
-        /// with their names already (used for cacheing so we don't retrieve the column names every time)
-        /// </param>
+        /// <param name="reader">Used to determine the columns of the table as well as the next SQL row to process</param>
         /// <returns>The built dictionary</returns>
-        public static Dictionary<string, string> BuildDictionaryFromSqlRow(SqlDataReader reader, List<string> cols)
+        public static IReadOnlyDictionary<string, string> BuildDictionaryFromSqlRow(SqlDataReader reader)
         {
-            if (cols.Count == 0)
-            {
-                for (int i = 0; i < reader.FieldCount; i++)
-                {
-                    cols.Add(reader.GetName(i));
-                }
-            }
-
-            var result = new Dictionary<string, string>();
-            foreach (string col in cols)
-            {
-                result.Add(col, reader[col].ToString());
-            }
-            return result;
+            return Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, i => reader.GetValue(i).ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
The change simplifies its caller in file `SqlTableChangeMonitor.cs` in `triggerbindings` branch. I have tested the change on my Azure SQL database to ensure that it does not impact performance. Here's the output of sample test run ([test code](https://github.com/JatinSanghvi/sql-extension-test/tree/build-row-dictionary)). It queries a SQL table of 16 columns of different types for 20 times The times were consistent across runs:

```
Using new build-dictionary method: False
Total rows read: 5900.
Elapsed time: 00:00:04.7862972

Using new build-dictionary method: True
Total rows read: 5900.
Elapsed time: 00:00:04.8179076
```