### PR TITLE
Always disable telemetry during integration tests

### DIFF
--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -18,6 +18,7 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
 using Microsoft.AspNetCore.WebUtilities;
 using System.Collections.Generic;
 using System.Linq;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
@@ -199,6 +200,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             {
                 environmentVariables.ToList().ForEach(ev => startInfo.EnvironmentVariables[ev.Key] = ev.Value);
             }
+
+            // Always disable telemetry during test runs
+            startInfo.EnvironmentVariables[TelemetryOptoutEnvVar] = "1";
+
             this.LogOutput($"Starting {startInfo.FileName} {startInfo.Arguments} in {startInfo.WorkingDirectory}");
             this.FunctionHost = new Process
             {


### PR DESCRIPTION
Telemetry wasn't being disabled during benchmark tests, adding it into the test setup to ensure that it's disabled there too. 

I'm also going to look into disabling it for all dev builds as well so that our testing doesn't affect the numbers. 