### PR TITLE
Add common test project changes from `triggerbindings` branch

### DIFF
--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -33,4 +33,12 @@
     <Message Text="Copied JS Samples output to $(OutDir)\SqlExtensionSamples\JavaScript" Importance="high" />
   </Target>
 
+  <Target Name="CopyTestSqlFiles" AfterTargets="Build">
+    <ItemGroup>
+      <_CSharpTestSqlFiles Include="Integration\test-csharp\Database\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_CSharpTestSqlFiles)" DestinationFolder="$(OutDir)\Database\%(RecursiveDir)" />
+    <Message Text="Copied C# test SQL files to $(OutDir)\Database" Importance="high" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
It reduces the chance of file content digressing between `main` and `triggerbindings` branch and also ensures that the improvements made in the `triggerbindings` branch are made part of the `main` branch.