### PR TITLE
Add policheck and var for uploading to TSA

### DIFF
--- a/builds/TSAConfig.gdntsa
+++ b/builds/TSAConfig.gdntsa
@@ -14,6 +14,7 @@
     "tools": [
         "BinSkim",
         "RoslynAnalyzers",
-        "CredScan"
+        "CredScan",
+        "Policheck"
     ]
 }

--- a/builds/TSAConfig.gdntsa
+++ b/builds/TSAConfig.gdntsa
@@ -1,7 +1,7 @@
 {
     "codebaseName": "Sql Bindings",
     "notificationAliases": [
-        "sqltools@service.microsoft.com"
+        "sqlbindings@microsoft.com"
     ],
     "codebaseAdmins": [
         "REDMOND\\chlafren",

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -96,10 +96,6 @@ steps:
   inputs:
     targetType: F
     result: PoliCheck.xml
-    targetArgument: '$(Build.SourcesDirectory)/**/*'
-    optionsFC: 0
-    optionsXS: 0
-    optionsHMENABLE: 0
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -142,7 +142,7 @@ steps:
   inputs:
     GdnPublishTsaOnboard: true
     GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\builds\TSAConfig.gdntsa'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['TSA_UPLOAD'], 'true'))
 
 # 5.0 isn't supported on Mac yet
 - task: UseDotNet@2

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -91,6 +91,15 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    optionsFC: 0
+    optionsXS: 0
+    optionsHMENABLE: 0
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
   inputs:
     toolMajorVersion: V2

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -91,10 +91,12 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
   displayName: 'Run PoliCheck'
   inputs:
     targetType: F
+    result: PoliCheck.xml
+    targetArgument: '$(Build.SourcesDirectory)/**/*'
     optionsFC: 0
     optionsXS: 0
     optionsHMENABLE: 0

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -265,3 +265,4 @@ steps:
   displayName: 'Post Analysis'
   inputs:
     GdnBreakPolicyMinSev: Error
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -260,3 +260,8 @@ steps:
   displayName: 'Component Detection'
   inputs:
     failOnAlert: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
+  displayName: 'Post Analysis'
+  inputs:
+    GdnBreakPolicyMinSev: Error

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -53,56 +53,56 @@ steps:
   displayName: Start Server in Docker Container
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
-# - task: DotNetCoreCLI@2
-#   displayName: '.NET Restore'
-#   inputs:
-#     command: restore
-#     projects: '${{ parameters.solution }}'
+- task: DotNetCoreCLI@2
+  displayName: '.NET Restore'
+  inputs:
+    command: restore
+    projects: '${{ parameters.solution }}'
 
   # Don't generate package so we can sign it before packaging
-# - task: DotNetCoreCLI@2
-#   displayName: '.NET Build'
-#   inputs:
-#     command: build
-#     projects: '${{ parameters.solution }}'
-#     arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
+- task: DotNetCoreCLI@2
+  displayName: '.NET Build'
+  inputs:
+    command: build
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
 
-# - script: |
-#     npm install
-#     npm run lint
-#   workingDirectory: $(Build.SourcesDirectory)/samples/samples-js
-#   displayName: Lint samples-js
+- script: |
+    npm install
+    npm run lint
+  workingDirectory: $(Build.SourcesDirectory)/samples/samples-js
+  displayName: Lint samples-js
 
-# - task: UsePythonVersion@0
-#   inputs:
-#     versionSpec: '3.9'
-#     addToPath: true
-#     architecture: 'x64'
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.9'
+    addToPath: true
+    architecture: 'x64'
 
-# - script: |
-#     pip3 install pylint_runner
-#     pip3 install pylintfileheader
-#     pylint_runner
-#   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
-#   displayName: Lint samples-python
+- script: |
+    pip3 install pylint_runner
+    pip3 install pylintfileheader
+    pylint_runner
+  workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
+  displayName: Lint samples-python
 
-# - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
-#   inputs:
-#     InputType: 'CommandLine'
-#     arguments: 'analyze $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\* --recurse --verbose'
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
+  inputs:
+    InputType: 'CommandLine'
+    arguments: 'analyze $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\* --recurse --verbose'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-# - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
-#   inputs:
-#     userProvideBuildInfo: 'autoMsBuildInfo'
-#   env:
-#     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
+  inputs:
+    userProvideBuildInfo: 'autoMsBuildInfo'
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-# - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-#   inputs:
-#     toolMajorVersion: V2
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  inputs:
+    toolMajorVersion: V2
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
   displayName: 'Create Security Analysis Report'
@@ -152,110 +152,110 @@ steps:
     version: '2.1.x'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
-# - task: EsrpCodeSigning@1
-#   displayName: 'ESRP CodeSigning - Binaries'
-#   inputs:
-#     ConnectedServiceName: 'Code Signing'
-#     FolderPath: '$(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}'
-#     Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
-#     signConfigType: inlineSignParams
-#     inlineOperation: |
-#      [
-#        {
-#         "KeyCode" : "CP-235847-SN",
-#         "operationSetCode" : "StrongNameSign",
-#         "Parameters" : [],
-#         "ToolName" : "sign",
-#         "ToolVersion" : "1.0"
-#        },
-#        {
-#         "KeyCode" : "CP-235847-SN",
-#         "operationSetCode" : "StrongNameVerify",
-#         "Parameters" : [],
-#         "ToolName" : "sign",
-#         "ToolVersion" : "1.0"
-#        },
-#        {
-#          "keyCode": "CP-230012",
-#          "operationSetCode": "SigntoolSign",
-#          "parameters": [
-#           {
-#             "parameterName": "OpusName",
-#             "parameterValue": "Azure Functions SQL Extension"
-#           },
-#           {
-#             "parameterName": "OpusInfo",
-#             "parameterValue": "https://github.com/Azure/azure-functions-sql-extension"
-#           },
-#           {
-#             "parameterName": "PageHash",
-#             "parameterValue": "/NPH"
-#           },
-#           {
-#             "parameterName": "FileDigest",
-#             "parameterValue": "/fd sha256"
-#           },
-#           {
-#             "parameterName": "TimeStamp",
-#             "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-#           }
-#          ],
-#          "toolName": "signtool.exe",
-#          "toolVersion": "6.2.9304.0"
-#        },
-#        {
-#          "keyCode": "CP-230012",
-#          "operationSetCode": "SigntoolVerify",
-#          "parameters": [
-#           {
-#             "parameterName": "VerifyAll",
-#             "parameterValue": "/all"
-#           }
-#          ],
-#          "toolName": "signtool.exe",
-#          "toolVersion": "6.2.9304.0"
-#        }
-#      ]
-#     SessionTimeout: 600
-#     MaxConcurrency: 5
+- task: EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning - Binaries'
+  inputs:
+    ConnectedServiceName: 'Code Signing'
+    FolderPath: '$(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}'
+    Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+       {
+        "KeyCode" : "CP-235847-SN",
+        "operationSetCode" : "StrongNameSign",
+        "Parameters" : [],
+        "ToolName" : "sign",
+        "ToolVersion" : "1.0"
+       },
+       {
+        "KeyCode" : "CP-235847-SN",
+        "operationSetCode" : "StrongNameVerify",
+        "Parameters" : [],
+        "ToolName" : "sign",
+        "ToolVersion" : "1.0"
+       },
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolSign",
+         "parameters": [
+          {
+            "parameterName": "OpusName",
+            "parameterValue": "Azure Functions SQL Extension"
+          },
+          {
+            "parameterName": "OpusInfo",
+            "parameterValue": "https://github.com/Azure/azure-functions-sql-extension"
+          },
+          {
+            "parameterName": "PageHash",
+            "parameterValue": "/NPH"
+          },
+          {
+            "parameterName": "FileDigest",
+            "parameterValue": "/fd sha256"
+          },
+          {
+            "parameterName": "TimeStamp",
+            "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+          }
+         ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       },
+       {
+         "keyCode": "CP-230012",
+         "operationSetCode": "SigntoolVerify",
+         "parameters": [
+          {
+            "parameterName": "VerifyAll",
+            "parameterValue": "/all"
+          }
+         ],
+         "toolName": "signtool.exe",
+         "toolVersion": "6.2.9304.0"
+       }
+     ]
+    SessionTimeout: 600
+    MaxConcurrency: 5
 
   # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
-# - task: DotNetCoreCLI@2
-#   displayName: '.NET Pack Nuget'
-#   inputs:
-#     command: custom
-#     custom: pack
-#     projects: '${{ parameters.solution }}'
-#     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
+- task: DotNetCoreCLI@2
+  displayName: '.NET Pack Nuget'
+  inputs:
+    command: custom
+    custom: pack
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
 
-# - task: DotNetCoreCLI@2
-#   displayName: '.NET Test'
-#   env:
-#     TEST_SERVER: '$(testServer)'
-#     NODE_MODULES_PATH: '$(nodeModulesPath)'
-#     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-#   inputs:
-#     command: test
-#     projects: '${{ parameters.solution }}'
-#     arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
-#   condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
+- task: DotNetCoreCLI@2
+  displayName: '.NET Test'
+  env:
+    TEST_SERVER: '$(testServer)'
+    NODE_MODULES_PATH: '$(nodeModulesPath)'
+    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+  inputs:
+    command: test
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
+  condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
 
-# - task: DotNetCoreCLI@2
-#   displayName: '.NET Test on Linux'
-#   env:
-#     SA_PASSWORD: '$(serverPassword)'
-#     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-#   inputs:
-#     command: test
-#     projects: '${{ parameters.solution }}'
-#     arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+- task: DotNetCoreCLI@2
+  displayName: '.NET Test on Linux'
+  env:
+    SA_PASSWORD: '$(serverPassword)'
+    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+  inputs:
+    command: test
+    projects: '${{ parameters.solution }}'
+    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
-# - script: |
-#     docker stop sql1
-#     docker rm sql1
-#   displayName: 'Stop and Remove SQL Server Image'
-#   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+- script: |
+    docker stop sql1
+    docker rm sql1
+  displayName: 'Stop and Remove SQL Server Image'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
@@ -266,5 +266,4 @@ steps:
   displayName: 'Post Analysis'
   inputs:
     GdnBreakPolicyMinSev: Error
-  continueOnError: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -12,6 +12,14 @@ steps:
   inputs:
     useGlobalJson: true
 
+# Run Policheck early to avoid scanning dependency folders
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    result: PoliCheck.xml
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
 - script: npm install -g azure-functions-core-tools
   displayName: 'Install Azure Functions Core Tools'
 
@@ -45,63 +53,56 @@ steps:
   displayName: Start Server in Docker Container
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
-- task: DotNetCoreCLI@2
-  displayName: '.NET Restore'
-  inputs:
-    command: restore
-    projects: '${{ parameters.solution }}'
+# - task: DotNetCoreCLI@2
+#   displayName: '.NET Restore'
+#   inputs:
+#     command: restore
+#     projects: '${{ parameters.solution }}'
 
   # Don't generate package so we can sign it before packaging
-- task: DotNetCoreCLI@2
-  displayName: '.NET Build'
-  inputs:
-    command: build
-    projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
+# - task: DotNetCoreCLI@2
+#   displayName: '.NET Build'
+#   inputs:
+#     command: build
+#     projects: '${{ parameters.solution }}'
+#     arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
 
-- script: |
-    npm install
-    npm run lint
-  workingDirectory: $(Build.SourcesDirectory)/samples/samples-js
-  displayName: Lint samples-js
+# - script: |
+#     npm install
+#     npm run lint
+#   workingDirectory: $(Build.SourcesDirectory)/samples/samples-js
+#   displayName: Lint samples-js
 
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '3.9'
-    addToPath: true
-    architecture: 'x64'
+# - task: UsePythonVersion@0
+#   inputs:
+#     versionSpec: '3.9'
+#     addToPath: true
+#     architecture: 'x64'
 
-- script: |
-    pip3 install pylint_runner
-    pip3 install pylintfileheader
-    pylint_runner
-  workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
-  displayName: Lint samples-python
+# - script: |
+#     pip3 install pylint_runner
+#     pip3 install pylintfileheader
+#     pylint_runner
+#   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
+#   displayName: Lint samples-python
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
-  inputs:
-    InputType: 'CommandLine'
-    arguments: 'analyze $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\* --recurse --verbose'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+# - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
+#   inputs:
+#     InputType: 'CommandLine'
+#     arguments: 'analyze $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\* --recurse --verbose'
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
-  inputs:
-    userProvideBuildInfo: 'autoMsBuildInfo'
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+# - task: securedevelopmentteam.vss-secure-development-tools.build-task-roslynanalyzers.RoslynAnalyzers@3
+#   inputs:
+#     userProvideBuildInfo: 'autoMsBuildInfo'
+#   env:
+#     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
-  displayName: 'Run PoliCheck'
-  inputs:
-    targetType: F
-    result: PoliCheck.xml
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-  inputs:
-    toolMajorVersion: V2
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+# - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+#   inputs:
+#     toolMajorVersion: V2
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@2
   displayName: 'Create Security Analysis Report'
@@ -151,110 +152,110 @@ steps:
     version: '2.1.x'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
-- task: EsrpCodeSigning@1
-  displayName: 'ESRP CodeSigning - Binaries'
-  inputs:
-    ConnectedServiceName: 'Code Signing'
-    FolderPath: '$(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}'
-    Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-       {
-        "KeyCode" : "CP-235847-SN",
-        "operationSetCode" : "StrongNameSign",
-        "Parameters" : [],
-        "ToolName" : "sign",
-        "ToolVersion" : "1.0"
-       },
-       {
-        "KeyCode" : "CP-235847-SN",
-        "operationSetCode" : "StrongNameVerify",
-        "Parameters" : [],
-        "ToolName" : "sign",
-        "ToolVersion" : "1.0"
-       },
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolSign",
-         "parameters": [
-          {
-            "parameterName": "OpusName",
-            "parameterValue": "Azure Functions SQL Extension"
-          },
-          {
-            "parameterName": "OpusInfo",
-            "parameterValue": "https://github.com/Azure/azure-functions-sql-extension"
-          },
-          {
-            "parameterName": "PageHash",
-            "parameterValue": "/NPH"
-          },
-          {
-            "parameterName": "FileDigest",
-            "parameterValue": "/fd sha256"
-          },
-          {
-            "parameterName": "TimeStamp",
-            "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-          }
-         ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       },
-       {
-         "keyCode": "CP-230012",
-         "operationSetCode": "SigntoolVerify",
-         "parameters": [
-          {
-            "parameterName": "VerifyAll",
-            "parameterValue": "/all"
-          }
-         ],
-         "toolName": "signtool.exe",
-         "toolVersion": "6.2.9304.0"
-       }
-     ]
-    SessionTimeout: 600
-    MaxConcurrency: 5
+# - task: EsrpCodeSigning@1
+#   displayName: 'ESRP CodeSigning - Binaries'
+#   inputs:
+#     ConnectedServiceName: 'Code Signing'
+#     FolderPath: '$(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}'
+#     Pattern: 'Microsoft.Azure.WebJobs.Extensions.Sql.dll'
+#     signConfigType: inlineSignParams
+#     inlineOperation: |
+#      [
+#        {
+#         "KeyCode" : "CP-235847-SN",
+#         "operationSetCode" : "StrongNameSign",
+#         "Parameters" : [],
+#         "ToolName" : "sign",
+#         "ToolVersion" : "1.0"
+#        },
+#        {
+#         "KeyCode" : "CP-235847-SN",
+#         "operationSetCode" : "StrongNameVerify",
+#         "Parameters" : [],
+#         "ToolName" : "sign",
+#         "ToolVersion" : "1.0"
+#        },
+#        {
+#          "keyCode": "CP-230012",
+#          "operationSetCode": "SigntoolSign",
+#          "parameters": [
+#           {
+#             "parameterName": "OpusName",
+#             "parameterValue": "Azure Functions SQL Extension"
+#           },
+#           {
+#             "parameterName": "OpusInfo",
+#             "parameterValue": "https://github.com/Azure/azure-functions-sql-extension"
+#           },
+#           {
+#             "parameterName": "PageHash",
+#             "parameterValue": "/NPH"
+#           },
+#           {
+#             "parameterName": "FileDigest",
+#             "parameterValue": "/fd sha256"
+#           },
+#           {
+#             "parameterName": "TimeStamp",
+#             "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+#           }
+#          ],
+#          "toolName": "signtool.exe",
+#          "toolVersion": "6.2.9304.0"
+#        },
+#        {
+#          "keyCode": "CP-230012",
+#          "operationSetCode": "SigntoolVerify",
+#          "parameters": [
+#           {
+#             "parameterName": "VerifyAll",
+#             "parameterValue": "/all"
+#           }
+#          ],
+#          "toolName": "signtool.exe",
+#          "toolVersion": "6.2.9304.0"
+#        }
+#      ]
+#     SessionTimeout: 600
+#     MaxConcurrency: 5
 
   # Extra parameter GeneratePackageOnBuild=false is needed for issue https://github.com/dotnet/sdk/pull/3473#issuecomment-516612070
-- task: DotNetCoreCLI@2
-  displayName: '.NET Pack Nuget'
-  inputs:
-    command: custom
-    custom: pack
-    projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
+# - task: DotNetCoreCLI@2
+#   displayName: '.NET Pack Nuget'
+#   inputs:
+#     command: custom
+#     custom: pack
+#     projects: '${{ parameters.solution }}'
+#     arguments: '--configuration ${{ parameters.configuration }} --output $(Build.ArtifactStagingDirectory) --no-build -p:PackageVersion="${{ parameters.nugetVersion }}" -p:GeneratePackageOnBuild=false'
 
-- task: DotNetCoreCLI@2
-  displayName: '.NET Test'
-  env:
-    TEST_SERVER: '$(testServer)'
-    NODE_MODULES_PATH: '$(nodeModulesPath)'
-    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-  inputs:
-    command: test
-    projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
-  condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
+# - task: DotNetCoreCLI@2
+#   displayName: '.NET Test'
+#   env:
+#     TEST_SERVER: '$(testServer)'
+#     NODE_MODULES_PATH: '$(nodeModulesPath)'
+#     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+#   inputs:
+#     command: test
+#     projects: '${{ parameters.solution }}'
+#     arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
+#   condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
 
-- task: DotNetCoreCLI@2
-  displayName: '.NET Test on Linux'
-  env:
-    SA_PASSWORD: '$(serverPassword)'
-    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-  inputs:
-    command: test
-    projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+# - task: DotNetCoreCLI@2
+#   displayName: '.NET Test on Linux'
+#   env:
+#     SA_PASSWORD: '$(serverPassword)'
+#     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+#   inputs:
+#     command: test
+#     projects: '${{ parameters.solution }}'
+#     arguments: '--configuration ${{ parameters.configuration }} ${{ parameters.testFilter }} --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
-- script: |
-    docker stop sql1
-    docker rm sql1
-  displayName: 'Stop and Remove SQL Server Image'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+# - script: |
+#     docker stop sql1
+#     docker rm sql1
+#   displayName: 'Stop and Remove SQL Server Image'
+#   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
@@ -264,6 +265,6 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Post Analysis'
   inputs:
-    GdnBreakPolicyMinSev: Warning
+    GdnBreakPolicyMinSev: Error
   continueOnError: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -264,5 +264,6 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: 'Post Analysis'
   inputs:
-    GdnBreakPolicyMinSev: Error
+    GdnBreakPolicyMinSev: Warning
+  continueOnError: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))


### PR DESCRIPTION
- TSA_UPLOAD is used to control uploading bugs to TSA scans - this will be enabled for scheduled runs. This allows us to manually run builds to update the TSA code base as needed (although this should rarely be done)
- Changing notification alias to a smaller scope