### PR TITLE
Refactor how trigger integration tests wait for changes

### DIFF
--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 {
@@ -158,6 +159,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         public static string CleanJsonString(string jsonStr)
         {
             return jsonStr.Trim().Replace(" ", "").Replace(Environment.NewLine, "");
+        }
+
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout, string message = "The operation has timed out.")
+        {
+
+            using var timeoutCancellationTokenSource = new CancellationTokenSource();
+
+            Task completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+            if (completedTask == task)
+            {
+                timeoutCancellationTokenSource.Cancel();
+                return await task;  // Very important in order to propagate exceptions
+            }
+            else
+            {
+                throw new TimeoutException(message);
+            }
         }
     }
 }


### PR DESCRIPTION
ValidateProductChanges relied on just always waiting a certain amount of time and then checking if we got the expected changes. It's a lot more reliable to instead monitor the output for the expected changes and then complete it as soon as the test sees them - that avoids any potential issues with network/CPU slowness affecting the exact rate at which the tests receive the update notifications. 

The new WaitForProductChanges does just that, with a timeout parameter allowing for ensuring that we still end after a reasonable amount of time for the change (with an appropriate buffer given to allow for any potential slowness described above). 