### PR TITLE
Fix DateTime support AsyncEnumerable and AsyncCollector

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -344,6 +344,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
         public class TableInformation
         {
+            private const string DATETIME_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fff";
+
             public IEnumerable<MemberInfo> PrimaryKeys { get; }
 
             /// <summary>
@@ -388,7 +390,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 this.JsonSerializerSettings = new JsonSerializerSettings
                 {
-                    ContractResolver = new DynamicPOCOContractResolver(columns, comparer)
+                    ContractResolver = new DynamicPOCOContractResolver(columns, comparer),
+                    DateFormatString = DATETIME_FORMAT
                 };
             }
             public static bool GetCaseSensitivityFromCollation(string collation)

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -136,9 +136,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         /// <param name="reader">Used to determine the columns of the table as well as the next SQL row to process</param>
         /// <returns>The built dictionary</returns>
-        public static IReadOnlyDictionary<string, string> BuildDictionaryFromSqlRow(SqlDataReader reader)
+        public static IReadOnlyDictionary<string, object> BuildDictionaryFromSqlRow(SqlDataReader reader)
         {
-            return Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, i => reader.GetValue(i).ToString());
+            return Enumerable.Range(0, reader.FieldCount).ToDictionary(reader.GetName, i => reader.GetValue(i));
         }
 
         /// <summary>


### PR DESCRIPTION
# AsyncEnumerable
Forcing .ToString() on data read from SqlDataReader causes localization issue with some conversion such as datetime column.
Since SqlDataReader already converts sql columns to the CLR types, it is better to leave the task to the Json deserializator. 

# AsyncCollector
Json default serialization of DateTime properties could be not handled by dbms, so forcing to the standard ISO (without timezone) could be better.