### PR TITLE
Add site event properties

### DIFF
--- a/src/Telemetry/TelemetryCommonProperties.cs
+++ b/src/Telemetry/TelemetryCommonProperties.cs
@@ -14,6 +14,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         private readonly string _productVersion;
         private readonly string _azureFunctionsEnvironment;
         private readonly bool _hasWebsiteInstanceId;
+        private readonly string _websiteInstanceId;
+        private readonly string _websiteSiteName;
         private readonly string _functionsWorkerRuntime;
 
         public TelemetryCommonProperties(string productVersion, TelemetryClient telemetryClient, IConfiguration config)
@@ -21,7 +23,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
             this._productVersion = productVersion;
             this._userLevelCacheWriter = new UserLevelCacheWriter(telemetryClient);
             this._azureFunctionsEnvironment = config.GetValue(AZURE_FUNCTIONS_ENVIRONMENT_KEY, "");
-            this._hasWebsiteInstanceId = config.GetValue(WEBSITE_INSTANCE_ID_KEY, "") != "";
+            this._websiteInstanceId = config.GetValue(WEBSITE_INSTANCE_ID_KEY, "");
+            this._hasWebsiteInstanceId = !string.IsNullOrEmpty(this._websiteInstanceId);
+            this._websiteSiteName = config.GetValue(WEBSITE_SITE_NAME_KEY, "");
             this._functionsWorkerRuntime = config.GetValue(FUNCTIONS_WORKER_RUNTIME_KEY, "");
         }
 
@@ -32,10 +36,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
         private const string MachineId = "MachineId";
         private const string AzureFunctionsEnvironment = "AzureFunctionsEnvironment";
         private const string HasWebsiteInstanceId = "HasWebsiteInstanceId";
+        private const string WebsiteInstanceId = "WebsiteInstanceId";
+        private const string WebsiteSiteName = "WebsiteSiteName";
         private const string FunctionsWorkerRuntime = "FunctionsWorkerRuntime";
 
         private const string AZURE_FUNCTIONS_ENVIRONMENT_KEY = "AZURE_FUNCTIONS_ENVIRONMENT";
         private const string WEBSITE_INSTANCE_ID_KEY = "WEBSITE_INSTANCE_ID";
+        private const string WEBSITE_SITE_NAME_KEY = "WEBSITE_SITE_NAME";
         private const string FUNCTIONS_WORKER_RUNTIME_KEY = "FUNCTIONS_WORKER_RUNTIME";
 
         public Dictionary<string, string> GetTelemetryCommonProperties()
@@ -47,6 +54,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry
                 {MachineId, this.GetMachineId()},
                 {AzureFunctionsEnvironment, this._azureFunctionsEnvironment},
                 {HasWebsiteInstanceId, this._hasWebsiteInstanceId.ToString()},
+                {WebsiteInstanceId, this._websiteInstanceId },
+                {WebsiteSiteName, this._websiteSiteName},
                 {FunctionsWorkerRuntime, this._functionsWorkerRuntime}
             };
         }


### PR DESCRIPTION
Adds WebsiteSiteId and WebsiteSiteName to the common properties.

[WEBSITE_INSTANCE_ID](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#scaling) - `Read-only. Unique ID of the current VM instance, when the app is scaled out to multiple instances.`
[WEBSITE_SITE_NAME](https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#app-environment) - `Read-only. App name.`

The Site Name is generally what we'll be using to determine unique deployed apps, but the instance ID will be useful to see scaling support usage in the future. 