### PR TITLE
Renew all leases through single statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ The trigger binding utilizes SQL [change tracking](https://docs.microsoft.com/sq
 
     For more information, please refer to the documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-table). The trigger needs to have read access on the table being monitored for changes as well as to the change tracking system tables. It also needs write access to an `az_func` schema within the database, where it will create additional worker tables to store the trigger states and leases. Each function trigger will thus have an associated change tracking table and worker table.
 
-    > **NOTE:** The worker table contains all columns corresponding to the primary key from the user table and three additional columns, particularly with names: `ChangeVersion`, `AttemptCount` and `LeaseExpirationTime`. If any of the primary key columns happen to have the same name, that will result in an error message describing the name-conflict. In such case, renaming the primary key column in the user table should resolve the error.
+    > **NOTE:** The worker table contains all columns corresponding to the primary key from the user table and three additional columns named `ChangeVersion`, `AttemptCount` and `LeastExpirationTime`. If any of the primary key columns happen to have the same name, that will result in an error message listing any conflicts. In this case, the listed primary key columns must be renamed for the trigger to work.
 
 #### Trigger Samples
 The trigger binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)

--- a/README.md
+++ b/README.md
@@ -607,6 +607,8 @@ The trigger binding utilizes SQL [change tracking](https://docs.microsoft.com/sq
 
     For more information, please refer to the documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-table). The trigger needs to have read access on the table being monitored for changes as well as to the change tracking system tables. It also needs write access to an `az_func` schema within the database, where it will create additional worker tables to store the trigger states and leases. Each function trigger will thus have an associated change tracking table and worker table.
 
+    > **NOTE:** The worker table contains all columns corresponding to the primary key from the user table and three additional columns, particularly with names: `ChangeVersion`, `AttemptCount` and `LeaseExpirationTime`. If any of the primary key columns happen to have the same name, that will result in an error message describing the name-conflict. In such case, renaming the primary key column in the user table should resolve the error.
+
 #### Trigger Samples
 The trigger binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)
 

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,7 +43,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly string _workerTableName;
         private readonly IReadOnlyList<string> _userTableColumns;
         private readonly IReadOnlyList<string> _primaryKeyColumns;
-        private readonly IReadOnlyList<(string col, string hash)> _primaryKeyColumnHashes;
         private readonly IReadOnlyList<string> _rowMatchConditions;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly ILogger _logger;
@@ -103,11 +101,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this._workerTableName = workerTableName;
             this._userTableColumns = userTableColumns;
             this._primaryKeyColumns = primaryKeyColumns;
-            this._primaryKeyColumnHashes = primaryKeyColumns.Select(col => (col, GetColumnHash(col))).ToList();
 
             // Prep search-conditions that will be used besides WHERE clause to match table rows.
             this._rowMatchConditions = Enumerable.Range(0, BatchSize)
-                .Select(index => string.Join(" AND ", this._primaryKeyColumnHashes.Select(ch => $"{ch.col.AsBracketQuotedString()} = @{ch.hash}_{index}")))
+                .Select(rowIndex => string.Join(" AND ", this._primaryKeyColumns.Select((col, colIndex) => $"{col.AsBracketQuotedString()} = @{rowIndex}_{colIndex}")))
                 .ToList();
 
             this._executor = executor;
@@ -163,8 +160,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         if (this._state == State.CheckingForChanges)
                         {
-                            await this.GetChangesAsync(token);
-                            await this.ProcessChangesAsync(token);
+                            await this.GetTableChangesAsync(token);
+                            await this.ProcessTableChangesAsync(token);
                         }
 
                         await Task.Delay(TimeSpan.FromSeconds(PollingIntervalInSeconds), token);
@@ -195,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// Queries the change/worker tables to check for new changes on the user's table. If any are found, stores the
         /// change along with the corresponding data from the user table in "_rows".
         /// </summary>
-        private async Task GetChangesAsync(CancellationToken token)
+        private async Task GetTableChangesAsync(CancellationToken token)
         {
             TelemetryInstance.TrackEvent(TelemetryEventName.GetChangesStart, this._telemetryProps);
 
@@ -292,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             }
         }
 
