### PR TITLE
Run PR validation on release branches and rename nuget to *-lapreview.nupkg

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -5,6 +5,7 @@ pr:
     include:
     - main
     - triggerbindings
+    - release/*
 
 variables:
   solution: '**/*.sln'

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -18,7 +18,7 @@ variables:
   versionMajorMinor: '$(versionMajor).$(versionMinor)'  # This variable is only used for the counter so we reset properly when either major or minor is bumped
   versionPatch: $[counter(variables['versionMinor'], 0)] # This will reset when we bump minor version
   binariesVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
-  nugetVersion: '$(binariesVersion)-preview'
+  nugetVersion: '$(binariesVersion)-lapreview'
 
 stages:
 - stage: BuildPublish


### PR DESCRIPTION
Currently the packages generated from the LA preview branch will have numbers that are very similar to the "official" nuget.org packages which could be dangerous (if the numbers happened to line up) and confusing (hard to tell where a package came from). Changing it to -lapreview will help avoid these problems. 

Doing directly to release branch since this isn't something we want in main ever - so leaving it out of the triggerbindings branch to keep things clean for eventual merging there. 