### PR TITLE
Increase default trigger throughput and add benchmark tests

### DIFF
--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
         {
             BenchmarkRunner.Run<SqlInputBindingPerformance>();
             BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+            BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
         }
     }
 }

--- a/performance/SqlTriggerBindingPerformance.cs
+++ b/performance/SqlTriggerBindingPerformance.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
+{
+    public class SqlTriggerBindingPerformance : SqlTriggerBindingIntegrationTests
+    {
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            this.EnableChangeTrackingForTable("Products");
+            this.StartFunctionHost(nameof(ProductsTrigger), SupportedLanguages.CSharp);
+        }
+
+        [Benchmark]
+        [Arguments(1)]
+        [Arguments(10)]
+        [Arguments(100)]
+        [Arguments(1000)]
+        public async Task ProductsTriggerTest(int count)
+        {
+            await this.WaitForProductChanges(
+                1,
+                count,
+                SqlChangeOperation.Insert,
+                () => { this.InsertProducts(1, count); return Task.CompletedTask; },
+                id => $"Product {id}",
+                id => id * 100,
+                GetBatchProcessingTimeout(1, count));
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            // Delete all rows in Products table after each iteration
+            this.ExecuteNonQuery("TRUNCATE TABLE Products");
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            this.Dispose();
+        }
+    }
+}

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private const int LeaseRenewalIntervalInSeconds = 15;
         private const int MaxRetryReleaseLeases = 3;
 
-        public const int DefaultBatchSize = 10;
-        public const int DefaultPollingIntervalMs = 5000;
+        public const int DefaultBatchSize = 100;
+        public const int DefaultPollingIntervalMs = 1000;
         #endregion Constants
 
         private readonly string _connectionString;

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
     [Collection("IntegrationTests")]
     public class SqlTriggerBindingIntegrationTests : IntegrationTestBase
     {
-        public SqlTriggerBindingIntegrationTests(ITestOutputHelper output) : base(output)
+        public SqlTriggerBindingIntegrationTests(ITestOutputHelper output = null) : base(output)
         {
             this.EnableChangeTrackingForDatabase();
         }
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             ");
         }
 
-        private void EnableChangeTrackingForTable(string tableName)
+        protected void EnableChangeTrackingForTable(string tableName)
         {
             this.ExecuteNonQuery($@"
                 ALTER TABLE [dbo].[{tableName}]
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             };
         }
 
-        private void InsertProducts(int firstId, int lastId)
+        protected void InsertProducts(int firstId, int lastId)
         {
             int count = lastId - firstId + 1;
             this.ExecuteNonQuery(
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 string.Join(",\n", Enumerable.Range(firstId, count).Select(id => $"({id}, 'Product {id}', {id * 100})")) + ";");
         }
 
-        private void UpdateProducts(int firstId, int lastId)
+        protected void UpdateProducts(int firstId, int lastId)
         {
             int count = lastId - firstId + 1;
             this.ExecuteNonQuery(
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 "WHERE ProductId IN (" + string.Join(", ", Enumerable.Range(firstId, count)) + ");");
         }
 
-        private void DeleteProducts(int firstId, int lastId)
+        protected void DeleteProducts(int firstId, int lastId)
         {
             int count = lastId - firstId + 1;
             this.ExecuteNonQuery(
@@ -445,7 +445,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 "WHERE ProductId IN (" + string.Join(", ", Enumerable.Range(firstId, count)) + ");");
         }
 
-        private async Task WaitForProductChanges(
+        protected async Task WaitForProductChanges(
             int firstId,
             int lastId,
             SqlChangeOperation operation,


### PR DESCRIPTION
Batch Size : 10 -> 100
Polling Interval (ms) : 5000 -> 1000

Throughput change : 2 changes / sec -> 100 changes / sec (50x increase)

I'm purposely being pretty conservative here - in my local testing there wasn't any real noticeable change in memory/CPU usage even with this big of an increase. 

Two follow up tasks : 

- Continue running benchmarks with other values - and set them up to properly capture other metrics during test runs to ensure that overall perf isn't affected
- Add telemetry for the batch sizes used so we can see what values people are using to get a sense of whether we should look at changing them again