### PR TITLE
Remove developers list from pom.xml

### DIFF
--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -40,14 +40,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <developers>
-    <developer>
-      <id>LucyZhang</id>
-      <name>Lucy Zhang</name>
-      <email>luczhan@microsoft.com</email>
-    </developer>
-  </developers>
-
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>


### PR DESCRIPTION
This isn't a required field and we shouldn't be adding specific names on libraries like this