### PR TITLE
Wait for error inside `StartFunctionsHostAndWaitForError` method

### DIFF
--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.StartFunctionHost(functionName, Common.SupportedLanguages.CSharp, useTestFolder, OutputHandler);
 
             // The functions host generally logs the error message within a second after starting up.
-            const int BufferTimeForErrorInSeconds = 5;
+            const int BufferTimeForErrorInSeconds = 15;
             bool isCompleted = tcs.Task.Wait(TimeSpan.FromSeconds(BufferTimeForErrorInSeconds));
 
             this.FunctionHost.OutputDataReceived -= OutputHandler;

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -269,9 +269,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             // All trigger integration tests are only using C# functions for testing at the moment.
             this.StartFunctionHost(functionName, Common.SupportedLanguages.CSharp, useTestFolder, OutputHandler);
+
+            // The functions host generally logs the error message within a second after starting up.
+            const int BufferTimeForErrorInSeconds = 5;
+            bool isCompleted = tcs.Task.Wait(TimeSpan.FromSeconds(BufferTimeForErrorInSeconds));
+
             this.FunctionHost.OutputDataReceived -= OutputHandler;
             this.FunctionHost.Kill();
 
+            Assert.True(isCompleted, "Functions host did not log failure to start SQL trigger listener within specified time.");
             Assert.Equal(expectedErrorMessage, errorMessage);
         }
     }


### PR DESCRIPTION
- Closes #348 

It's basically a copy of interim changes that were made in #296 ([commit](https://github.com/Azure/azure-functions-sql-extension/blob/76f4bdb8c1325de5913ee18b7ac577678e2554b4/test/Integration/SqlTriggerBindingIntegrationTests.cs#L265-L276)).