### PR TITLE
update samples sdk version to match the extension

### DIFF
--- a/samples/samples-csharp/Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj
+++ b/samples/samples-csharp/Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <_FunctionsExtensionTargetFramework>netstandard2.0</_FunctionsExtensionTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/samples-csharp/global.json
+++ b/samples/samples-csharp/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestFeature"
-  }
-}

--- a/samples/samples-csharp/global.json
+++ b/samples/samples-csharp/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.419",
+    "version": "6.0.300",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Building C# samples project errors out with the below on Windows:
![image](https://user-images.githubusercontent.com/12754347/192392677-91ee8103-55e4-4a83-a7ca-9dc96756f166.png)

Updating it to match the sdk version used by the extension fixes it.
