### PR TITLE
Fix polling size override using wrong configuration value

### DIFF
--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
             // Check if there's config settings to override the default batch size/polling interval values
             int? configuredBatchSize = configuration.GetValue<int?>(SqlTriggerConstants.ConfigKey_SqlTrigger_BatchSize);
-            int? configuredPollingInterval = configuration.GetValue<int?>(SqlTriggerConstants.ConfigKey_SqlTrigger_BatchSize);
+            int? configuredPollingInterval = configuration.GetValue<int?>(SqlTriggerConstants.ConfigKey_SqlTrigger_PollingInterval);
             this._batchSize = configuredBatchSize ?? this._batchSize;
             this._pollingIntervalInMs = configuredPollingInterval ?? this._pollingIntervalInMs;
             var monitorStartProps = new Dictionary<TelemetryPropertyName, string>(telemetryProps)

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// Creates a DataReceievedEventHandler that will wait for the specified regex and then check that
         /// the matched group matches the expected value.
         /// </summary>
-        /// <param name="taskCompletionSource">The task completion source to signal when the value is receieved</param>
+        /// <param name="taskCompletionSource">The task completion source to signal when the value is received</param>
         /// <param name="regex">The regex. This must have a single group match for the specific value being looked for</param>
         /// <param name="valueName">The name of the value to output if the match fails</param>
         /// <param name="expectedValue">The value expected to be equal to the matched group from the regex</param>

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// <param name="regex">The regex. This must have a single group match for the specific value being looked for</param>
         /// <param name="valueName">The name of the value to output if the match fails</param>
         /// <param name="expectedValue">The value expected to be equal to the matched group from the regex</param>
-        /// <returns></returns>
+        /// <returns>The event handler</returns>
         public static DataReceivedEventHandler CreateOutputReceievedHandler(TaskCompletionSource<bool> taskCompletionSource, string regex, string valueName, string expectedValue)
         {
             return (object sender, DataReceivedEventArgs e) =>

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [Fact]
         public async Task BatchSizeOverrideTriggerTest()
         {
-            // Use enough items for the default batch size to require 4 batches but then
+            // Use enough items to require 4 batches to be processed but then
             // set the batch size to the same value so they can all be processed in one
             // batch. The test will only wait for ~1 batch worth of time so will timeout
             // if the batch size isn't actually changed

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 id => $"Product {id}",
                 id => id * 100,
                 this.GetBatchProcessingTimeout(firstId, lastId, batchSize: batchSize));
-            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(5000));
+            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(5000), "Timed out waiting for BatchSize configuration message");
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             // only wait for the expected time and timeout if the default polling
             // interval isn't actually modified. 
             const int lastId = SqlTableChangeMonitor<object>.DefaultBatchSize * 5;
-            const int pollingIntervalMs = 75;
+            const int pollingIntervalMs = SqlTableChangeMonitor<object>.DefaultPollingIntervalMs / 2;
             this.EnableChangeTrackingForTable("Products");
             var taskCompletionSource = new TaskCompletionSource<bool>();
             DataReceivedEventHandler handler = TestUtils.CreateOutputReceievedHandler(
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 id => $"Product {id}",
                 id => id * 100,
                 this.GetBatchProcessingTimeout(firstId, lastId, pollingIntervalMs: pollingIntervalMs));
-            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(5000));
+            await taskCompletionSource.Task.TimeoutAfter(TimeSpan.FromSeconds(5000), "Timed out waiting for PollingInterval configuration message");
         }
 
         /// <summary>


### PR DESCRIPTION
This was broken in https://github.com/Azure/azure-functions-sql-extension/pull/376 (copypaste typo)

It wasn't caught by the test because the default values were changed but the tests hadn't been updated with the new values. I fixed them to use the default values defined in the trigger code directly so this doesn't happen again if those are changed in the future. 

I also added another check to watch for the log message we send to indicate what the batchSize/pollingInterval values are as a secondary verification. 