### PR TITLE
Add name to java binding interface

### DIFF
--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.microsoft.azure.functions</groupId>
   <artifactId>azure-functions-java-library-sql</artifactId>
-  <version>0.1.0</version> <!-- Update the dependency version in samples-java/pom.xml too if this version is updated. -->
+  <version>0.1.1</version> <!-- Update the dependency version in samples-java/pom.xml too if this version is updated. -->
   <packaging>jar</packaging>
 
   <parent>

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
@@ -15,12 +15,12 @@ import com.microsoft.azure.functions.annotation.CustomBinding;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
-@CustomBinding(direction = "in", name = "sql", type = "sql")
+@CustomBinding(direction = "in", name = "", type = "sql")
 public @interface SQLInput {
     /**
      * The variable name used in function.json.
      */
-    String name() default "sql";
+    String name();
 
     /**
      * Query string or name of stored procedure to be run.

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
@@ -18,6 +18,11 @@ import com.microsoft.azure.functions.annotation.CustomBinding;
 @CustomBinding(direction = "in", name = "sql", type = "sql")
 public @interface SQLInput {
     /**
+     * The variable name used in function.json.
+     */
+    String name() default "sql";
+
+    /**
      * Query string or name of stored procedure to be run.
      */
     String commandText() default "";

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLOutput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLOutput.java
@@ -19,6 +19,11 @@
 @CustomBinding(direction = "out", name = "sql", type = "sql")
 public @interface SQLOutput {
     /**
+     * The variable name used in function.json.
+     */
+    String name() default "sql";
+
+    /**
      * Name of the table to upsert data to.
      */
     String commandText() default "";

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLOutput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLOutput.java
@@ -16,12 +16,12 @@
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.PARAMETER, ElementType.METHOD })
-@CustomBinding(direction = "out", name = "sql", type = "sql")
+@CustomBinding(direction = "out", name = "", type = "sql")
 public @interface SQLOutput {
     /**
      * The variable name used in function.json.
      */
-    String name() default "sql";
+    String name();
 
     /**
      * Name of the table to upsert data to.

--- a/samples/samples-java/pom.xml
+++ b/samples/samples-java/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.microsoft.azure.functions</groupId>
             <artifactId>azure-functions-java-library-sql</artifactId>
-            <version>0.1.0</version>
+            <version>0.1.1</version>
         </dependency>
 
         <dependency>

--- a/samples/samples-java/src/main/java/com/function/AddProductParams.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductParams.java
@@ -29,6 +29,7 @@ public class AddProductParams {
                 route = "addproduct-params")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "product",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<Product> product) {

--- a/samples/samples-java/src/main/java/com/function/AddProductReturnValue.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductReturnValue.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 public class AddProductReturnValue {
     @FunctionName("AddProductReturnValue")
     @SQLOutput(
+        name = "product",
         commandText = "Products",
         connectionStringSetting = "SqlConnectionString")
     public Product run(

--- a/samples/samples-java/src/main/java/com/function/AddProductToTwoTables.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductToTwoTables.java
@@ -23,25 +23,31 @@ import com.function.Common.Product;
 import java.io.IOException;
 import java.util.Optional;
 
-public class AddProduct {
-    @FunctionName("AddProduct")
+public class AddProductToTwoTables {
+    @FunctionName("AddProductToTwoTables")
     public HttpResponseMessage run(
             @HttpTrigger(
                 name = "req",
                 methods = {HttpMethod.POST},
                 authLevel = AuthorizationLevel.ANONYMOUS,
-                route = "addproduct")
+                route = "addproducttotwotables")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
                 name = "product",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
-                OutputBinding<Product> product) throws JsonParseException, JsonMappingException, IOException {
+                OutputBinding<Product> product,
+            @SQLOutput(
+                name = "productWithIdentity",
+                commandText = "ProductsWithIdentity",
+                connectionStringSetting = "SqlConnectionString")
+                OutputBinding<Product> productWithIdentity) throws JsonParseException, JsonMappingException, IOException {
 
         String json = request.getBody().get();
         ObjectMapper mapper = new ObjectMapper();
         Product p = mapper.readValue(json, Product.class);
         product.setValue(p);
+        productWithIdentity.setValue(p);
 
         return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(product).build();
     }

--- a/samples/samples-java/src/main/java/com/function/AddProductWithDefaultPK.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductWithDefaultPK.java
@@ -33,6 +33,7 @@ public class AddProductWithDefaultPK {
                 route = "addproductwithdefaultpk")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "product",
                 commandText = "dbo.ProductsWithDefaultPK",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<ProductWithDefaultPK> product) throws JsonParseException, JsonMappingException, IOException {

--- a/samples/samples-java/src/main/java/com/function/AddProductWithIdentityColumn.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductWithIdentityColumn.java
@@ -28,6 +28,7 @@ public class AddProductWithIdentityColumn {
                 route = "addproductwithidentitycolumn")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "product",
                 commandText = "ProductsWithIdentity",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<ProductWithoutId> product) {

--- a/samples/samples-java/src/main/java/com/function/AddProductWithIdentityColumnIncluded.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductWithIdentityColumnIncluded.java
@@ -29,6 +29,7 @@ public class AddProductWithIdentityColumnIncluded {
                 route = "addproductwithidentitycolumnincluded")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "product",
                 commandText = "ProductsWithIdentity",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<ProductWithOptionalId> product) {

--- a/samples/samples-java/src/main/java/com/function/AddProductWithMultiplePrimaryColumnsAndIdentity.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductWithMultiplePrimaryColumnsAndIdentity.java
@@ -28,6 +28,7 @@ public class AddProductWithMultiplePrimaryColumnsAndIdentity {
                 route = "addproductwithmultipleprimarycolumnsandidentity")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "product",
                 commandText = "ProductsWithMultiplePrimaryColumnsAndIdentity",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<MultiplePrimaryKeyProductWithoutId> product) {

--- a/samples/samples-java/src/main/java/com/function/AddProductsArray.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductsArray.java
@@ -33,6 +33,7 @@ public class AddProductsArray {
                 route = "addproducts-array")
                 HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "products",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<Product[]> products) throws JsonParseException, JsonMappingException, IOException {

--- a/samples/samples-java/src/main/java/com/function/AddProductsWithIdentityColumnArray.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductsWithIdentityColumnArray.java
@@ -28,6 +28,7 @@ public class AddProductsWithIdentityColumnArray {
                 authLevel = AuthorizationLevel.ANONYMOUS,
                 route = "addproductswithidentitycolumnarray") HttpRequestMessage<Optional<String>> request,
             @SQLOutput(
+                name = "products",
                 commandText = "dbo.ProductsWithIdentity",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<ProductWithoutId[]> products) {

--- a/samples/samples-java/src/main/java/com/function/GetProductNamesView.java
+++ b/samples/samples-java/src/main/java/com/function/GetProductNamesView.java
@@ -28,6 +28,7 @@ public class GetProductNamesView {
                 route = "getproduct-namesview")
                 HttpRequestMessage<Optional<String>> request,
             @SQLInput(
+                name = "productNames",
                 commandText = "SELECT * FROM ProductNames",
                 commandType = "Text",
                 connectionStringSetting = "SqlConnectionString")

--- a/samples/samples-java/src/main/java/com/function/GetProducts.java
+++ b/samples/samples-java/src/main/java/com/function/GetProducts.java
@@ -28,6 +28,7 @@ public class GetProducts {
                 route = "getproducts/{cost}")
                 HttpRequestMessage<Optional<String>> request,
             @SQLInput(
+                name = "products",
                 commandText = "SELECT * FROM Products WHERE Cost = @Cost",
                 commandType = "Text",
                 parameters = "@Cost={cost}",

--- a/samples/samples-java/src/main/java/com/function/GetProductsNameEmpty.java
+++ b/samples/samples-java/src/main/java/com/function/GetProductsNameEmpty.java
@@ -28,6 +28,7 @@ public class GetProductsNameEmpty {
                 route = "getproducts-nameempty/{cost}")
                 HttpRequestMessage<Optional<String>> request,
             @SQLInput(
+                name = "products",
                 commandText = "SELECT * FROM Products WHERE Cost = @Cost and Name = @Name",
                 commandType = "Text",
                 parameters = "@Cost={cost},@Name=",

--- a/samples/samples-java/src/main/java/com/function/GetProductsStoredProcedure.java
+++ b/samples/samples-java/src/main/java/com/function/GetProductsStoredProcedure.java
@@ -28,6 +28,7 @@ public class GetProductsStoredProcedure {
                 route = "getproducts-storedprocedure/{cost}")
                 HttpRequestMessage<Optional<String>> request,
             @SQLInput(
+                name = "products",
                 commandText = "SelectProductsCost",
                 commandType = "StoredProcedure",
                 parameters = "@Cost={cost}",

--- a/samples/samples-java/src/main/java/com/function/GetProductsStoredProcedureFromAppSetting.java
+++ b/samples/samples-java/src/main/java/com/function/GetProductsStoredProcedureFromAppSetting.java
@@ -28,6 +28,7 @@ public class GetProductsStoredProcedureFromAppSetting {
                 route = "getproductsbycost")
                 HttpRequestMessage<Optional<String>> request,
             @SQLInput(
+                name = "products",
                 commandText = "%Sp_SelectCost%",
                 commandType = "StoredProcedure",
                 parameters = "@Cost=%ProductCost%",

--- a/samples/samples-java/src/main/java/com/function/QueueTriggerProducts.java
+++ b/samples/samples-java/src/main/java/com/function/QueueTriggerProducts.java
@@ -21,6 +21,7 @@ public class QueueTriggerProducts {
                 connection = "AzureWebJobsStorage")
             String queueMessage,
             @SQLOutput(
+                name = "products",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<Product[]> products) {

--- a/samples/samples-java/src/main/java/com/function/TimerTriggerProducts.java
+++ b/samples/samples-java/src/main/java/com/function/TimerTriggerProducts.java
@@ -20,6 +20,7 @@ public class TimerTriggerProducts {
                 schedule = "*/5 * * * * *")
                 String timerInfo,
             @SQLOutput(
+                name = "products",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<Product[]> products) {


### PR DESCRIPTION
Previously, we could not set the name for the bindings which meant that we would get the following error if we tried to create a function with multiple sql bindings:
`"The 'HttpTriggerJava1' function is in error: Multiple bindings with name 'sql' discovered. Binding names must be unique."`

With this change, name will be required and the current samples have to be updated with a name value to work.