### PR TITLE
Perf test fixes/improvements

### DIFF
--- a/performance/.editorconfig
+++ b/performance/.editorconfig
@@ -1,0 +1,9 @@
+# See https://github.com/dotnet/roslyn-analyzers/blob/main/.editorconfig for an example on different settings and how they're used
+
+[*.cs]
+
+# Disabled
+dotnet_diagnostic.CA1309.severity = silent # Use ordinal StringComparison - this isn't important for tests and just adds clutter
+dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn't important for tests and just adds clutter
+dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
+dotnet_diagnostic.CA2201.severity = silent # Do not raise reserved exception types - tests can throw whatever they want

--- a/performance/SqlTriggerBindingPerformance.cs
+++ b/performance/SqlTriggerBindingPerformance.cs
@@ -4,17 +4,16 @@
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
-using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration;
 using BenchmarkDotNet.Attributes;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 {
-    public class SqlTriggerBindingPerformance : SqlTriggerBindingIntegrationTests
+    [MemoryDiagnoser]
+    public class SqlTriggerBindingPerformance : SqlTriggerBindingPerformanceTestBase
     {
         [GlobalSetup]
         public void GlobalSetup()
         {
-            this.EnableChangeTrackingForTable("Products");
             this.StartFunctionHost(nameof(ProductsTrigger), SupportedLanguages.CSharp);
         }
 
@@ -33,19 +32,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
                 id => $"Product {id}",
                 id => id * 100,
                 this.GetBatchProcessingTimeout(1, count));
-        }
-
-        [IterationCleanup]
-        public void IterationCleanup()
-        {
-            // Delete all rows in Products table after each iteration
-            this.ExecuteNonQuery("TRUNCATE TABLE Products");
-        }
-
-        [GlobalCleanup]
-        public void GlobalCleanup()
-        {
-            this.Dispose();
         }
     }
 }

--- a/performance/SqlTriggerBindingPerformanceTestBase.cs
+++ b/performance/SqlTriggerBindingPerformanceTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
             this.DisposeFunctionHosts();
             this.SetChangeTrackingForTable("Products", false);
             // Delete all rows in Products table after each iteration so we start fresh each time
-            this.ExecuteNonQuery("DELETE FROM Products");
+            this.ExecuteNonQuery("TRUNCATE TABLE Products");
             // Delete the leases table, otherwise we may end up getting blocked by leases from a previous run
             this.ExecuteNonQuery(@"DECLARE @cmd varchar(100)
 DECLARE cmds CURSOR FOR

--- a/performance/SqlTriggerBindingPerformanceTestBase.cs
+++ b/performance/SqlTriggerBindingPerformanceTestBase.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
+{
+    public class SqlTriggerBindingPerformanceTestBase : SqlTriggerBindingIntegrationTests
+    {
+        [IterationSetup]
+        public void IterationSetup()
+        {
+            this.SetChangeTrackingForTable("Products", true);
+        }
+
+        [IterationCleanup]
+        public void IterationCleanup()
+        {
+            this.DisposeFunctionHosts();
+            this.SetChangeTrackingForTable("Products", false);
+            // Delete all rows in Products table after each iteration so we start fresh each time
+            this.ExecuteNonQuery("DELETE FROM Products");
+            // Delete the leases table, otherwise we may end up getting blocked by leases from a previous run
+            this.ExecuteNonQuery(@"DECLARE @cmd varchar(100)
+DECLARE cmds CURSOR FOR
+SELECT 'DROP TABLE az_func.' + Name + ''
+FROM sys.tables
+WHERE Name LIKE 'Leases_%'
+
+OPEN cmds
+WHILE 1 = 1
+BEGIN
+    FETCH cmds INTO @cmd
+    IF @@fetch_status != 0 BREAK
+    EXEC(@cmd)
+END
+CLOSE cmds;
+DEALLOCATE cmds");
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            this.Dispose();
+        }
+    }
+}

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -394,18 +394,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 this.LogOutput($"Failed to close connection. Error: {e1.Message}");
             }
 
-            foreach (Process functionHost in this.FunctionHostList)
-            {
-                try
-                {
-                    functionHost.Kill();
-                    functionHost.Dispose();
-                }
-                catch (Exception e2)
-                {
-                    this.LogOutput($"Failed to stop function host, Error: {e2.Message}");
-                }
-            }
+            this.DisposeFunctionHosts();
 
             try
             {
@@ -430,6 +419,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             }
 
             GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes all the running function hosts
+        /// </summary>
+        protected void DisposeFunctionHosts()
+        {
+            foreach (Process functionHost in this.FunctionHostList)
+            {
+                try
+                {
+                    functionHost.Kill();
+                    functionHost.Dispose();
+                }
+                catch (Exception e2)
+                {
+                    this.LogOutput($"Failed to stop function host, Error: {e2.Message}");
+                }
+            }
+            this.FunctionHostList.Clear();
         }
 
         protected async Task<HttpResponseMessage> SendInputRequest(string functionName, string query = "")

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -433,9 +433,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                     functionHost.Kill();
                     functionHost.Dispose();
                 }
-                catch (Exception e2)
+                catch (Exception ex)
                 {
-                    this.LogOutput($"Failed to stop function host, Error: {e2.Message}");
+                    this.LogOutput($"Failed to stop function host, Error: {ex.Message}");
                 }
             }
             this.FunctionHostList.Clear();

--- a/test/README.md
+++ b/test/README.md
@@ -56,7 +56,7 @@ Our integration tests are based on functions from the samples project. To run in
                this.StartFunctionHost(nameof(<FUNCTIONNAME>), lang); // Replace <FUNCTIONNAME> with the class name of the function this test is running against
             // test code here
         }
-   ```  
+   ```
    Ex: When the test has parameters:
 
    ```
@@ -87,3 +87,19 @@ Our integration tests are based on functions from the samples project. To run in
             // test code here
         }
    ```
+
+## Troubleshooting Tests
+
+This section lists some things to try to help troubleshoot test failures
+
+### Enable debug logging on the Function
+
+Enabling debug logging can greatly increase the information available which can help track down issues or understand at least where the problem may be. To enable debug logging for the Function open [host.json](../samples/samples-csharp/host.json) and add the following property to the `logLevel` section, then rebuild and re-run your test.
+
+```json
+"logLevel": {
+    "default": "Debug"
+}
+```
+
+WARNING : Doing this will add a not-insignificant overhead to the test run duration from writing all the additional content to the log files, which may cause timeouts to occur in tests. If this happens you can temporarily increase those timeouts while debug logging is enabled to avoid having unexpected failures.


### PR DESCRIPTION
1. Add editorconfig with same stuff we ignore in test projects since we don't need to be as strict here
2. Add MemoryDiagnoser to trigger test
3. Move common stuff to base class - I'll be adding more trigger perf tests here soon which will reuse those
4. Disable/Re-enable change tracking on the table after/before each test so that we start with a clean slate each time 
5. Delete Leases table after each run, otherwise we run into an issue where the functions are killed before they can release their leases and so end up skipping over the rows since the IDs are reused across multiple runs. This is kind of messy and would be worth revisiting in the future 
6. Adding logging statement to tests when they start waiting for product changes to come through, this can help figure out timeout issues since it tells you when it's actually started watching so you can see what it was doing before it timed out
7. Add README section on troubleshooting tests on enabling debug logging. Made https://github.com/Azure/azure-functions-sql-extension/issues/438 for tracking enabling this for all test runs 