### PR TITLE
Add comments to explain LastSyncVersion selection

### DIFF
--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -586,8 +586,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 changeVersionSet.Add(long.Parse(changeVersion, CultureInfo.InvariantCulture));
             }
 
-            // If there are more than one version numbers in the set, return the second highest one. Otherwise, return
+            // The batch of changes are gotten in ascending order of the version number.
+            // With this, it is ensured that if there are multiple version numbers in the changeVersionSet,
+            // all the other rows with version numbers less than the highest should have either been processed or
+            // have leases acquired on them by another worker.
+            // Therefore, if there are more than one version numbers in the set, return the second highest one. Otherwise, return
             // the only version number in the set.
+            // Also this LastSyncVersion is actually updated in the GlobalState table only after verifying that the changes with  
+            // changeVersion <= newLastSyncVersion have been processed in BuildUpdateTablesPostInvocation query. 
             long lastSyncVersion = changeVersionSet.ElementAt(changeVersionSet.Count > 1 ? changeVersionSet.Count - 2 : 0);
             this._logger.LogDebugWithThreadId($"RecomputeLastSyncVersion. LastSyncVersion={lastSyncVersion} ChangeVersionSet={string.Join(",", changeVersionSet)}");
             return lastSyncVersion;


### PR DESCRIPTION
Closes #306 

Read up on this in the design doc and this is what I understand for the decision of new last sync version.

- Since the batch of changes are acquired in ascending order. With multiple version numbers in the batch, the other changes with version numbers less than the highest version number should either be already processed or being leased by other workers, which is why last sync version is updated to second highest version number.
- In the query where the last sync version is actually updated in the `GlobalState` Table it checks if there are any unprocessed changes with version numbers lower than new last sync version. If there are none, every change with version number <= new last sync version is cleared from the `Leases` Table.
- It is ensured that a worker lagging behind won't update the last sync version to a lower version due to condition of updating only when `@current_last_sync_version < {newLastSyncVersion}`.
- Initially the last sync version is set in the `GlobalState` Table using `CHANGE_TRACKING_MIN_VALID_VERSION({userTableId}) `

Have added comments related to this in the PR.