### PR TITLE
Fix recursive perf project build and add memory diagnoser

### DIFF
--- a/performance/Microsoft.Azure.WebJobs.Extensions.Sql.Performance.csproj
+++ b/performance/Microsoft.Azure.WebJobs.Extensions.Sql.Performance.csproj
@@ -25,9 +25,9 @@
 
   <!-- Copy C# Samples output to BenchmarkDotNet project bin (https://github.com/dotnet/BenchmarkDotNet/issues/946) -->
   <ItemGroup>
-    <None Include="$(OutDir)\**\*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <Link>%(RecursiveDir)\%(Filename)%(Extension)</Link>
+    <None Include="$(OutDir)\SqlExtensionSamples\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>SqlExtensionSamples\%(RecursiveDir)\%(Filename)%(Extension)</Link>
       <Visible>True</Visible>
     </None>
   </ItemGroup>

--- a/performance/SqlInputBindingPerformance.cs
+++ b/performance/SqlInputBindingPerformance.cs
@@ -11,6 +11,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 {
+    [MemoryDiagnoser]
     public class SqlInputBindingPerformance : IntegrationTestBase
     {
         [GlobalSetup]

--- a/performance/SqlOutputBindingPerformance.cs
+++ b/performance/SqlOutputBindingPerformance.cs
@@ -13,6 +13,7 @@ using BenchmarkDotNet.Attributes;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 {
+    [MemoryDiagnoser]
     public class SqlOutputBindingPerformance : IntegrationTestBase
     {
         [GlobalSetup]


### PR DESCRIPTION
1. We were copying over the entire output folder for each build, which included a ton of stuff we don't necessarily need - including the generated runtime folder used when running the tests. This could result in recursively copying these output folders if they weren't properly cleaned up which meant the builds would get longer and longer (I was to the point where I was copying multiple GB of files each time I built)

Fixed it to just copy the samples folder since that's all we need

2. Added MemoryDiagnoser (https://benchmarkdotnet.org/articles/configs/diagnosers.html) so we get memory statistics as well

e.g.

|          Method | count |    Mean |    Error |   StdDev |     Gen 0 |     Gen 1 | Allocated |
|---------------- |------ |--------:|---------:|---------:|----------:|----------:|----------:|
| GetProductsTest |     1 | 2.059 s | 0.0107 s | 0.0095 s | 1000.0000 | 1000.0000 |     36 KB |
| GetProductsTest |    10 | 2.052 s | 0.0137 s | 0.0121 s | 1000.0000 | 1000.0000 |     37 KB |
| GetProductsTest |   100 | 2.059 s | 0.0090 s | 0.0084 s | 1000.0000 | 1000.0000 |     41 KB |

> // * Legends *
>   count     : Value of the 'count' parameter
>   Mean      : Arithmetic mean of all measurements
>   Error     : Half of 99.9% confidence interval
>   StdDev    : Standard deviation of all measurements
>   Gen 0     : GC Generation 0 collects per 1000 operations
>   Gen 1     : GC Generation 1 collects per 1000 operations
>   Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
>   1 s       : 1 Second (1 sec)