### PR TITLE
Check for reserved column names on all columns

### DIFF
--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -15,6 +15,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public const string LeasesTableAttemptCountColumnName = "_az_func_AttemptCount";
         public const string LeasesTableLeaseExpirationTimeColumnName = "_az_func_LeaseExpirationTime";
 
+        /// <summary>
+        /// The column names that are used in internal state tables and so can't exist in the target table
+        /// since that shares column names with the primary keys from each user table being monitored.
+        /// </summary>
+        public static readonly string[] ReservedColumnNames = new string[]
+        {
+                    LeasesTableChangeVersionColumnName,
+                    LeasesTableAttemptCountColumnName,
+                    LeasesTableLeaseExpirationTimeColumnName
+        };
+
         public const string ConfigKey_SqlTrigger_BatchSize = "Sql_Trigger_BatchSize";
         public const string ConfigKey_SqlTrigger_PollingInterval = "Sql_Trigger_PollingIntervalMs";
     }

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -257,22 +257,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     throw new InvalidOperationException($"Could not find primary key created in table: '{this._userTable.FullName}'.");
                 }
 
-                string[] reservedColumnNames = new[]
-                {
-                    SqlTriggerConstants.LeasesTableChangeVersionColumnName,
-                    SqlTriggerConstants.LeasesTableAttemptCountColumnName,
-                    SqlTriggerConstants.LeasesTableLeaseExpirationTimeColumnName
-                };
-
-                var conflictingColumnNames = primaryKeyColumns.Select(col => col.name).Intersect(reservedColumnNames).ToList();
-
-                if (conflictingColumnNames.Count > 0)
-                {
-                    string columnNames = string.Join(", ", conflictingColumnNames.Select(col => $"'{col}'"));
-                    throw new InvalidOperationException($"Found reserved column name(s): {columnNames} in table: '{this._userTable.FullName}'." +
-                        " Please rename them to be able to use trigger binding.");
-                }
-
                 this._logger.LogDebugWithThreadId($"END GetPrimaryKeyColumns ColumnNames(types) = {string.Join(", ", primaryKeyColumns.Select(col => $"'{col.name}({col.type})'"))}.");
                 return primaryKeyColumns;
             }
@@ -315,6 +299,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     string columnNamesAndTypes = string.Join(", ", userDefinedTypeColumns.Select(col => $"'{col.name}' (type: {col.type})"));
                     throw new InvalidOperationException($"Found column(s) with unsupported type(s): {columnNamesAndTypes} in table: '{this._userTable.FullName}'.");
+                }
+
+                string[] reservedColumnNames = new string[]
+                    {
+                        SqlTriggerConstants.LeasesTableChangeVersionColumnName,
+                        SqlTriggerConstants.LeasesTableAttemptCountColumnName,
+                        SqlTriggerConstants.LeasesTableLeaseExpirationTimeColumnName
+                    };
+
+                var conflictingColumnNames = userTableColumns.Intersect(reservedColumnNames).ToList();
+
+                if (conflictingColumnNames.Count > 0)
+                {
+                    string columnNames = string.Join(", ", conflictingColumnNames.Select(col => $"'{col}'"));
+                    throw new InvalidOperationException($"Found reserved column name(s): {columnNames} in table: '{this._userTable.FullName}'." +
+                        " Please rename them to be able to use trigger binding.");
                 }
 
                 this._logger.LogDebugWithThreadId($"END GetUserTableColumns ColumnNames = {string.Join(", ", userTableColumns.Select(col => $"'{col}'"))}.");

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -301,14 +301,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     throw new InvalidOperationException($"Found column(s) with unsupported type(s): {columnNamesAndTypes} in table: '{this._userTable.FullName}'.");
                 }
 
-                string[] reservedColumnNames = new string[]
-                    {
-                        SqlTriggerConstants.LeasesTableChangeVersionColumnName,
-                        SqlTriggerConstants.LeasesTableAttemptCountColumnName,
-                        SqlTriggerConstants.LeasesTableLeaseExpirationTimeColumnName
-                    };
-
-                var conflictingColumnNames = userTableColumns.Intersect(reservedColumnNames).ToList();
+                var conflictingColumnNames = userTableColumns.Intersect(SqlTriggerConstants.ReservedColumnNames).ToList();
 
                 if (conflictingColumnNames.Count > 0)
                 {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/333

Simple fix here was just to move the check from the primary columns query to the general user table query. 

I briefly looked into whether we could refactor the logic slightly to not cause the error to be thrown - since only primary key columns really need to be unique since they share a table with the reserved columns in question. But while it should be possible it wasn't straightforward - and given the name of these columns it seems very unlikely to be a problem so just doing the quick fix for now and we can revisit later if needed. 