### PR TITLE
Ignore build warning in samples

### DIFF
--- a/samples/samples-csharp/.editorconfig
+++ b/samples/samples-csharp/.editorconfig
@@ -1,6 +1,9 @@
 # See https://github.com/dotnet/roslyn-analyzers/blob/main/.editorconfig for an example on different settings and how they're used
 
 [*.cs]
+
+dotnet_diagnostic.CS0659.severity = silent # overrides Object.Equals but does not override Object.GetHashCode() - not necessary for our samples
+
 # Disable these until they can be fixed
 dotnet_diagnostic.CA1305.severity = silent
 dotnet_diagnostic.CA1805.severity = silent


### PR DESCRIPTION
Equals overload was added in https://github.com/Azure/azure-functions-sql-extension/pull/454

https://learn.microsoft.com/en-us/dotnet/csharp/misc/cs0659

`'class' overrides Object.Equals(object o) but does not override Object.GetHashCode()`

This isn't something we care about for our samples so we can safely ignore it. 