-        private async Task ProcessChangesAsync(CancellationToken token)
+        private async Task ProcessTableChangesAsync(CancellationToken token)
         {
             if (this._rows.Count > 0)
             {
@@ -613,20 +610,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Creates GUID string from column name that can be used as name of SQL local variable. The column names
-        /// cannot be used directly as variable names as they may contain characters like ',', '.', '+', spaces, etc.
-        /// that are not allowed in variable names.
-        /// </summary>
-        private static string GetColumnHash(string columnName)
-        {
-            using (var sha256 = SHA256.Create())
-            {
-                byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(columnName));
-                return new Guid(hash.Take(16).ToArray()).ToString("N");
-            }
-        }
-
-        /// <summary>
         /// Builds the command to update the global state table in the case of a new minimum valid version number.
         /// Sets the LastSyncVersion for this _userTable to be the new minimum valid version number.
         /// </summary>
@@ -699,13 +682,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             var acquireLeasesQuery = new StringBuilder();
 
-            for (int index = 0; index < this._rows.Count; index++)
+            for (int rowIndex = 0; rowIndex < this._rows.Count; rowIndex++)
             {
-                string valuesList = string.Join(", ", this._primaryKeyColumnHashes.Select(ch => $"@{ch.hash}_{index}"));
-                string changeVersion = this._rows[index]["SYS_CHANGE_VERSION"];
+                string valuesList = string.Join(", ", this._primaryKeyColumns.Select((_, colIndex) => $"@{rowIndex}_{colIndex}"));
+                string changeVersion = this._rows[rowIndex]["SYS_CHANGE_VERSION"];
 
                 acquireLeasesQuery.Append($@"
-                    IF NOT EXISTS (SELECT * FROM {this._workerTableName} WITH (TABLOCKX) WHERE {this._rowMatchConditions[index]})
+                    IF NOT EXISTS (SELECT * FROM {this._workerTableName} WITH (TABLOCKX) WHERE {this._rowMatchConditions[rowIndex]})
                         INSERT INTO {this._workerTableName} WITH (TABLOCKX)
                         VALUES ({valuesList}, {changeVersion}, 1, DATEADD(second, {LeaseIntervalInSeconds}, SYSDATETIME()));
                     ELSE
@@ -714,7 +697,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                             ChangeVersion = {changeVersion},
                             AttemptCount = AttemptCount + 1,
                             LeaseExpirationTime = DATEADD(second, {LeaseIntervalInSeconds}, SYSDATETIME())
-                        WHERE {this._rowMatchConditions[index]};
+                        WHERE {this._rowMatchConditions[rowIndex]};
                 ");
             }
 
@@ -728,18 +711,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <returns>The SqlCommand populated with the query and appropriate parameters</returns>
         private SqlCommand BuildRenewLeasesCommand(SqlConnection connection)
         {
-            var renewLeasesQuery = new StringBuilder();
+            string matchCondition = string.Join(" OR ", this._rowMatchConditions.Take(this._rows.Count));
 
-            for (int index = 0; index < this._rows.Count; index++)
-            {
-                renewLeasesQuery.Append($@"
-                    UPDATE {this._workerTableName} WITH (TABLOCKX)
-                    SET LeaseExpirationTime = DATEADD(second, {LeaseIntervalInSeconds}, SYSDATETIME())
-                    WHERE {this._rowMatchConditions[index]};
-                ");
-            }
+            string renewLeasesQuery = $@"
+                UPDATE {this._workerTableName} WITH (TABLOCKX)
+                SET LeaseExpirationTime = DATEADD(second, {LeaseIntervalInSeconds}, SYSDATETIME())
+                WHERE {matchCondition};
+            ";
 
-            return this.GetSqlCommandWithParameters(renewLeasesQuery.ToString(), connection, null);
+            return this.GetSqlCommandWithParameters(renewLeasesQuery, connection, null);
         }
 
         /// <summary>
@@ -753,19 +733,19 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             var releaseLeasesQuery = new StringBuilder("DECLARE @current_change_version bigint;\n");
 
-            for (int index = 0; index < this._rows.Count; index++)
+            for (int rowIndex = 0; rowIndex < this._rows.Count; rowIndex++)
             {
-                string changeVersion = this._rows[index]["SYS_CHANGE_VERSION"];
+                string changeVersion = this._rows[rowIndex]["SYS_CHANGE_VERSION"];
 
                 releaseLeasesQuery.Append($@"
                     SELECT @current_change_version = ChangeVersion
                     FROM {this._workerTableName} WITH (TABLOCKX)
-                    WHERE {this._rowMatchConditions[index]};
+                    WHERE {this._rowMatchConditions[rowIndex]};
 
                     IF @current_change_version <= {changeVersion}
                         UPDATE {this._workerTableName} WITH (TABLOCKX) 
                         SET ChangeVersion = {changeVersion}, AttemptCount = 0, LeaseExpirationTime = NULL
-                        WHERE {this._rowMatchConditions[index]};
+                        WHERE {this._rowMatchConditions[rowIndex]};
                 ");
             }
 
@@ -834,14 +814,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             var command = new SqlCommand(commandText, connection, transaction);
 
-            for (int index = 0; index < this._rows.Count; index++)
-            {
-                foreach ((string col, string hash) in this._primaryKeyColumnHashes)
-                {
-                    command.Parameters.Add(new SqlParameter($"@{hash}_{index}", this._rows[index][col]));
-                }
-            }
+            SqlParameter[] parameters = Enumerable.Range(0, this._rows.Count)
+                .SelectMany(rowIndex => this._primaryKeyColumns.Select((col, colIndex) => new SqlParameter($"@{rowIndex}_{colIndex}", this._rows[rowIndex][col])))
+                .ToArray();
 
+            command.Parameters.AddRange(parameters);
             return command;
         }
 

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -743,7 +743,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     WHERE {this._rowMatchConditions[rowIndex]};
 
                     IF @current_change_version <= {changeVersion}
-                        UPDATE {this._workerTableName} WITH (TABLOCKX) 
+                        UPDATE {this._workerTableName} WITH (TABLOCKX)
                         SET ChangeVersion = {changeVersion}, AttemptCount = 0, LeaseExpirationTime = NULL
                         WHERE {this._rowMatchConditions[rowIndex]};
                 ");

--- a/src/TriggerBinding/SqlTriggerBindingProvider.cs
+++ b/src/TriggerBinding/SqlTriggerBindingProvider.cs
@@ -57,6 +57,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             ParameterInfo parameter = context.Parameter;
             SqlTriggerAttribute attribute = parameter.GetCustomAttribute<SqlTriggerAttribute>(inherit: false);
 
+            // During application startup, the WebJobs SDK calls 'TryCreateAsync' method of all registered trigger
+            // binding providers in sequence for each parameter in the user function. A provider that finds the
+            // parameter-attribute that it can handle returns the binding object. Rest of the providers are supposed to
+            // return null. This binding object later gets used for binding before every function invocation.
             if (attribute == null)
             {
                 return Task.FromResult(default(ITriggerBinding));

--- a/src/TriggerBinding/SqlTriggerBindingProvider.cs
+++ b/src/TriggerBinding/SqlTriggerBindingProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             // return null. This binding object later gets used for binding before every function invocation.
             if (attribute == null)
             {
-                return Task.FromResult(default(ITriggerBinding));
+                return Task.FromResult<ITriggerBinding>(null);
             }
 
             if (!IsValidTriggerParameterType(parameter.ParameterType))

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             string createSchemaQuery = $@"
                 IF SCHEMA_ID(N'{SqlTriggerConstants.SchemaName}') IS NULL
-                    EXEC ('CREATE SCHEMA [{SqlTriggerConstants.SchemaName}]');
+                    EXEC ('CREATE SCHEMA {SqlTriggerConstants.SchemaName}');
             ";
 
             using (var createSchemaCommand = new SqlCommand(createSchemaQuery, connection, transaction))
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             IReadOnlyList<(string name, string type)> primaryKeyColumns,
             CancellationToken cancellationToken)
         {
-            string primaryKeysWithTypes = string.Join(",\n", primaryKeyColumns.Select(col => $"{col.name.AsBracketQuotedString()} [{col.type}]"));
+            string primaryKeysWithTypes = string.Join(", ", primaryKeyColumns.Select(col => $"{col.name.AsBracketQuotedString()} {col.type}"));
             string primaryKeys = string.Join(", ", primaryKeyColumns.Select(col => col.name.AsBracketQuotedString()));
 
             string createWorkerTableQuery = $@"


### PR DESCRIPTION
1. Make renew-leases operation a single SQL statement (_addresses https://github.com/Azure/azure-functions-sql-extension/pull/226#discussion_r930429371_).
2. Simplify SQL variable names (no need to use hashes of column names).
3. Add comment for why trigger-binding provider should return null binding in particular case. (_addresses https://github.com/Azure/azure-functions-sql-extension/pull/226#discussion_r933613139_)