### PR TITLE
Don't publish TSA results on PRs

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -135,7 +135,7 @@ steps:
   inputs:
     GdnPublishTsaOnboard: true
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\builds\TSAConfig.gdntsa'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.Reason', 'PullRequest']))
 
 # 5.0 isn't supported on Mac yet
 - task: UseDotNet@2


### PR DESCRIPTION
We should only be publishing the results to the TSA codebase on our scheduled builds so as not to generate false positives from in-progress PRs. 