### PR TITLE
Use app locks for all transactions

### DIFF
--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// of a function are running in parallel.
         ///
         /// The trigger heavily uses transactions to ensure atomic changes, that way if an error occurs during any step of a process we aren't left
-        /// with an incomplete state. Because of this locks are placed on rows that are read/modified during the transaction, but the lock isn't
+        /// with an incomplete state. Because of this, locks are placed on rows that are read/modified during the transaction, but the lock isn't
         /// applied until the statement itself is executed. Some transactions have many statements executed in a row that touch a number of different
         /// tables so it's very easy for two transactions to get in a deadlock depending on the speed they execute their statements and the order they
         /// are processed in.

--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -29,5 +29,41 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public const string ConfigKey_SqlTrigger_BatchSize = "Sql_Trigger_BatchSize";
         public const string ConfigKey_SqlTrigger_PollingInterval = "Sql_Trigger_PollingIntervalMs";
         public const string ConfigKey_SqlTrigger_MaxChangesPerWorker = "Sql_Trigger_MaxChangesPerWorker";
+
+        public const string AppLockResource = "_az_func_Trigger";
+        /// <summary>
+        /// Timeout for acquiring the application lock - 30sec chosen as a reasonable value to ensure we aren't
+        /// hanging infinitely while also giving plenty of time for the blocking transaction to complete. 
+        /// </summary>
+        public const int AppLockTimeoutMs = 30000;
+
+        /// <summary>
+        /// T-SQL statements for getting an application lock. This is used to prevent deadlocks - primarily when multiple instances
+        /// of a function are running in parallel.
+        ///
+        /// The trigger heavily uses transactions to ensure atomic changes, that way if an error occurs during any step of a process we aren't left
+        /// with an incomplete state. Because of this locks are placed on rows that are read/modified during the transaction, but the lock isn't
+        /// applied until the statement itself is executed. Some transactions have many statements executed in a row that touch a number of different
+        /// tables so it's very easy for two transactions to get in a deadlock depending on the speed they execute their statements and the order they
+        /// are processed in.
+        ///
+        /// So to avoid this we use application locks to ensure that anytime we enter a transaction we first guarantee that we're the only transaction
+        /// currently making any changes to the tables, which means that we're guaranteed not to have any deadlocks - albeit at the cost of speed. This
+        /// is acceptable for now, although further investigation could be done into using multiple resources to lock on (such as a different one for each
+        /// table) to increase the parallelization of the transactions.
+        ///
+        /// See the following articles for more information on locking in MSSQL
+        /// https://learn.microsoft.com/sql/relational-databases/sql-server-transaction-locking-and-row-versioning-guide
+        /// https://learn.microsoft.com/sql/t-sql/statements/set-transaction-isolation-level-transact-sql
+        /// https://learn.microsoft.com/sql/relational-databases/system-stored-procedures/sp-getapplock-transact-sql
+        /// </summary>
+        public static readonly string AppLockStatements = $@"DECLARE @result int;
+                EXEC @result = sp_getapplock @Resource = '{AppLockResource}',
+                            @LockMode = 'Exclusive',
+                            @LockTimeout = {AppLockTimeoutMs}
+                IF @result < 0
+                BEGIN
+                    RAISERROR('Unable to acquire exclusive lock on {AppLockResource}. Result = %d', 16, 1, @result)
+                END;";
     }
 }

--- a/src/TriggerBinding/SqlTriggerConstants.cs
+++ b/src/TriggerBinding/SqlTriggerConstants.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public const string ConfigKey_SqlTrigger_PollingInterval = "Sql_Trigger_PollingIntervalMs";
         public const string ConfigKey_SqlTrigger_MaxChangesPerWorker = "Sql_Trigger_MaxChangesPerWorker";
 
+        /// <summary>
+        /// The resource name to use for getting the application lock. We use the same resource name for all instances
+        /// of the function because there is some shared state across all the functions. 
+        /// </summary>
+        /// <remarks>A future improvement could be to make unique application locks for each FuncId/TableId combination so that functions
+        /// working on different tables aren't blocking each other</remarks>
         public const string AppLockResource = "_az_func_Trigger";
         /// <summary>
         /// Timeout for acquiring the application lock - 30sec chosen as a reasonable value to ensure we aren't


