### PR TITLE
Add more app lock statements

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -408,6 +408,8 @@ This extension collect usage data in order to help us improve your experience. T
     {
         ConsumeChangesLoop,
         Convert,
+        CreateGlobalStateTable,
+        CreateLeasesTable,
         CreateSchema,
         FlushAsync,
         GetCaseSensitivity,


### PR DESCRIPTION
Follow up to https://github.com/Azure/azure-functions-sql-extension/pull/455

Utilize app locking in the listener startup transaction, this should help avoid the race conditions we've seen occasionally on startup. 

Along the way I also added the exception handling that was added in https://github.com/Azure/azure-functions-sql-extension/pull/456 to the other creation statements. While these shouldn't happen with the addition of the app locking it doesn't hurt to have the extra precaution - and at the very least this means we'll now be getting telemetry for when it does happen so we can see if people are still hitting issues there. 

# Testing

## Before Change 

### Single Host

|              Method | count |        Mean |    Error |   StdDev |      Median | Allocated |
|-------------------- |------ |------------:|---------:|---------:|------------:|----------:|
| ProductsTriggerTest |     1 |    931.1 ms |  9.83 ms |  8.71 ms |    930.8 ms |     12 KB |
| ProductsTriggerTest |    10 |    935.0 ms | 11.01 ms |  9.76 ms |    937.9 ms |     26 KB |
| ProductsTriggerTest |   100 |  1,109.5 ms | 23.12 ms | 67.43 ms |  1,134.0 ms |    175 KB |
| ProductsTriggerTest |  1000 | 10,497.1 ms | 52.18 ms | 48.81 ms | 10,482.1 ms |  1,737 KB |

### Multi Host

|    Method | HostCount |    Mean |    Error |   StdDev |   Median | Allocated |
|---------- |---------- |--------:|---------:|---------:|---------:|----------:|
| MultiHost |         2 | 2.437 s | 0.2054 s | 0.6055 s | 2.1257 s |    351 KB |
| MultiHost |         5 | 1.109 s | 0.1222 s | 0.3602 s | 0.9969 s |    336 KB |

## After Change

### Single Host

|              Method | count |        Mean |    Error |    StdDev |      Median | Allocated |
|-------------------- |------ |------------:|---------:|----------:|------------:|----------:|
| ProductsTriggerTest |     1 |    929.5 ms |  9.12 ms |   7.61 ms |    929.0 ms |     12 KB |
| ProductsTriggerTest |    10 |    937.6 ms | 14.87 ms |  11.61 ms |    937.9 ms |     27 KB |
| ProductsTriggerTest |   100 |  1,039.2 ms | 35.89 ms | 105.83 ms |    978.1 ms |    174 KB |
| ProductsTriggerTest |  1000 | 10,529.3 ms | 28.61 ms |  26.76 ms | 10,527.1 ms |  1,716 KB |

### Multi Host

|    Method | HostCount |    Mean |    Error |   StdDev |  Median | Allocated |
|---------- |---------- |--------:|---------:|---------:|--------:|----------:|
| MultiHost |         2 | 2.498 s | 0.2137 s | 0.6301 s | 2.150 s |    341 KB |
| MultiHost |         5 | 1.221 s | 0.1293 s | 0.3792 s | 1.086 s |    342 KB |