### PR TITLE
Copy latest sql dll to extension bundle in pipeline

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -73,14 +73,16 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle for Windows'
   inputs:
-    contents: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\**\Microsoft.Azure.WebJobs.Extensions.Sql.dll
+    sourceFolder: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\netstandard2.0
+    contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)\bin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle for Linux'
   inputs:
-    contents: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/**/Microsoft.Azure.WebJobs.Extensions.Sql.dll
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
+    contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -76,7 +76,7 @@ steps:
   inputs:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)\bin
+    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
 
 - script: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -247,7 +247,6 @@ steps:
     TEST_SERVER: '$(testServer)'
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-    AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MIN: '0'
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
@@ -259,7 +258,6 @@ steps:
   env:
     SA_PASSWORD: '$(serverPassword)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-    AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MIN: '0'
   inputs:
     command: test
     projects: '${{ parameters.solution }}'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -73,8 +73,9 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
   inputs:
-    contents: '$(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\Microsoft.Azure.WebJobs.Extensions.Sql.dll'
-    targetFolder: '$(azureFunctionsExtensionBundlePath)'
+    contents: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\Microsoft.Azure.WebJobs.Extensions.Sql.dll
+    targetFolder: $(azureFunctionsExtensionBundlePath)
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - script: |
     npm install

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -259,6 +259,7 @@ steps:
   env:
     SA_PASSWORD: '$(serverPassword)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+    AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MIN: '0'
   inputs:
     command: test
     projects: '${{ parameters.solution }}'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -75,7 +75,7 @@ steps:
   inputs:
     sourceFolder: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)\bin
+    targetFolder: $(azureFunctionsExtensionBundlePath)\..\..\Microsoft.Azure.Functions.ExtensionBundle.Preview\**\bin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: CopyFiles@2
@@ -83,7 +83,7 @@ steps:
   inputs:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
+    targetFolder: $(azureFunctionsExtensionBundlePath)/../../Microsoft.Azure.Functions.ExtensionBundle.Preview/**/bin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -71,11 +71,18 @@ steps:
     arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
 
 - task: CopyFiles@2
-  displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
+  displayName: 'Copy Sql extension dll to Azure Functions extension bundle for Windows'
   inputs:
     contents: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\**\Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)
+    targetFolder: $(azureFunctionsExtensionBundlePath)\bin
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- task: CopyFiles@2
+  displayName: 'Copy Sql extension dll to Azure Functions extension bundle for Linux'
+  inputs:
+    contents: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/**/Microsoft.Azure.WebJobs.Extensions.Sql.dll
+    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |
     npm install

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -32,6 +32,9 @@ steps:
   displayName: 'Set npm installation path for Windows'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
+- bash: echo "##vso[task.setvariable variable=azureFunctionsExtensionBundlePath]$(func GetExtensionBundlePath)"
+  displayName: 'Set Azure Functions extension bundle path'
+
 - task: DockerInstaller@0
   displayName: Docker Installer
   inputs:
@@ -66,6 +69,12 @@ steps:
     command: build
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
+
+- task: CopyFiles@2
+  displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
+  inputs:
+    contents: '$(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\Microsoft.Azure.WebJobs.Extensions.Sql.dll'
+    targetFolder: '$(azureFunctionsExtensionBundlePath)'
 
 - script: |
     npm install

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -73,7 +73,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
   inputs:
-    contents: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\Microsoft.Azure.WebJobs.Extensions.Sql.dll
+    contents: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\**\Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -34,6 +34,7 @@ steps:
 
 - bash: echo "##vso[task.setvariable variable=azureFunctionsExtensionBundlePath]$(func GetExtensionBundlePath)"
   displayName: 'Set Azure Functions extension bundle path'
+  workingDirectory: $(Build.SourcesDirectory)/samples/samples-js
 
 - task: DockerInstaller@0
   displayName: Docker Installer
@@ -75,7 +76,7 @@ steps:
   inputs:
     sourceFolder: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)\..\..\Microsoft.Azure.Functions.ExtensionBundle.Preview\**\bin
