### PR TITLE
Fix folder used for Integration tests

### DIFF
--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </remarks>
         protected void StartFunctionHost(string functionName, SupportedLanguages language, bool useTestFolder = false, DataReceivedEventHandler customOutputHandler = null)
         {
-            string workingDirectory = useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", Enum.GetName(typeof(SupportedLanguages), language));
+            string workingDirectory = language == SupportedLanguages.CSharp && useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", Enum.GetName(typeof(SupportedLanguages), language));
             if (!Directory.Exists(workingDirectory))
             {
                 throw new FileNotFoundException("Working directory not found at " + workingDirectory);

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -106,7 +106,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="lang">The language to run the test against</param>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.JavaScript)] // Temporarily skipping while we look into the datetime conversion issue with JavaScript
         public void AddProductColumnTypesTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductColumnTypes), lang, true);

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="lang">The language to run the test against</param>
         [Theory]
         [SqlInlineData()]
+        [UnsupportedLanguages(SupportedLanguages.JavaScript)] // Temporarily skipping while we look into the datetime conversion issue with JavaScript
         public void AddProductColumnTypesTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductColumnTypes), lang, true);

--- a/test/Integration/test-js/AddProductColumnTypes/index.js
+++ b/test/Integration/test-js/AddProductColumnTypes/index.js
@@ -5,8 +5,8 @@
 module.exports = async function (context, req) {
     const product = {
         "productId": req.query.productId,
-        "datetime": Date.now(),
-        "datetime2": Date.now()
+        "datetime": new Date().toISOString(),
+        "datetime2": new Date().toISOString()
     };
 
     context.bindings.product = JSON.stringify(product);


### PR DESCRIPTION
This PR fixes the working directory being used for integration tests. Previously the tests in test/Integration/test-js were not being used.

Also converted the Date in the AddProductColumnTypes function to ISO format. Without ISO format, we get the following error from SQL Database: `Conversion failed when converting date and/or time from character string.`
Issue documented here: https://github.com/Azure/azure-functions-sql-extension/issues/385