### PR TITLE
Specify pool for build java library stage

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -85,5 +85,9 @@ stages:
   jobs:
   - job: BuildJavaLibrary
     displayName: Build Java Library
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
     steps:
     - template: build-release-java.yml


### PR DESCRIPTION
Seems like the pipeline can sometimes fail if the pool vmImage is not specified so adding the default 'ubuntu-latest' image to the java stage. Ran an ad-hoc build to verify it is working correctly - https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=177134&view=logs&j=8284a43e-2cd8-5cf9-04d1-6e290abdc0f8&t=54507b4f-0645-58db-92e5-3dcff810ebdb