### PR TITLE
Deserialize objects to compare integration tests

### DIFF
--- a/samples/samples-csharp/Common/Product.cs
+++ b/samples/samples-csharp/Common/Product.cs
@@ -10,6 +10,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common
         public string Name { get; set; }
 
         public int Cost { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Product)
+            {
+                var that = obj as Product;
+                return this.ProductID == that.ProductID && this.Name == that.Name && this.Cost == that.Cost;
+            }
+            return false;
+        }
     }
 
     public class ProductWithOptionalId

--- a/test/Common/ProductColumnTypes.cs
+++ b/test/Common/ProductColumnTypes.cs
@@ -12,5 +12,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         public DateTime Datetime { get; set; }
 
         public DateTime Datetime2 { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ProductColumnTypes)
+            {
+                var that = obj as ProductColumnTypes;
+                return this.ProductID == that.ProductID && this.Datetime == that.Datetime && this.Datetime2 == that.Datetime2;
+            }
+            return false;
+        }
     }
 }

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -35,10 +35,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts", cost.ToString());
 
             // Verify result
-            string expectedResponse = JsonConvert.SerializeObject(products);
+            Product[] expectedResponse = products;
             string actualResponse = await response.Content.ReadAsStringAsync();
+            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, TestUtils.CleanJsonString(actualResponse), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expectedResponse, actualProductResponse);
         }
 
         [Theory]
@@ -57,10 +58,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts-storedprocedure", cost.ToString());
 
             // Verify result
-            string expectedResponse = JsonConvert.SerializeObject(products);
+            Product[] expectedResponse = products;
             string actualResponse = await response.Content.ReadAsStringAsync();
+            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, TestUtils.CleanJsonString(actualResponse), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expectedResponse, actualProductResponse);
         }
 
         [Theory]
@@ -84,10 +86,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts-nameempty", cost.ToString());
 
             // Verify result
-            string expectedResponse = JsonConvert.SerializeObject(products);
+            Product[] expectedResponse = products;
             string actualResponse = await response.Content.ReadAsStringAsync();
+            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, TestUtils.CleanJsonString(actualResponse), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expectedResponse, actualProductResponse);
         }
 
         [Theory]
@@ -104,11 +107,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             // Run the function
             HttpResponseMessage response = await this.SendInputRequest("getproductsbycost");
 
-            // Verify result
-            string expectedResponse = JsonConvert.SerializeObject(productsWithCost100);
+            /// Verify result
+            Product[] expectedResponse = productsWithCost100;
             string actualResponse = await response.Content.ReadAsStringAsync();
+            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, TestUtils.CleanJsonString(actualResponse), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(expectedResponse, actualProductResponse);
         }
 
         [Theory]

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -177,10 +177,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             HttpResponseMessage response = await this.SendInputRequest("getproducts-columntypesserialization");
             // We expect the datetime and datetime2 fields to be returned in UTC format
-            string expectedResponse = "[{\"ProductId\":999,\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\"}]";
-            string actualResponse = await response.Content.ReadAsStringAsync();
+            ProductColumnTypes[] expectedResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\"}]");
 
-            Assert.Equal(expectedResponse, TestUtils.CleanJsonString(actualResponse), StringComparer.OrdinalIgnoreCase);
+            string actualResponse = await response.Content.ReadAsStringAsync();
+            ProductColumnTypes[] actualProductResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>(actualResponse);
+
+            Assert.Equal(expectedResponse, actualProductResponse);
+
         }
     }
 }

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -35,11 +35,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts", cost.ToString());
 
             // Verify result
-            Product[] expectedResponse = products;
             string actualResponse = await response.Content.ReadAsStringAsync();
             Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, actualProductResponse);
+            Assert.Equal(products, actualProductResponse);
         }
 
         [Theory]
@@ -58,11 +57,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts-storedprocedure", cost.ToString());
 
             // Verify result
-            Product[] expectedResponse = products;
             string actualResponse = await response.Content.ReadAsStringAsync();
             Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, actualProductResponse);
+            Assert.Equal(products, actualProductResponse);
         }
 
         [Theory]
@@ -86,11 +84,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts-nameempty", cost.ToString());
 
             // Verify result
-            Product[] expectedResponse = products;
             string actualResponse = await response.Content.ReadAsStringAsync();
             Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, actualProductResponse);
+            Assert.Equal(products, actualProductResponse);
         }
 
         [Theory]
@@ -107,12 +104,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             // Run the function
             HttpResponseMessage response = await this.SendInputRequest("getproductsbycost");
 
-            /// Verify result
-            Product[] expectedResponse = productsWithCost100;
+            // Verify result
             string actualResponse = await response.Content.ReadAsStringAsync();
             Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
 
-            Assert.Equal(expectedResponse, actualProductResponse);
+            Assert.Equal(productsWithCost100, actualProductResponse);
         }
 
         [Theory]
@@ -183,7 +179,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             ProductColumnTypes[] actualProductResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>(actualResponse);
 
             Assert.Equal(expectedResponse, actualProductResponse);
-
         }
     }
 }


### PR DESCRIPTION
Found issues when I ran tests in PowerShell specifically comparing strings together was not working as we should not expect the returned string to be in order for instance. So we can compare objects instead. 