### PR TITLE
Constructor cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ dotnet_analyzer_diagnostic.severity = error
 # Namespace does not match folder structure - Ideally this should be enabled but it seems to have issues with root level files so disabling for now
 dotnet_diagnostic.IDE0130.severity = none
 
+# CA1805: Do not initialize unnecessarily - It's better to be explicit when initializing vars to ensure correct value is used
+dotnet_diagnostic.CA1805.severity = none
+
 # Documentation related errors, remove once they are fixed
 dotnet_diagnostic.CS1591.severity = none
 dotnet_diagnostic.CS1573.severity = none

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -89,32 +89,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             ILogger logger,
             IDictionary<TelemetryPropertyName, string> telemetryProps)
         {
-            _ = !string.IsNullOrEmpty(connectionString) ? true : throw new ArgumentNullException(nameof(connectionString));
-            _ = !string.IsNullOrEmpty(userTable.FullName) ? true : throw new ArgumentNullException(nameof(userTable));
-            _ = !string.IsNullOrEmpty(userFunctionId) ? true : throw new ArgumentNullException(nameof(userFunctionId));
-            _ = !string.IsNullOrEmpty(leasesTableName) ? true : throw new ArgumentNullException(nameof(leasesTableName));
-            _ = userTableColumns ?? throw new ArgumentNullException(nameof(userTableColumns));
-            _ = primaryKeyColumns ?? throw new ArgumentNullException(nameof(primaryKeyColumns));
-            _ = executor ?? throw new ArgumentNullException(nameof(executor));
-            _ = logger ?? throw new ArgumentNullException(nameof(logger));
+            this._connectionString = !string.IsNullOrEmpty(connectionString) ? connectionString : throw new ArgumentNullException(nameof(connectionString));
+            this._userTable = !string.IsNullOrEmpty(userTable?.FullName) ? userTable : throw new ArgumentNullException(nameof(userTable));
+            this._userFunctionId = !string.IsNullOrEmpty(userFunctionId) ? userFunctionId : throw new ArgumentNullException(nameof(userFunctionId));
+            this._leasesTableName = !string.IsNullOrEmpty(leasesTableName) ? leasesTableName : throw new ArgumentNullException(nameof(leasesTableName));
+            this._userTableColumns = userTableColumns ?? throw new ArgumentNullException(nameof(userTableColumns));
+            this._primaryKeyColumns = primaryKeyColumns ?? throw new ArgumentNullException(nameof(primaryKeyColumns));
+            this._executor = executor ?? throw new ArgumentNullException(nameof(executor));
+            this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            this._connectionString = connectionString;
             this._userTableId = userTableId;
-            this._userTable = userTable;
-            this._userFunctionId = userFunctionId;
-            this._leasesTableName = leasesTableName;
-            this._userTableColumns = userTableColumns;
-            this._primaryKeyColumns = primaryKeyColumns;
 
             // Prep search-conditions that will be used besides WHERE clause to match table rows.
             this._rowMatchConditions = Enumerable.Range(0, BatchSize)
                 .Select(rowIndex => string.Join(" AND ", this._primaryKeyColumns.Select((col, colIndex) => $"{col.AsBracketQuotedString()} = @{rowIndex}_{colIndex}")))
                 .ToList();
 
-            this._executor = executor;
-            this._logger = logger;
-
-            this._telemetryProps = telemetryProps;
+            this._telemetryProps = telemetryProps ?? new Dictionary<TelemetryPropertyName, string>();
 
 #pragma warning disable CS4014 // Queue the below tasks and exit. Do not wait for their completion.
             _ = Task.Run(() =>

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly ILogger _logger;
 
-        private readonly CancellationTokenSource _cancellationTokenSourceCheckForChanges = new CancellationTokenSource();;
-        private readonly CancellationTokenSource _cancellationTokenSourceRenewLeases = new CancellationTokenSource();;
-        private CancellationTokenSource _cancellationTokenSourceExecutor = new CancellationTokenSource();;
+        private readonly CancellationTokenSource _cancellationTokenSourceCheckForChanges = new CancellationTokenSource();
+        private readonly CancellationTokenSource _cancellationTokenSourceRenewLeases = new CancellationTokenSource();
+        private CancellationTokenSource _cancellationTokenSourceExecutor = new CancellationTokenSource();
 
         // The semaphore gets used by lease-renewal loop to ensure that '_state' stays set to 'ProcessingChanges' while
         // the leases are being renewed. The change-consumption loop requires to wait for the semaphore before modifying

--- a/src/TriggerBinding/SqlTriggerBindingProvider.cs
+++ b/src/TriggerBinding/SqlTriggerBindingProvider.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             this._hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
 
-            _ = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
-            this._logger = loggerFactory.CreateLogger(LogCategories.CreateTriggerCategory("Sql"));
+            this._logger = loggerFactory?.CreateLogger(LogCategories.CreateTriggerCategory("Sql")) ?? throw new ArgumentNullException(nameof(loggerFactory));
         }
 
         /// <summary>

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -34,11 +34,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly string _userFunctionId;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly ILogger _logger;
+        private readonly IConfiguration _configuration;
 
         private readonly IDictionary<TelemetryPropertyName, string> _telemetryProps = new Dictionary<TelemetryPropertyName, string>();
 
         private SqlTableChangeMonitor<T> _changeMonitor;
-        private int _listenerState;
+        private int _listenerState = ListenerNotStarted;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlTriggerListener{T}"/> class.
@@ -50,18 +51,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <param name="logger">Facilitates logging of messages</param>
         public SqlTriggerListener(string connectionString, string tableName, string userFunctionId, ITriggeredFunctionExecutor executor, ILogger logger)
         {
-            _ = !string.IsNullOrEmpty(connectionString) ? true : throw new ArgumentNullException(nameof(connectionString));
-            _ = !string.IsNullOrEmpty(tableName) ? true : throw new ArgumentNullException(nameof(tableName));
-            _ = !string.IsNullOrEmpty(userFunctionId) ? true : throw new ArgumentNullException(nameof(userFunctionId));
-            _ = executor ?? throw new ArgumentNullException(nameof(executor));
-            _ = logger ?? throw new ArgumentNullException(nameof(logger));
-
-            this._connectionString = connectionString;
-            this._userTable = new SqlObject(tableName);
-            this._userFunctionId = userFunctionId;
-            this._executor = executor;
-            this._logger = logger;
-            this._listenerState = ListenerNotStarted;
+            this._connectionString = !string.IsNullOrEmpty(connectionString) ? connectionString : throw new ArgumentNullException(nameof(connectionString));
+            this._userTable = !string.IsNullOrEmpty(tableName) ? new SqlObject(tableName) : throw new ArgumentNullException(nameof(tableName));
+            this._userFunctionId = !string.IsNullOrEmpty(userFunctionId) ? userFunctionId : throw new ArgumentNullException(nameof(userFunctionId));
+            this._executor = executor ?? throw new ArgumentNullException(nameof(executor));
+            this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public void Cancel()

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly string _userFunctionId;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly ILogger _logger;
-        private readonly IConfiguration _configuration;
 
         private readonly IDictionary<TelemetryPropertyName, string> _telemetryProps = new Dictionary<TelemetryPropertyName, string>();
 


### PR DESCRIPTION
No reason to declare vars in the constructor, just adds clutter. 

And using shortcutting logic for assigning the constructor parameters like we do elsewhere. 

Also disabling CA1805 - it doesn't really provide any useful benefit. 