+    targetFolder: $(azureFunctionsExtensionBundlePath)\bin
     overWrite: true
     ignoreMakeDirErrors: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
@@ -85,7 +86,7 @@ steps:
   inputs:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)/../../Microsoft.Azure.Functions.ExtensionBundle.Preview/**/bin
+    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
     ignoreMakeDirErrors: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -247,6 +247,7 @@ steps:
     TEST_SERVER: '$(testServer)'
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+    AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MIN: '0'
   inputs:
     command: test
     projects: '${{ parameters.solution }}'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -72,22 +72,12 @@ steps:
     arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
 
 - task: CopyFiles@2
-  displayName: 'Copy Sql extension dll to Azure Functions extension bundle for Windows'
-  inputs:
-    sourceFolder: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\netstandard2.0
-    contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)\bin
-    overWrite: true
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
-
-- task: CopyFiles@2
-  displayName: 'Copy Sql extension dll to Azure Functions extension bundle for Linux'
+  displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
   inputs:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
+    targetFolder: $(azureFunctionsExtensionBundlePath)\bin
     overWrite: true
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |
     npm install

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -76,6 +76,8 @@ steps:
     sourceFolder: $(Build.SourcesDirectory)\src\bin\${{ parameters.configuration }}\netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)\..\..\Microsoft.Azure.Functions.ExtensionBundle.Preview\**\bin
+    overWrite: true
+    ignoreMakeDirErrors: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: CopyFiles@2
@@ -84,6 +86,8 @@ steps:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)/../../Microsoft.Azure.Functions.ExtensionBundle.Preview/**/bin
+    overWrite: true
+    ignoreMakeDirErrors: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -78,7 +78,6 @@ steps:
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)\bin
     overWrite: true
-    ignoreMakeDirErrors: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: CopyFiles@2
@@ -88,7 +87,6 @@ steps:
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
-    ignoreMakeDirErrors: true
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
         private const string Collation = "Collation";
 
-        private const int DEFAULT_TABLE_INFO_CACHE_TIMEOUT_MIN = 10;
+        private const int AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MINUTES = 10;
 
         private readonly IConfiguration _configuration;
         private readonly SqlAttribute _attribute;
@@ -174,13 +174,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 ObjectCache cachedTables = MemoryCache.Default;
                 var tableInfo = cachedTables[cacheKey] as TableInformation;
 
-                int timeout = DEFAULT_TABLE_INFO_CACHE_TIMEOUT_MIN;
-                string timeoutEnvVar = Environment.GetEnvironmentVariable("AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MIN");
+                int timeout = AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MINUTES;
+                string timeoutEnvVar = Environment.GetEnvironmentVariable("AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MINUTES");
                 if (!string.IsNullOrEmpty(timeoutEnvVar))
                 {
                     if (int.TryParse(timeoutEnvVar, NumberStyles.Integer, CultureInfo.InvariantCulture, out timeout))
                     {
                         this._logger.LogDebugWithThreadId($"Overriding default table info cache timeout with new value {timeout}");
+                    }
+                    else
+                    {
+                        timeout = AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MINUTES;
                     }
                 }
 

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// - The functionName is different than its route.<br/>
         /// - You can start multiple functions by passing in a space-separated list of function names.<br/>
         /// </remarks>
-        protected void StartFunctionHost(string functionName, SupportedLanguages language, bool useTestFolder = false, DataReceivedEventHandler customOutputHandler = null)
+        protected void StartFunctionHost(string functionName, SupportedLanguages language, bool useTestFolder = false, DataReceivedEventHandler customOutputHandler = null, Dictionary<string, string> environmentVariables = null)
         {
             string workingDirectory = language == SupportedLanguages.CSharp && useTestFolder ? GetPathToBin() : Path.Combine(GetPathToBin(), "SqlExtensionSamples", Enum.GetName(typeof(SupportedLanguages), language));
             if (!Directory.Exists(workingDirectory))
@@ -195,6 +195,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 RedirectStandardError = true,
                 UseShellExecute = false
             };