### PR DESCRIPTION
## Description
This is to address deadlocks that I started seeing when running benchmarks with multiple hosts. Even just 2 hosts running in parallel would very consistently get in a deadlock after a couple of minutes. I was able to track the deadlock down to the [GetChanges ](https://github.com/Azure/azure-functions-sql-extension/blob/triggerbindings/src/TriggerBinding/SqlTableChangeMonitor.cs#L750) and [UpdateTablesPostInvocation](https://github.com/Azure/azure-functions-sql-extension/blob/triggerbindings/src/TriggerBinding/SqlTableChangeMonitor.cs#L916) - although I did not dig into it further enough to know exactly what table it was deadlocked on.

Explanation copied from the comment : 

```
/// The trigger heavily uses transactions to ensure atomic changes, that way if an error occurs during any step of a process we aren't left
/// with an incomplete state. Because of this locks are placed on rows that are read/modified during the transaction, but the lock isn't
/// applied until the statement itself is executed. Some transactions have many statements executed in a row that touch a number of different
/// tables so it's very easy for two transactions to get in a deadlock depending on the speed they execute their statements and the order they
/// are processed in.
///
/// So to avoid this we use application locks to ensure that anytime we enter a transaction we first guarantee that we're the only transaction
/// currently making any changes to the tables, which means that we're guaranteed not to have any deadlocks - albeit at the cost of speed. This
/// is acceptable for now, although further investigation could be done into using multiple resources to lock on (such as a different one for each
/// table) to increase the parallelization of the transactions.
```

I looked at various ways to change the existing locking to remove the possibility of a deadlock, but in the end I came to the conclusion that with the transaction-based nature of most of our statements and how many things each transaction does that trying to do so would be very risky and maybe even impossible.

The app locking approach is very heavy handed - but it's a very straightforward way to ensure application consistency. 

The main downside with this is that we will take a perf hit when multiple functions are running in parallel. But right now focusing on consistency and correctness is more important to me so I wanted to start with this and then selectively make improvements later so we can be sure they're tested properly. 

## Testing

First part was just using the benchmark parallelization suite. Before this change I would very consistently hit a deadlock within a couple of minutes of running with even just two hosts running in parallel. After the change I was able to run the full suite with both 2 hosts and 5 hosts (which runs each benchmark test 50+ times to generate the histogram)

(note that the overall times include the startup time for the host processes, which is why we're seeing such huge values. I'll be following up with fixing that so it only measures the time taken to get all the change notifications but for purposes of this fix that number isn't directly relevant)

```
SqlTriggerBindingPerformance_Parallelization.MultiHost: Job-FLKWWV(InvocationCount=1, UnrollFactor=1) [hostCount=2]
Runtime = .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT; GC = Concurrent Workstation
Mean = 16.049 s, StdErr = 0.094 s (0.58%), N = 81, StdDev = 0.843 s
Min = 14.720 s, Q1 = 15.258 s, Median = 15.976 s, Q3 = 16.769 s, Max = 17.892 s
IQR = 1.510 s, LowerFence = 12.993 s, UpperFence = 19.035 s
ConfidenceInterval = [15.729 s; 16.369 s] (CI 99.9%), Margin = 0.320 s (1.99% of Mean)
Skewness = 0.37, Kurtosis = 1.9, MValue = 2.65
-------------------- Histogram --------------------
[14.464 s ; 15.014 s) | @@@
[15.014 s ; 15.526 s) | @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
[15.526 s ; 16.044 s) | @@@@@@@
[16.044 s ; 16.555 s) | @@@@@@@@@@@@@@@@@
[16.555 s ; 17.233 s) | @@@@@@@@@@@@@@@
[17.233 s ; 17.762 s) | @@@@@@@
[17.762 s ; 18.148 s) | @
---------------------------------------------------

SqlTriggerBindingPerformance_Parallelization.MultiHost: Job-FLKWWV(InvocationCount=1, UnrollFactor=1) [hostCount=5]
Runtime = .NET 6.0.10 (6.0.1022.47605), X64 RyuJIT; GC = Concurrent Workstation
Mean = 38.582 s, StdErr = 0.221 s (0.57%), N = 57, StdDev = 1.671 s
Min = 35.312 s, Q1 = 37.624 s, Median = 38.795 s, Q3 = 39.644 s, Max = 42.237 s
IQR = 2.020 s, LowerFence = 34.594 s, UpperFence = 42.674 s
ConfidenceInterval = [37.813 s; 39.350 s] (CI 99.9%), Margin = 0.769 s (1.99% of Mean)
Skewness = -0.06, Kurtosis = 2.37, MValue = 2
-------------------- Histogram --------------------
[34.742 s ; 36.062 s) | @@@@@
[36.062 s ; 37.202 s) | @@@@@@@@
[37.202 s ; 38.602 s) | @@@@@@@@@@@@@@
[38.602 s ; 40.013 s) | @@@@@@@@@@@@@@@@@@@@@
[40.013 s ; 41.561 s) | @@@@@@@
[41.561 s ; 42.807 s) | @@
---------------------------------------------------
```

After getting that to pass I compared the execution times of the single host to make sure the app locking didn't have a huge impact on that : 

Without App Locking:
```
|              Method | count |     Mean |    Error |   StdDev | Allocated |
|-------------------- |------ |---------:|---------:|---------:|----------:|
| ProductsTriggerTest |     1 |  1.040 s | 0.0094 s | 0.0088 s |     12 KB |
| ProductsTriggerTest |    10 |  1.052 s | 0.0142 s | 0.0133 s |     26 KB |
| ProductsTriggerTest |   100 |  1.153 s | 0.0085 s | 0.0076 s |    174 KB |
| ProductsTriggerTest |  1000 | 10.565 s | 0.0350 s | 0.0310 s |  1,737 KB |
```

With App Locking:
```
|              Method | count |     Mean |    Error |   StdDev | Allocated |
|-------------------- |------ |---------:|---------:|---------:|----------:|
| ProductsTriggerTest |     1 |  1.042 s | 0.0099 s | 0.0092 s |     11 KB |
| ProductsTriggerTest |    10 |  1.056 s | 0.0098 s | 0.0087 s |     26 KB |
| ProductsTriggerTest |   100 |  1.170 s | 0.0147 s | 0.0137 s |    177 KB |
| ProductsTriggerTest |  1000 | 10.612 s | 0.0396 s | 0.0310 s |  1,718 KB |
```