### PR TITLE
Throw exception for scaling configuration invalid value

### DIFF
--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             this._maxChangesPerWorker = configuredMaxChangesPerWorker ?? DefaultMaxChangesPerWorker;
             if (this._maxChangesPerWorker <= 0)
             {
-                throw new ArgumentException($"Invalid value for configuration setting '{ConfigKey_SqlTrigger_MaxChangesPerWorker}'. Ensure that the value is a positive integer.");
+                throw new InvalidOperationException($"Invalid value for configuration setting '{ConfigKey_SqlTrigger_MaxChangesPerWorker}'. Ensure that the value is a positive integer.");
             }
         }
 

--- a/test/Unit/TriggerBinding/SqlTriggerListenerTests.cs
+++ b/test/Unit/TriggerBinding/SqlTriggerListenerTests.cs
@@ -232,20 +232,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [InlineData("-1")]
         [InlineData("0")]
         [InlineData("10000000000")]
-        public void ScaleMonitorGetScaleStatus_InvalidUserConfiguredMaxChangesPerWorker_UsesDefaultValue(string maxChangesPerWorker)
+        public void InvalidUserConfiguredMaxChangesPerWorker(string maxChangesPerWorker)
         {
-            (IScaleMonitor<SqlTriggerMetrics> monitor, _) = GetScaleMonitor(maxChangesPerWorker);
+            (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
+            Mock<IConfiguration> mockConfiguration = CreateMockConfiguration(maxChangesPerWorker);
 
-            ScaleStatusContext context;
-            ScaleStatus scaleStatus;
-
-            context = GetScaleStatusContext(new int[] { 0, 0, 0, 0, 10000 }, 10);
-            scaleStatus = monitor.GetScaleStatus(context);
-            Assert.Equal(ScaleVote.None, scaleStatus.Vote);
-
-            context = GetScaleStatusContext(new int[] { 0, 0, 0, 0, 10001 }, 10);
-            scaleStatus = monitor.GetScaleStatus(context);
-            Assert.Equal(ScaleVote.ScaleOut, scaleStatus.Vote);
+            Assert.Throws<ArgumentException>(() => new SqlTriggerListener<object>("testConnectionString", "testTableName", "testUserFunctionId", Mock.Of<ITriggeredFunctionExecutor>(), mockLogger.Object, mockConfiguration.Object));
         }
 
         private static IScaleMonitor<SqlTriggerMetrics> GetScaleMonitor(string tableName, string userFunctionId)

--- a/test/Unit/TriggerBinding/SqlTriggerListenerTests.cs
+++ b/test/Unit/TriggerBinding/SqlTriggerListenerTests.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
             Mock<IConfiguration> mockConfiguration = CreateMockConfiguration(maxChangesPerWorker);
 
-            Assert.Throws<ArgumentException>(() => new SqlTriggerListener<object>("testConnectionString", "testTableName", "testUserFunctionId", Mock.Of<ITriggeredFunctionExecutor>(), mockLogger.Object, mockConfiguration.Object));
+            Assert.Throws<InvalidOperationException>(() => new SqlTriggerListener<object>("testConnectionString", "testTableName", "testUserFunctionId", Mock.Of<ITriggeredFunctionExecutor>(), mockLogger.Object, mockConfiguration.Object));
         }
 
         private static IScaleMonitor<SqlTriggerMetrics> GetScaleMonitor(string tableName, string userFunctionId)


### PR DESCRIPTION
Closes #436 
Changed the behavior of scaling configuration to be consistent with other configuration values.
Also added a condition to throw exception for non-positive integer values as this would not result in exception, and cause the function to scale out infinitely.