+
+            if (environmentVariables != null)
+            {
+                foreach (KeyValuePair<string, string> variable in environmentVariables)
+                {
+                    startInfo.EnvironmentVariables[variable.Key] = variable.Value;
+                }
+            }
 
             // Always disable telemetry during test runs
             startInfo.EnvironmentVariables[TelemetryOptoutEnvVar] = "1";

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -371,8 +371,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             // Change database collation back to case insensitive
             this.ExecuteNonQuery($"ALTER DATABASE {this.DatabaseName} SET Single_User WITH ROLLBACK IMMEDIATE; ALTER DATABASE {this.DatabaseName} COLLATE Latin1_General_CI_AS; ALTER DATABASE {this.DatabaseName} SET Multi_User;");
 
-            Thread.Sleep(660000); // Wait 11 minutes to ensure table info cache is not hit since database collation was changed
-
             this.SendOutputGetRequest("addproduct-params", query).Wait();
 
             // Verify result

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -352,7 +352,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData()]
         public void AddProductCaseSensitiveTest(SupportedLanguages lang)
         {
-            this.StartFunctionHost(nameof(AddProductParams), lang);
+            // Set table info cache timeout to 0 minutes so that new collation gets picked up
+            var environmentVariables = new Dictionary<string, string>()
+            {
+                { "AZ_FUNC_TABLE_INFO_CACHE_TIMEOUT_MINUTES", "0" }
+            };
+            this.StartFunctionHost(nameof(AddProductParams), lang, false, null, environmentVariables);
 
             // Change database collation to case sensitive
             this.ExecuteNonQuery($"ALTER DATABASE {this.DatabaseName} SET Single_User WITH ROLLBACK IMMEDIATE; ALTER DATABASE {this.DatabaseName} COLLATE Latin1_General_CS_AS; ALTER DATABASE {this.DatabaseName} SET Multi_User;");

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.StartFunctionHost(nameof(AddProductParams), lang);
 
             // Change database collation to case sensitive
-            this.ExecuteNonQuery($"ALTER DATABASE {this.DatabaseName} COLLATE Latin1_General_CS_AS");
+            this.ExecuteNonQuery($"ALTER DATABASE {this.DatabaseName} SET Single_User WITH ROLLBACK IMMEDIATE; ALTER DATABASE {this.DatabaseName} COLLATE Latin1_General_CS_AS; ALTER DATABASE {this.DatabaseName} SET Multi_User;");
 
             var query = new Dictionary<string, string>()
             {
@@ -369,7 +369,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproduct-params", query).Wait());
 
             // Change database collation back to case insensitive
-            this.ExecuteNonQuery($"ALTER DATABASE {this.DatabaseName} COLLATE Latin1_General_CI_AS");
+            this.ExecuteNonQuery($"ALTER DATABASE {this.DatabaseName} SET Single_User WITH ROLLBACK IMMEDIATE; ALTER DATABASE {this.DatabaseName} COLLATE Latin1_General_CI_AS; ALTER DATABASE {this.DatabaseName} SET Multi_User;");
+
+            Thread.Sleep(660000); // Wait 11 minutes to ensure table info cache is not hit since database collation was changed
 
             this.SendOutputGetRequest("addproduct-params", query).Wait();
 


### PR DESCRIPTION
This PR adds a task in the build pipeline to copy the latest sql dll to the extension bundle so that the latest changes can be used for non-CSharp tests. Passing ad hoc build https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=174829&view=results

I also realized that the case sensitive test was failing after this PR: https://github.com/Azure/azure-functions-sql-extension/pull/388 (my bad for not noticing that the PR validation was not running when I merged in the PR). The test failed because we cache the table info for 10 minutes so when we change the table collation back to case insensitive, SqlAsyncCollector still thinks the collation is case sensitive.

I couldn't figure out why the cache was being missed previously (the cache was empty during the second upsert) and I didn't change the caching logic is this PR https://github.com/Azure/azure-functions-sql-extension/pull/388 so not sure what exact change caused the table caching to work.