### PR TITLE
Use merge query for renewing leases

### DIFF
--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -745,15 +745,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 // These are the internal column values that we use. Note that we use SYS_CHANGE_VERSION because that's
                 // the new version - the _az_func_ChangeVersion has the old version 
                 .Concat(new string[] { "SYS_CHANGE_VERSION bigint", "_az_func_AttemptCount int" });
-            IList<string> bracketedPrimaryKeys = this._primaryKeyColumns.Select(p => p.name.AsBracketQuotedString()).ToList();
+            IEnumerable<string> bracketedPrimaryKeys = this._primaryKeyColumns.Select(p => p.name.AsBracketQuotedString());
 
             // Create the query that the merge statement will match the rows on
-            var primaryKeyMatchingQuery = new StringBuilder($"ExistingData.{bracketedPrimaryKeys[0]} = NewData.{bracketedPrimaryKeys[0]}");
-            foreach (string primaryKey in bracketedPrimaryKeys.Skip(1))
-            {
-                primaryKeyMatchingQuery.Append($" AND ExistingData.{primaryKey} = NewData.{primaryKey}");
-            }
-
+            string primaryKeyMatchingQuery = string.Join(" AND ", bracketedPrimaryKeys.Select(key => $"ExistingData.{key} = NewData.{key}"));
             const string acquireLeasesCte = "acquireLeasesCte";
             const string rowDataParameter = "@rowData";
             // Create the merge query that will either update the rows that already exist or insert a new one if it doesn't exist

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -777,7 +777,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <returns>The SqlCommand populated with the query and appropriate parameters</returns>
         private SqlCommand BuildGetUnprocessedChangesCommand(SqlConnection connection)
         {
-            string leasesTableJoinCondition = string.Join(" AND ", this._primaryKeyColumns.Select(col => $"c.{col.AsBracketQuotedString()} = l.{col.AsBracketQuotedString()}"));
+            string leasesTableJoinCondition = string.Join(" AND ", this._primaryKeyColumns.Select(col => $"c.{col.name.AsBracketQuotedString()} = l.{col.name.AsBracketQuotedString()}"));
 
             string getUnprocessedChangesQuery = $@"
                 DECLARE @last_sync_version bigint;

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -776,7 +776,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             var command = new SqlCommand(query, connection, transaction);
             SqlParameter par = command.Parameters.Add(rowDataParameter, SqlDbType.NVarChar, -1);
             string rowData = JsonConvert.SerializeObject(rows);
-            this._logger.LogInformation(rowData);
             par.Value = rowData;
             return command;
         }

--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public const string LeasesTableChangeVersionColumnName = "_az_func_ChangeVersion";
         public const string LeasesTableAttemptCountColumnName = "_az_func_AttemptCount";
         public const string LeasesTableLeaseExpirationTimeColumnName = "_az_func_LeaseExpirationTime";
-
+        public const string SysChangeVersionColumnName = "SYS_CHANGE_VERSION";
         /// <summary>
         /// The column names that are used in internal state tables and so can't exist in the target table
         /// since that shares column names with the primary keys from each user table being monitored.

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         this._userFunctionId,
                         leasesTableName,
                         userTableColumns,
-                        primaryKeyColumns.Select(col => col.name).ToList(),
+                        primaryKeyColumns,
                         this._executor,
                         this._logger,
                         this._configuration,


### PR DESCRIPTION
While I was investigating timeouts that were happening during the BatchSizeOverride tests I noticed that the renew leases query seemed to be the main cause of the issue - because of recent changes to the tests we were greatly increasing the number of items being processed at once which meant that the query being generated was a huge number (400 in this case) of INSERT/UPDATE statements that were all being executed sequentially with their own table locks. 

When there's only 10 items this isn't too bad - but with 400 items I started seeing it take >1sec to process all those statements. This then caused the test to fail because it never got the trigger events it was waiting on in the time it expected.

To fix this I'm switching to use a merge statement like we do elsewhere so that we can update all the rows in a single statement. It takes in the serialized row data (containing the list of rows to renew leases for) and creates a table from that and then merges that in with the leases table, either creating or updating the values as needed.

Now I'm seeing <50ms updates for 400 rows. 