### PR TITLE
Use enums as keys for telemetry events

### DIFF
--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    var props = new Dictionary<string, string>()
+                    var props = new Dictionary<TelemetryPropertyName, string>()
                     {
-                        { TelemetryPropertyName.Type.ToString(), ConvertType.SqlCommand.ToString() }
+                        { TelemetryPropertyName.Type, ConvertType.SqlCommand.ToString() }
                     };
                     TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
@@ -105,9 +105,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    var props = new Dictionary<string, string>()
+                    var props = new Dictionary<TelemetryPropertyName, string>()
                     {
-                        { TelemetryPropertyName.Type.ToString(), ConvertType.IEnumerable.ToString() }
+                        { TelemetryPropertyName.Type, ConvertType.IEnumerable.ToString() }
                     };
                     TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
@@ -135,9 +135,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    var props = new Dictionary<string, string>()
+                    var props = new Dictionary<TelemetryPropertyName, string>()
                     {
-                        { TelemetryPropertyName.Type.ToString(), ConvertType.Json.ToString() }
+                        { TelemetryPropertyName.Type, ConvertType.Json.ToString() }
                     };
                     TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
@@ -179,9 +179,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    var props = new Dictionary<string, string>()
+                    var props = new Dictionary<TelemetryPropertyName, string>()
                     {
-                        { TelemetryPropertyName.Type.ToString(), ConvertType.IAsyncEnumerable.ToString() }
+                        { TelemetryPropertyName.Type, ConvertType.IAsyncEnumerable.ToString() }
                     };
                     TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;
@@ -206,9 +206,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 catch (Exception ex)
                 {
-                    var props = new Dictionary<string, string>()
+                    var props = new Dictionary<TelemetryPropertyName, string>()
                     {
-                        { TelemetryPropertyName.Type.ToString(), ConvertType.JArray.ToString() }
+                        { TelemetryPropertyName.Type, ConvertType.JArray.ToString() }
                     };
                     TelemetryInstance.TrackException(TelemetryErrorName.Convert, ex, props);
                     throw;

--- a/src/Telemetry/TelemetryUtils.cs
+++ b/src/Telemetry/TelemetryUtils.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         /// </summary>
         /// <param name="props">The property bag to add our connection properties to</param>
         /// <param name="conn">The connection to add properties of</param>
-        public static void AddConnectionProps(this IDictionary<string, string> props, SqlConnection conn)
+        public static void AddConnectionProps(this IDictionary<TelemetryPropertyName, string> props, SqlConnection conn)
         {
-            props.Add(TelemetryPropertyName.ServerVersion.ToString(), conn.ServerVersion);
+            props.Add(TelemetryPropertyName.ServerVersion, conn.ServerVersion);
         }
 
         /// <summary>
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         /// </summary>
         /// <param name="conn">The connection to get properties of</param>
         /// <returns>The property dictionary</returns>
-        public static Dictionary<string, string> AsConnectionProps(this SqlConnection conn)
+        public static Dictionary<TelemetryPropertyName, string> AsConnectionProps(this SqlConnection conn)
         {
-            var props = new Dictionary<string, string>();
+            var props = new Dictionary<TelemetryPropertyName, string>();
             props.AddConnectionProps(conn);
             return props;
         }


### PR DESCRIPTION
Proposal to use enum values instead of strings as keys in `properties` and `measurements` dictionaries when logging new telemetry events. This ensures at build time that arbitrary strings cannot be passed to `Track*` methods.