### PR TITLE
Skip AddProductWithDefaultPKTest for Javascript

### DIFF
--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -384,6 +384,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
+        [UnsupportedLanguages(SupportedLanguages.JavaScript)] // Skip temporarily until the extension bundle is updated with this fix: https://github.com/Azure/azure-functions-sql-extension/pull/388
         public void AddProductWithDefaultPKTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithDefaultPK), lang);


### PR DESCRIPTION
The test is failing for JavaScript since the extension bundle does not contain the fix for default columns yet. I manually updated the sql extension dll in my local extension bundle to verify that this test passes for JavaScript. 

Created issue to re-enable: https://github.com/Azure/azure-functions-sql-extension/issues/393.

