### PR TITLE
Replace non-breaking spaces with regular spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,21 +68,21 @@ This will require connecting to and running queries - you can use [Azure Data St
     Otherwise connect to your database and run the following query to create a simple table to start with.
 
 ```sql
-CREATE TABLE Employees (
-        EmployeeId int,
-        FirstName varchar(255),
-        LastName varchar(255),
-        Company varchar(255),
-        Team varchar(255)
+CREATE TABLE Employees (
+        EmployeeId int,
+        FirstName varchar(255),
+        LastName varchar(255),
+        Company varchar(255),
+        Team varchar(255)
 );
 ```
 
 2. Next a primary key must be set in your SQL table before using the bindings. To do this, run the queries below, replacing the placeholder values for your table and column.
 
 ```sql
-ALTER TABLE ['{table_name}'] ALTER COLUMN ['{primary_key_column_name}'] int NOT NULL
+ALTER TABLE ['{table_name}'] ALTER COLUMN ['{primary_key_column_name}'] int NOT NULL
 
-ALTER TABLE ['{table_name}'] ADD CONSTRAINT PKey PRIMARY KEY CLUSTERED (['{primary_key_column_name}']);
+ALTER TABLE ['{table_name}'] ADD CONSTRAINT PKey PRIMARY KEY CLUSTERED (['{primary_key_column_name}']);
 ```
 
 
@@ -184,7 +184,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
     }
     ```
 
-    *In the above, "select * from Employees" is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [Input Binding](#Input-Binding) section*
+    *In the above, "select * from Employees" is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [Input Binding](#Input-Binding) section*
 
 - Add 'using System.Collections.Generic;' to the namespaces list at the top of the page.
 - Currently, there is an error for the IEnumerable. We'll fix this by creating an Employee class.
@@ -192,14 +192,14 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Paste the below in the file. These are the column values of our SQL Database table.
 
     ```csharp
-    namespace Company.Function {
-        public class Employee{
-            public int EmployeeId { get; set; }
-            public string LastName { get; set; }
-            public string FirstName { get; set; }
-            public string Company { get; set; }
-            public string Team { get; set; }
-        }
+    namespace Company.Function {
+        public class Employee{
+            public int EmployeeId { get; set; }
+            public string LastName { get; set; }
+            public string FirstName { get; set; }
+            public string Company { get; set; }
+            public string Team { get; set; }
+        }
     }
     ```
 
@@ -401,8 +401,8 @@ public static async Task<IActionResult> Run(
 
 The output binding takes a list of rows to be upserted into a user table. If the primary key value of the row already exists in the table, the row is interpreted as an update, meaning that the values of the other columns in the table for that primary key are updated. If the primary key value does not exist in the table, the row is interpreted as an insert. The upserting of the rows is batched by the output binding code.
 
-  > **NOTE:** By default the Output binding uses the T-SQL [MERGE](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql) statement which requires [SELECT](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql#permissions) permissions on the target database. 
-  
+  > **NOTE:** By default the Output binding uses the T-SQL [MERGE](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql) statement which requires [SELECT](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql#permissions) permissions on the target database.
+
 The output binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs):
 
 - **CommandText**: Passed as a constructor argument to the binding. Represents the name of the table into which rows will be upserted.

--- a/docs/SqlBindingRelatedRepos.md
+++ b/docs/SqlBindingRelatedRepos.md
@@ -1,10 +1,10 @@
-# Azure SQL Bindings for Azure Functions 
+# Azure SQL Bindings for Azure Functions
 This document contains a list of all repositories related to SQL Bindings.
- 
-## Docs 
-[Azure SQL bindings for Functions | Microsoft Docs ](https://aka.ms/sqlbindings)
-  
-## SQL Bindings VSCode Extension 
+
+## Docs
+[Azure SQL bindings for Functions | Microsoft Docs ](https://aka.ms/sqlbindings)
+
+## SQL Bindings VSCode Extension
 This extension enables users to develop Azure Functions with SQL Bindings.
 
 [azuredatastudio/extensions/sql-bindings at main · microsoft/azuredatastudio (github.com)](https://github.com/microsoft/azuredatastudio/tree/main/extensions/sql-bindings)
@@ -12,30 +12,30 @@ This extension enables users to develop Azure Functions with SQL Bindings.
 STS contains the logic for adding a SQL binding to an existing Azure Function.
 
 [sqltoolsservice/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions at main · microsoft/sqltoolsservice (github.com)](https://github.com/microsoft/sqltoolsservice/tree/main/src/Microsoft.SqlTools.ServiceLayer/AzureFunctions)
- 
-## Templates 
+
+## Templates
 Contains templates for the various types of bindings and supported languages, each under a Sql* folder.
 
 [azure-functions-templates/Functions.Templates/Templates at dev · Azure/azure-functions-templates (github.com)](https://github.com/Azure/azure-functions-templates/tree/dev/Functions.Templates/Templates)
- 
-### Instructions for adding new templates: 
+
+### Instructions for adding new templates:
 [Azure/azure-functions-templates: Azure functions templates for the azure portal, CLI, and VS (github.com)](https://github.com/Azure/azure-functions-templates#creating-a-dotnet-templates-cs-and-fs)
- 
-## Extension Bundle 
-Currently SQL Bindings is part of the 3.x and 4.x Preview bundles. 
+
+## Extension Bundle
+Currently SQL Bindings is part of the 3.x and 4.x Preview bundles.
 
 [Azure/azure-functions-extension-bundles at v3.x-preview (github.com)](https://github.com/Azure/azure-functions-extension-bundles/tree/v3.x-preview)
 
 [Azure/azure-functions-extension-bundles at v4.x-preview (github.com)](https://github.com/Azure/azure-functions-extension-bundles/tree/v4.x-preview)
- 
-## Python SQL Bindings 
-### Python Library 
-We define SqlRow and SqlRowList in _sql.py and the SqlConverter in sql.py. 
+
+## Python SQL Bindings
+### Python Library
+We define SqlRow and SqlRowList in _sql.py and the SqlConverter in sql.py.
 
 [Azure/azure-functions-python-library: Azure Functions Python SDK (github.com)](https://github.com/Azure/azure-functions-python-library)
- 
-### Python Worker  
+
+### Python Worker
 End to end tests for SQL Bindings in the Python Worker.
 
 [Azure/azure-functions-python-worker: Python worker for Azure Functions. (github.com)](https://github.com/Azure/azure-functions-python-worker)
- 
+


### PR DESCRIPTION
The pull request replaces [non-breaking spaces](https://en.wikipedia.org/wiki/Non-breaking_space) with regular [spaces](https://en.wikipedia.org/wiki/Space_(punctuation)). The presence of non-breaking spaces is causing confusion when someone searches for text like `CREATE TABLE Employees` (with regular spaces) in Visual Studio Code and gets no results back.