### PR TITLE
Add trigger binding support - Part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,8 @@ The trigger binding utilizes SQL [change tracking](https://docs.microsoft.com/sq
 
     For more information, please refer to the documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-table). The trigger needs to have read access on the table being monitored for changes as well as to the change tracking system tables. It also needs write access to an `az_func` schema within the database, where it will create additional worker tables to store the trigger states and leases. Each function trigger will thus have an associated change tracking table and worker table.
 
+    > **NOTE:** The worker table contains all columns corresponding to the primary key from the user table and three additional columns, particularly with names: `ChangeVersion`, `AttemptCount` and `LeaseExpirationTime`. If any of the primary key columns happen to have the same name, that will result in an error message describing the name-conflict. In such case, renaming the primary key column in the user table should resolve the error.
+
 #### Trigger Samples
 The trigger binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)
 

--- a/src/TriggerBinding/SqlTriggerBindingProvider.cs
+++ b/src/TriggerBinding/SqlTriggerBindingProvider.cs
@@ -57,6 +57,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             ParameterInfo parameter = context.Parameter;
             SqlTriggerAttribute attribute = parameter.GetCustomAttribute<SqlTriggerAttribute>(inherit: false);
 
+            // During application startup, the WebJobs SDK calls 'TryCreateAsync' method of all registered trigger
+            // binding providers in sequence for each parameter in the user function. A provider that finds the
+            // parameter-attribute that it can handle returns the binding object. Rest of the providers are supposed to
+            // return null. This binding object later gets used for binding before every function invocation.
             if (attribute == null)
             {
                 return Task.FromResult(default(ITriggerBinding));

--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -6,9 +6,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
     internal static class SqlTriggerConstants
     {
         public const string SchemaName = "az_func";
-
         public const string GlobalStateTableName = "[" + SchemaName + "].[GlobalState]";
-
         public const string WorkerTableNameFormat = "[" + SchemaName + "].[Worker_{0}]";
     }
 }

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -190,8 +190,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             using (var getPrimaryKeyColumnsCommand = new SqlCommand(getPrimaryKeyColumnsQuery, connection))
             using (SqlDataReader reader = await getPrimaryKeyColumnsCommand.ExecuteReaderAsync(cancellationToken))
             {
-                string[] variableLengthTypes = new string[] { "varchar", "nvarchar", "nchar", "char", "binary", "varbinary" };
-                string[] variablePrecisionTypes = new string[] { "numeric", "decimal" };
+                string[] variableLengthTypes = new[] { "varchar", "nvarchar", "nchar", "char", "binary", "varbinary" };
+                string[] variablePrecisionTypes = new[] { "numeric", "decimal" };
 
                 var primaryKeyColumns = new List<(string name, string type)>();
 
@@ -222,10 +222,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     throw new InvalidOperationException($"Could not find primary key created in table: '{this._userTable.FullName}'.");
                 }
 
-                string[] reservedColumnNames = new string[] { "ChangeVersion", "AttemptCount", "LeaseExpirationTime" };
-                string[] conflictingColumnNames = primaryKeyColumns.Select(col => col.name).Intersect(reservedColumnNames).ToArray();
+                string[] reservedColumnNames = new[] { "ChangeVersion", "AttemptCount", "LeaseExpirationTime" };
+                var conflictingColumnNames = primaryKeyColumns.Select(col => col.name).Intersect(reservedColumnNames).ToList();
 
-                if (conflictingColumnNames.Length > 0)
+                if (conflictingColumnNames.Count > 0)
                 {
                     throw new InvalidOperationException($"Found reserved column name(s): '{string.Join(", ", conflictingColumnNames)}' in table: '{this._userTable.FullName}'." +
                         " Please rename them to be able to use trigger binding.");
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             string createSchemaQuery = $@"
                 IF SCHEMA_ID(N'{SqlTriggerConstants.SchemaName}') IS NULL
-                    EXEC ('CREATE SCHEMA [{SqlTriggerConstants.SchemaName}]');
+                    EXEC ('CREATE SCHEMA {SqlTriggerConstants.SchemaName}');
             ";
 
             using (var createSchemaCommand = new SqlCommand(createSchemaQuery, connection, transaction))
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             IReadOnlyList<(string name, string type)> primaryKeyColumns,
             CancellationToken cancellationToken)
         {
-            string primaryKeysWithTypes = string.Join(",\n", primaryKeyColumns.Select(col => $"{col.name.AsBracketQuotedString()} [{col.type}]"));
+            string primaryKeysWithTypes = string.Join(", ", primaryKeyColumns.Select(col => $"{col.name.AsBracketQuotedString()} {col.type}"));
             string primaryKeys = string.Join(", ", primaryKeyColumns.Select(col => col.name.AsBracketQuotedString()));
 
             string createWorkerTableQuery = $@"


### PR DESCRIPTION
As it was discussed a while back, starting with fresh pull request targeting `triggerbindings` branch. This will also keep the discussion focused on new set of changes. The intention is to only update `triggerbindings` branch through commits from pull requests or through merges from `main` branch.

**PR changelog**
1. Improve error handling when user table has primary column with conflicting names _(addressed review comment from #226)_.
2. Add comment for why trigger-binding provider should return null binding in particular case _(addressed review comment from #226)_.
3. Simplify SQL variable names (no need to use hash of column names).
4. Make renew-leases operation a single SQL statement _(addressed review comment from #226)_.
5. Have higher locking granularity instead of from `TABLOCKX`.