### PR TITLE
Add configuration for batch size/polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Azure SQL bindings for Azure Functions are supported for:
     - [Python functions](#python-functions)
       - [Input Binding Tutorial](#input-binding-tutorial-2)
       - [Output Binding Tutorial](#output-binding-tutorial-2)
+  - [Configuration](#configuration)
+    - [Trigger Binding Configuration](#trigger-binding-configuration)
+      - [Sql_Trigger_BatchSize](#sql_trigger_batchsize)
+      - [Sql_Trigger_PollingIntervalMs](#sql_trigger_pollingintervalms)
   - [More Samples](#more-samples)
     - [Input Binding](#input-binding)
       - [Query String](#query-string)
@@ -553,6 +557,20 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 
 - Hit 'F5' to run your code. Click the link to upsert the output array values in your SQL table. Your upserted values should launch in the browser.
 - Congratulations! You have successfully created your first SQL output binding! Checkout [Output Binding](#Output-Binding) for more information on how to use it and explore on your own!
+
+## Configuration
+
+This section goes over some of the configuration values you can use to customize the SQL bindings. See [How to Use Azure Function App Settings](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings) to learn more.
+
+### Trigger Binding Configuration
+
+#### Sql_Trigger_BatchSize
+
+This controls the number of changes processed at once before being sent to the triggered function.
+
+#### Sql_Trigger_PollingIntervalMs
+
+This controls the delay in milliseconds between processing each batch of changes.
 
 ## More Samples
 

--- a/src/TriggerBinding/SqlTriggerBinding.cs
+++ b/src/TriggerBinding/SqlTriggerBinding.cs
@@ -15,6 +15,7 @@ using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Azure.WebJobs.Host.Protocols;
 using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly ParameterInfo _parameter;
         private readonly IHostIdProvider _hostIdProvider;
         private readonly ILogger _logger;
+        private readonly IConfiguration _configuration;
 
         private static readonly IReadOnlyDictionary<string, Type> _emptyBindingContract = new Dictionary<string, Type>();
         private static readonly IReadOnlyDictionary<string, object> _emptyBindingData = new Dictionary<string, object>();
@@ -41,13 +43,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <param name="parameter">Trigger binding parameter information</param>
         /// <param name="hostIdProvider">Provider of unique host identifier</param>
         /// <param name="logger">Facilitates logging of messages</param>
-        public SqlTriggerBinding(string connectionString, string tableName, ParameterInfo parameter, IHostIdProvider hostIdProvider, ILogger logger)
+        /// <param name="configuration">Provides configuration values</param>
+        public SqlTriggerBinding(string connectionString, string tableName, ParameterInfo parameter, IHostIdProvider hostIdProvider, ILogger logger, IConfiguration configuration)
         {
             this._connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
             this._tableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
             this._parameter = parameter ?? throw new ArgumentNullException(nameof(parameter));
             this._hostIdProvider = hostIdProvider ?? throw new ArgumentNullException(nameof(hostIdProvider));
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
         /// <summary>
@@ -68,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             _ = context ?? throw new ArgumentNullException(nameof(context), "Missing listener context");
 
             string userFunctionId = await this.GetUserFunctionIdAsync();
-            return new SqlTriggerListener<T>(this._connectionString, this._tableName, userFunctionId, context.Executor, this._logger);
+            return new SqlTriggerListener<T>(this._connectionString, this._tableName, userFunctionId, context.Executor, this._logger, this._configuration);
         }
 
         public ParameterDescriptor ToParameterDescriptor()

--- a/src/TriggerBinding/SqlTriggerBindingProvider.cs
+++ b/src/TriggerBinding/SqlTriggerBindingProvider.cs
@@ -78,10 +78,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             Type userType = parameter.ParameterType.GetGenericArguments()[0].GetGenericArguments()[0];
             Type bindingType = typeof(SqlTriggerBinding<>).MakeGenericType(userType);
 
-            var constructorParameterTypes = new Type[] { typeof(string), typeof(string), typeof(ParameterInfo), typeof(IHostIdProvider), typeof(ILogger) };
+            var constructorParameterTypes = new Type[] { typeof(string), typeof(string), typeof(ParameterInfo), typeof(IHostIdProvider), typeof(ILogger), typeof(IConfiguration) };
             ConstructorInfo bindingConstructor = bindingType.GetConstructor(constructorParameterTypes);
 
-            object[] constructorParameterValues = new object[] { connectionString, attribute.TableName, parameter, this._hostIdProvider, this._logger };
+            object[] constructorParameterValues = new object[] { connectionString, attribute.TableName, parameter, this._hostIdProvider, this._logger, this._configuration };
             var triggerBinding = (ITriggerBinding)bindingConstructor.Invoke(constructorParameterValues);
 
             return Task.FromResult(triggerBinding);

--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -14,5 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public const string LeasesTableChangeVersionColumnName = "_az_func_ChangeVersion";
         public const string LeasesTableAttemptCountColumnName = "_az_func_AttemptCount";
         public const string LeasesTableLeaseExpirationTimeColumnName = "_az_func_LeaseExpirationTime";
+
+        public const string ConfigKey_SqlTrigger_BatchSize = "Sql_Trigger_BatchSize";
+        public const string ConfigKey_SqlTrigger_PollingInterval = "Sql_Trigger_PollingIntervalMs";
     }
 }

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Azure.WebJobs.Host.Listeners;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -34,6 +35,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly string _userFunctionId;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly ILogger _logger;
+        private readonly IConfiguration _configuration;
 
         private readonly IDictionary<TelemetryPropertyName, string> _telemetryProps = new Dictionary<TelemetryPropertyName, string>();
 
@@ -48,13 +50,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <param name="userFunctionId">Unique identifier for the user function</param>
         /// <param name="executor">Defines contract for triggering user function</param>
         /// <param name="logger">Facilitates logging of messages</param>
-        public SqlTriggerListener(string connectionString, string tableName, string userFunctionId, ITriggeredFunctionExecutor executor, ILogger logger)
+        /// <param name="configuration">Provides configuration values</param>
+        public SqlTriggerListener(string connectionString, string tableName, string userFunctionId, ITriggeredFunctionExecutor executor, ILogger logger, IConfiguration configuration)
         {
             this._connectionString = !string.IsNullOrEmpty(connectionString) ? connectionString : throw new ArgumentNullException(nameof(connectionString));
             this._userTable = !string.IsNullOrEmpty(tableName) ? new SqlObject(tableName) : throw new ArgumentNullException(nameof(tableName));
             this._userFunctionId = !string.IsNullOrEmpty(userFunctionId) ? userFunctionId : throw new ArgumentNullException(nameof(userFunctionId));
             this._executor = executor ?? throw new ArgumentNullException(nameof(executor));
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
         public void Cancel()
@@ -122,6 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         primaryKeyColumns.Select(col => col.name).ToList(),
                         this._executor,
                         this._logger,
+                        this._configuration,
                         this._telemetryProps);
 
                     this._listenerState = ListenerStarted;
@@ -467,7 +472,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Clears the current telemetry property dictionary and initializes the default initial properties. 
+        /// Clears the current telemetry property dictionary and initializes the default initial properties.
         /// </summary>
         private void InitializeTelemetryProps()
         {

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -99,5 +99,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             logger.LogDebug($"TID:{Environment.CurrentManagedThreadId} {message}", args);
         }
+
+        public static void LogInformationWithThreadId(this ILogger logger, string message, params object[] args)
+        {
+            logger.LogInformation($"TID:{Environment.CurrentManagedThreadId} {message}", args);
+        }
     }
 }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -6,3 +6,4 @@
 dotnet_diagnostic.CA1309.severity = silent # Use ordinal StringComparison - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn't important for tests and just adds clutter
 dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
+dotnet_diagnostic.CA2201.severity = silent # Do not raise reserved exception types - tests can throw whatever they want

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -17,6 +17,7 @@ using Xunit.Abstractions;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
 using Microsoft.AspNetCore.WebUtilities;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
@@ -175,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// - The functionName is different than its route.<br/>
         /// - You can start multiple functions by passing in a space-separated list of function names.<br/>
         /// </remarks>
-        protected void StartFunctionHost(string functionName, SupportedLanguages language, bool useTestFolder = false, DataReceivedEventHandler customOutputHandler = null)
+        protected void StartFunctionHost(string functionName, SupportedLanguages language, bool useTestFolder = false, DataReceivedEventHandler customOutputHandler = null, IDictionary<string, string> environmentVariables = null)
         {
             string workingDirectory = useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", Enum.GetName(typeof(SupportedLanguages), language));
             if (!Directory.Exists(workingDirectory))
@@ -194,6 +195,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 RedirectStandardError = true,
                 UseShellExecute = false
             };
+            if (environmentVariables != null)
+            {
+                environmentVariables.ToList().ForEach(ev => startInfo.EnvironmentVariables[ev.Key] = ev.Value);
+            }
             this.LogOutput($"Starting {startInfo.FileName} {startInfo.Arguments} in {startInfo.WorkingDirectory}");
             this.FunctionHost = new Process
             {

--- a/test/Integration/test-csharp/ProductsTriggerWithValidation.cs
+++ b/test/Integration/test-csharp/ProductsTriggerWithValidation.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
+{
+    public static class ProductsTriggerWithValidation
+    {
+        /// <summary>
+        /// Simple trigger function with additional logic to allow for verifying that the expected number
+        /// of changes was recieved in each batch.
+        /// </summary>
+        [FunctionName(nameof(ProductsTriggerWithValidation))]
+        public static void Run(
+            [SqlTrigger("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+            IReadOnlyList<SqlChange<Product>> changes,
+            ILogger logger)
+        {
+            string expectedBatchSize = Environment.GetEnvironmentVariable("TEST_EXPECTED_BATCH_SIZE");
+            if (!string.IsNullOrEmpty(expectedBatchSize) && int.Parse(expectedBatchSize) != changes.Count)
+            {
+                throw new Exception($"Invalid batch size, got {changes.Count} changes but expected {expectedBatchSize}");
+            }
+            // The output is used to inspect the trigger binding parameter in test methods.
+            logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/Azure/azure-functions-sql-extension/issues/330

Adds two configuration values that can be used to control the batch size/polling interval.

I considered adding them as parameters to the trigger attribute as well but decided that was unnecessary overhead - it's simple enough to use an app setting for them.

I've created https://github.com/Azure/azure-functions-sql-extension/issues/330 to follow up with changing the defaults, that will require additional testing so wanted to get this in for now and then we can take our time finding new defaults without worrying about people being blocked. 