### PR TITLE
connection info telemetry data from input bindings

### DIFF
--- a/src/SqlAsyncEnumerable.cs
+++ b/src/SqlAsyncEnumerable.cs
@@ -7,6 +7,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Newtonsoft.Json;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -28,6 +30,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             this._connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this._attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
+            Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps();
+            TelemetryInstance.TrackConvert(ConvertType.IAsyncEnumerable, props);
+
         }
         /// <summary>
         /// Returns the enumerator associated with this enumerable. The enumerator will execute the query specified

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -158,12 +158,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 using (var adapter = new SqlDataAdapter())
                 using (SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, connection))
                 {
+                    Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps();
+                    TelemetryInstance.TrackConvert(type, props);
                     adapter.SelectCommand = command;
                     await connection.OpenAsync();
-                    Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps();
                     var dataTable = new DataTable();
                     adapter.Fill(dataTable);
-                    TelemetryInstance.TrackConvert(type, props);
                     this._logger.LogInformation($"{dataTable.Rows.Count} row(s) queried from database: {connection.Database} using Command: {command.CommandText}");
                     return JsonConvert.SerializeObject(dataTable);
                 }

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -149,6 +149,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <param name="attribute">
             /// The binding attribute that contains the name of the connection string app setting and query.
             /// </param>
+            /// <param name="type">
+            /// The type of conversion being performed by the input binding.
+            /// </param>
             /// <returns></returns>
             public virtual async Task<string> BuildItemFromAttributeAsync(SqlAttribute attribute, ConvertType? type = null)
             {

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// The binding attribute that contains the name of the connection string app setting and query.
             /// </param>
             /// <returns></returns>
-            public virtual async Task<string> BuildItemFromAttributeAsync(SqlAttribute attribute, ConvertType type)
+            public virtual async Task<string> BuildItemFromAttributeAsync(SqlAttribute attribute, ConvertType? type = null)
             {
                 using (SqlConnection connection = SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, this._configuration))
                 // Ideally, we would like to move away from using SqlDataAdapter both here and in the
@@ -158,8 +158,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 using (var adapter = new SqlDataAdapter())
                 using (SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, connection))
                 {
-                    Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps();
-                    TelemetryInstance.TrackConvert(type, props);
+                    if (type.HasValue)
+                    {
+                        Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps();
+                        TelemetryInstance.TrackConvert(type.Value, props);
+                    }
                     adapter.SelectCommand = command;
                     await connection.OpenAsync();
                     var dataTable = new DataTable();

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -162,8 +162,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     adapter.SelectCommand = command;
                     await connection.OpenAsync();
+                    Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps();
                     var dataTable = new DataTable();
                     adapter.Fill(dataTable);
+                    TelemetryInstance.TrackEvent(TelemetryEventName.BuildItemFromAttributeAsync, props);
                     this._logger.LogInformation($"{dataTable.Rows.Count} row(s) queried from database: {connection.Database} using Command: {command.CommandText}");
                     return JsonConvert.SerializeObject(dataTable);
                 }

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -321,6 +321,7 @@ This extension collect usage data in order to help us improve your experience. T
     public enum TelemetryEventName
     {
         AddAsync,
+        BuildItemFromAttributeAsync,
         Create,
         Convert,
         Error,

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -321,7 +321,6 @@ This extension collect usage data in order to help us improve your experience. T
     public enum TelemetryEventName
     {
         AddAsync,
-        BuildItemFromAttributeAsync,
         Create,
         Convert,
         Error,

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             var converter = new Mock<SqlGenericsConverter<TestData>>(config.Object, logger.Object);
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Cost\":32.5,\"Timestamp\":\"2019-11-22T06:32:15\"},{ \"ID\":2,\"Name\":\"Brush\",\"Cost\":12.3," +
                 "\"Timestamp\":\"2017-01-27T03:13:11\"},{ \"ID\":3,\"Name\":\"Comb\",\"Cost\":100.12,\"Timestamp\":\"1997-05-03T10:11:56\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.SqlCommand)).ReturnsAsync(json);
             var list = new List<TestData>();
             var data1 = new TestData
             {
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
             // SQL data is missing a field
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Timestamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.Json)).ReturnsAsync(json);
             var list = new List<TestData>();
             var data = new TestData
             {
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
             // SQL data's columns are named differently than the POCO's fields
             json = "[{ \"ID\":1,\"Product Name\":\"Broom\",\"Price\":32.5,\"Timessstamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.IEnumerable)).ReturnsAsync(json);
             list = new List<TestData>();
             data = new TestData
             {
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
             // Confirm that the JSON fields are case-insensitive (technically malformed string, but still works)
             json = "[{ \"id\":1,\"nAme\":\"Broom\",\"coSt\":32.5,\"TimEStamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.IAsyncEnumerable)).ReturnsAsync(json);
             list = new List<TestData>();
             data = new TestData
             {

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             var converter = new Mock<SqlGenericsConverter<TestData>>(config.Object, logger.Object);
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Cost\":32.5,\"Timestamp\":\"2019-11-22T06:32:15\"},{ \"ID\":2,\"Name\":\"Brush\",\"Cost\":12.3," +
                 "\"Timestamp\":\"2017-01-27T03:13:11\"},{ \"ID\":3,\"Name\":\"Comb\",\"Cost\":100.12,\"Timestamp\":\"1997-05-03T10:11:56\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.SqlCommand)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, null)).ReturnsAsync(json);
             var list = new List<TestData>();
             var data1 = new TestData
             {
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
             // SQL data is missing a field
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Timestamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.Json)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, null)).ReturnsAsync(json);
             var list = new List<TestData>();
             var data = new TestData
             {
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
             // SQL data's columns are named differently than the POCO's fields
             json = "[{ \"ID\":1,\"Product Name\":\"Broom\",\"Price\":32.5,\"Timessstamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.IEnumerable)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, null)).ReturnsAsync(json);
             list = new List<TestData>();
             data = new TestData
             {
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
             // Confirm that the JSON fields are case-insensitive (technically malformed string, but still works)
             json = "[{ \"id\":1,\"nAme\":\"Broom\",\"coSt\":32.5,\"TimEStamp\":\"2019-11-22T06:32:15\"}]";
-            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, Telemetry.ConvertType.IAsyncEnumerable)).ReturnsAsync(json);
+            converter.Setup(_ => _.BuildItemFromAttributeAsync(arg, null)).ReturnsAsync(json);
             list = new List<TestData>();
             data = new TestData
             {


### PR DESCRIPTION
Sql version isn't being captured for all the input bindings since we aren capturing the event prior to getting that info. Added  a new event BuildItemFromAttributeAsync.