### PR TITLE
Cleanup samples folders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
     "azureFunctions.projectSubpath": "samples/samples-csharp",
-    "azureFunctions.deploySubpath": "samples/samples-csharp/bin/Release/netcoreapp3.1/publish",
+    "azureFunctions.deploySubpath": "samples/samples-csharp/bin/Release/net6/publish",
     "azureFunctions.projectLanguage": "C#",
-    "azureFunctions.projectRuntime": "~3",
+    "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",
     "azureFunctions.preDeployTask": "publish (functions)",
     "omnisharp.enableEditorConfigSupport": true,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -71,7 +71,7 @@
 			"type": "func",
 			"dependsOn": "build (functions)",
 			"options": {
-				"cwd": "${workspaceFolder}/samples/samples-csharp/bin/Debug/netcoreapp3.1"
+				"cwd": "${workspaceFolder}/samples/samples-csharp/bin/Debug/net6"
 			},
 			"command": "host start",
 			"isBackground": true,

--- a/samples/samples-csharp/.vscode/launch.json
+++ b/samples/samples-csharp/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to .NET Functions",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:azureFunctions.pickProcess}"
+    }
+  ]
+}

--- a/samples/samples-csharp/.vscode/settings.json
+++ b/samples/samples-csharp/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "azureFunctions.deploySubpath": "bin/Release/net6/publish",
+  "azureFunctions.projectLanguage": "C#",
+  "azureFunctions.projectRuntime": "~4",
+  "debug.internalConsoleOptions": "neverOpen",
+  "azureFunctions.preDeployTask": "publish (functions)"
+}

--- a/samples/samples-csharp/.vscode/tasks.json
+++ b/samples/samples-csharp/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "clean (functions)",
+      "command": "dotnet",
+      "args": [
+        "clean",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "type": "process",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "build (functions)",
+      "command": "dotnet",
+      "args": [
+        "build",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "type": "process",
+      "dependsOn": "clean (functions)",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "clean release (functions)",
+      "command": "dotnet",
+      "args": [
+        "clean",
+        "--configuration",
+        "Release",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "type": "process",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "publish (functions)",
+      "command": "dotnet",
+      "args": [
+        "publish",
+        "--configuration",
+        "Release",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary"
+      ],
+      "type": "process",
+      "dependsOn": "clean release (functions)",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "type": "func",
+      "dependsOn": "build (functions)",
+      "options": {
+        "cwd": "${workspaceFolder}/bin/Debug/net6"
+      },
+      "command": "host start --verbose",
+      "isBackground": true,
+      "problemMatcher": "$func-dotnet-watch"
+    }
+  ]
+}

--- a/samples/samples-java/local.settings.json
+++ b/samples/samples-java/local.settings.json
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "java",
+    "SqlConnectionString": "",
+    "Sp_SelectCost": "SelectProductsCost",
+    "ProductCost": 100
+  }
+}

--- a/samples/samples-js/.vscode/extensions.json
+++ b/samples/samples-js/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-azuretools.vscode-azurefunctions"
+  ]
+}

--- a/samples/samples-js/.vscode/launch.json
+++ b/samples/samples-js/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Attach to Node Functions",
+            "type": "node",
+            "request": "attach",
+            "port": 9229,
+            "preLaunchTask": "func: host start"
+        }
+    ]
+}

--- a/samples/samples-js/.vscode/settings.json
+++ b/samples/samples-js/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "azureFunctions.deploySubpath": ".",
+    "azureFunctions.postDeployTask": "npm install (functions)",
+    "azureFunctions.projectLanguage": "JavaScript",
+    "azureFunctions.projectRuntime": "~4",
+    "debug.internalConsoleOptions": "neverOpen",
+    "azureFunctions.preDeployTask": "npm prune (functions)"
+}

--- a/samples/samples-js/.vscode/tasks.json
+++ b/samples/samples-js/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "type": "func",
+            "command": "host start",
+            "problemMatcher": "$func-node-watch",
+            "isBackground": true,
+            "dependsOn": "npm install (functions)"
+        },
+        {
+            "type": "shell",
+            "label": "npm install (functions)",
+            "command": "npm install"
+        },
+        {
+            "type": "shell",
+            "label": "npm prune (functions)",
+            "command": "npm prune --production",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/samples/samples-outofproc/.vscode/settings.json
+++ b/samples/samples-outofproc/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "azureFunctions.deploySubpath": "bin/Release/net6.0/publish",
+    "azureFunctions.deploySubpath": "bin/Release/net6/publish",
     "azureFunctions.projectLanguage": "C#",
     "azureFunctions.projectRuntime": "~4",
     "debug.internalConsoleOptions": "neverOpen",

--- a/samples/samples-outofproc/.vscode/tasks.json
+++ b/samples/samples-outofproc/.vscode/tasks.json
@@ -59,7 +59,7 @@
 			"type": "func",
 			"dependsOn": "build (functions)",
 			"options": {
-				"cwd": "${workspaceFolder}/bin/Debug/net6.0"
+				"cwd": "${workspaceFolder}/bin/Debug/net6"
 			},
 			"command": "host start",
 			"isBackground": true,

--- a/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
+++ b/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
- Add .vscode files for being able to launch/debug the samples directly from VS Code (note for non-C# in proc functions you'll need to open the target samples folder directly and run from there)
- Updated C# in proc samples to target correct runtimes
- Consolidate out of proc runtime from `net6.0` -> `net6`