### PR TITLE
Enable PR validation for 	`triggerbindings` branch

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -4,6 +4,7 @@ pr:
   branches:
     include:
     - main
+    - triggerbindings
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
Required to discover any issues in `triggerbindings` branch early on rather than waiting until the branch is merged into `main`.