### PR TITLE
Fix log error not printing out primary key name

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -35,6 +35,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this.Name = name;
             this.IsIdentity = isIdentity;
         }
+
+        public override string ToString()
+        {
+            return this.Name;
+        }
     }
 
     /// <typeparam name="T">A user-defined POCO that represents a row of the user's table</typeparam>


### PR DESCRIPTION
In https://github.com/Azure/azure-functions-sql-extension/blob/ad1a84daa5490720a9fb18f23f500025e65451f0/src/SqlAsyncCollector.cs we print out the list of primary keys - but since those objects don't have a ToString overload they just print out as `[PrimaryKey,PrimaryKey]`. 

Now they'll print out with the actual names - e.g. `[productid, name]`