### PR TITLE
Add more perf benchmarks for Trigger

### DIFF
--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -9,9 +9,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
     {
         public static void Main()
         {
-            BenchmarkRunner.Run<SqlInputBindingPerformance>();
-            BenchmarkRunner.Run<SqlOutputBindingPerformance>();
-            BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+            // BenchmarkRunner.Run<SqlInputBindingPerformance>();
+            // BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+            // BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
+            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
+            // BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
+            BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
         }
     }
 }

--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
     {
         public static void Main()
         {
-            // BenchmarkRunner.Run<SqlInputBindingPerformance>();
-            // BenchmarkRunner.Run<SqlOutputBindingPerformance>();
-            // BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
-            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
-            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
-            // BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
+            BenchmarkRunner.Run<SqlInputBindingPerformance>();
+            BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+            BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+            BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
+            BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
+            BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
             BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
         }
     }

--- a/performance/SqlTriggerBindingPerformance_Parallelization.cs
+++ b/performance/SqlTriggerBindingPerformance_Parallelization.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
         [Benchmark]
         [Arguments(2)]
         [Arguments(5)]
-        [Arguments(10)]
         public async Task MultiHost(int hostCount)
         {
             for (int i = 0; i < hostCount; ++i)

--- a/performance/SqlTriggerBindingPerformance_Parallelization.cs
+++ b/performance/SqlTriggerBindingPerformance_Parallelization.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
+{
+    [MemoryDiagnoser]
+    public class SqlTriggerBindingPerformance_Parallelization : SqlTriggerBindingPerformanceTestBase
+    {
+        [Benchmark]
+        [Arguments(2)]
+        [Arguments(5)]
+        [Arguments(10)]
+        public async Task MultiHost(int hostCount)
+        {
+            for (int i = 0; i < hostCount; ++i)
+            {
+                this.StartFunctionHost(nameof(ProductsTrigger), SupportedLanguages.CSharp);
+            }
+
+            int firstId = 1;
+            int lastId = 90;
+            await this.WaitForProductChanges(
+                firstId,
+                lastId,
+                SqlChangeOperation.Insert,
+                () => { this.InsertProducts(firstId, lastId); return Task.CompletedTask; },
+                id => $"Product {id}",
+                id => id * 100,
+                this.GetBatchProcessingTimeout(firstId, lastId));
+
+            firstId = 1;
+            lastId = 60;
+            // All table columns (not just the columns that were updated) would be returned for update operation.
+            await this.WaitForProductChanges(
+                firstId,
+                lastId,
+                SqlChangeOperation.Update,
+                () => { this.UpdateProducts(firstId, lastId); return Task.CompletedTask; },
+                id => $"Updated Product {id}",
+                id => id * 100,
+                this.GetBatchProcessingTimeout(firstId, lastId));
+
+            firstId = 31;
+            lastId = 90;
+            // The properties corresponding to non-primary key columns would be set to the C# type's default values
+            // (null and 0) for delete operation.
+            await this.WaitForProductChanges(
+                firstId,
+                lastId,
+                SqlChangeOperation.Delete,
+                () => { this.DeleteProducts(firstId, lastId); return Task.CompletedTask; },
+                _ => null,
+                _ => 0,
+                this.GetBatchProcessingTimeout(firstId, lastId));
+        }
+    }
+}

--- a/performance/SqlTriggerPerformance_BatchOverride.cs
+++ b/performance/SqlTriggerPerformance_BatchOverride.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using BenchmarkDotNet.Attributes;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
+{
+    [MemoryDiagnoser]
+    public class SqlTriggerBindingPerformance_BatchOverride : SqlTriggerBindingPerformanceTestBase
+    {
+        [Benchmark]
+        [Arguments(10, 1000)]
+        [Arguments(100, 1000)]
+        [Arguments(1000, 1000)]
+        [Arguments(5000, 1000)]
+        public async Task Run(int count, int batchSize)
+        {
+            this.StartFunctionHost(
+                nameof(ProductsTrigger),
+                SupportedLanguages.CSharp,
+                environmentVariables: new Dictionary<string, string>() {
+                    { "Sql_Trigger_BatchSize", batchSize.ToString() }
+                });
+            await this.WaitForProductChanges(
+                1,
+                count,
+                SqlChangeOperation.Insert,
+                () => { this.InsertProducts(1, count); return Task.CompletedTask; },
+                id => $"Product {id}",
+                id => id * 100,
+                this.GetBatchProcessingTimeout(1, count, batchSize: batchSize));
+        }
+    }
+}

--- a/performance/SqlTriggerPerformance_Overrides.cs
+++ b/performance/SqlTriggerPerformance_Overrides.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using BenchmarkDotNet.Attributes;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
+{
+    [MemoryDiagnoser]
+    public class SqlTriggerPerformance_Overrides : SqlTriggerBindingPerformanceTestBase
+    {
+        [Benchmark]
+        [Arguments(10, 1000, 500)]
+        [Arguments(10, 1000, 100)]
+        [Arguments(10, 1000, 10)]
+        [Arguments(10, 1000, 1)]
+        [Arguments(100, 1000, 500)]
+        [Arguments(100, 1000, 100)]
+        [Arguments(100, 1000, 10)]
+        [Arguments(100, 1000, 1)]
+        [Arguments(1000, 1000, 500)]
+        [Arguments(1000, 1000, 100)]
+        [Arguments(1000, 1000, 10)]
+        [Arguments(1000, 1000, 1)]
+        [Arguments(5000, 1000, 500)]
+        [Arguments(5000, 1000, 100)]
+        [Arguments(5000, 1000, 10)]
+        [Arguments(5000, 1000, 1)]
+        public async Task Run(int count, int batchSize, int pollingIntervalMs)
+        {
+            this.StartFunctionHost(
+                nameof(ProductsTrigger),
+                SupportedLanguages.CSharp,
+                environmentVariables: new Dictionary<string, string>() {
+                    { "Sql_Trigger_BatchSize", batchSize.ToString() },
+                    { "Sql_Trigger_PollingIntervalMs", pollingIntervalMs.ToString() }
+                });
+            await this.WaitForProductChanges(
+                1,
+                count,
+                SqlChangeOperation.Insert,
+                () => { this.InsertProducts(1, count); return Task.CompletedTask; },
+                id => $"Product {id}",
+                id => id * 100,
+                this.GetBatchProcessingTimeout(1, count, batchSize: batchSize));
+        }
+    }
+}

--- a/performance/SqlTriggerPerformance_PollingIntervalOverride.cs
+++ b/performance/SqlTriggerPerformance_PollingIntervalOverride.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using BenchmarkDotNet.Attributes;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
+{
+    [MemoryDiagnoser]
+    public class SqlTriggerBindingPerformance_PollingIntervalOverride : SqlTriggerBindingPerformanceTestBase
+    {
+        [Benchmark]
+        [Arguments(1000, 500)]
+        [Arguments(1000, 100)]
+        [Arguments(1000, 10)]
+        [Arguments(1000, 1)]
+        public async Task Run(int count, int pollingIntervalMs)
+        {
+            this.StartFunctionHost(
+                nameof(ProductsTrigger),
+                SupportedLanguages.CSharp,
+                environmentVariables: new Dictionary<string, string>() {
+                    { "Sql_Trigger_PollingIntervalMs", pollingIntervalMs.ToString() }
+                });
+            await this.WaitForProductChanges(
+                1,
+                count,
+                SqlChangeOperation.Insert,
+                () => { this.InsertProducts(1, count); return Task.CompletedTask; },
+                id => $"Product {id}",
+                id => id * 100,
+                this.GetBatchProcessingTimeout(1, count, pollingIntervalMs: pollingIntervalMs));
+        }
+    }
+}


### PR DESCRIPTION
Getting in the latest tests I've been working on. I will likely be coming back and cleaning these up more later (for example combining the override tests all into one file) but for now splitting them out like this makes it easier/faster to run since the tests can take a long time with having to spin up a new host each iteration. 