### PR TITLE
Add performance pipeline

### DIFF
--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -6,6 +6,8 @@ schedules: [ ]
 
 variables:
   configuration: 'Release'
+  serverPassword: ''
+  nodeModulesPath: ''
   LGTM.UploadSnapshot: true
   Semmle.SkipAnalysis: true
 

--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -2,7 +2,7 @@ trigger: none
 
 pr: none
 
-schedules: none
+schedules: [ ]
 
 variables:
   configuration: 'Release'

--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -1,0 +1,43 @@
+trigger: none
+
+pr: none
+
+schedules: none
+
+variables:
+  configuration: 'Release'
+  LGTM.UploadSnapshot: true
+  Semmle.SkipAnalysis: true
+
+stages:
+- stage: BuildPublish
+  displayName: 'Release Build and Publish'
+
+  jobs:
+  - job: BuildTest
+    displayName: 'Build and Test on '
+
+    strategy:
+      matrix:
+        # Disabling performance tests on macOS due to issues with running MSSQL on Docker
+        # We need to set up a self-hosted agent with Docker running by default: https://github.com/microsoft/azure-pipelines-tasks/issues/12823
+        # mac:
+        #   imageName: 'macos-latest'
+        #   testServer: ''
+        windows:
+          imageName: 'windows-latest'
+          testServer: '(LocalDb)\MSSQLLocalDB'
+        linux:
+          imageName: 'ubuntu-latest'
+          testServer: ''
+
+    pool:
+      vmImage: '$(imageName)'
+
+    workspace:
+      clean: all
+
+    steps:
+      - template: 'template-steps-performance.yml'
+        parameters:
+          configuration: '$(configuration)'

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -71,4 +71,4 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - publish: $(System.DefaultWorkingDirectory)/performance/BenchmarkDotNet.Artifacts
-  artifact: BenchmarkDotNet.Artifacts
+  artifact: BenchmarkDotNet.Artifacts-$(variables['Agent.OS'])

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -76,5 +76,6 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - publish: $(System.DefaultWorkingDirectory)/performance/BenchmarkDotNet.Artifacts
+  displayName: Publish BenchmarkDotNet.Artifacts
   artifact: BenchmarkDotNet.Artifacts-$(variables['Agent.OS'])
-  condition: succeeded()
+  condition: succeededOrFailed()

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -15,6 +15,10 @@ parameters:
       - trigger_overrides
       - trigger_parallel
 
+variables:
+  - serverPassword: ''
+  - nodeModulesPath: ''
+
 steps:
 - task: UseDotNet@2
   displayName: 'Install .NET SDK'
@@ -29,10 +33,9 @@ steps:
 
 # This step is necessary because npm installs to a non-traditional location on Windows hosted agents
 # This sets the path to npm global installations as a variable which then gets passed to the .NET run task
-# We do it for all OSes to ensure the variable is set correctly regardless
 - bash: echo "##vso[task.setvariable variable=nodeModulesPath]$(npm root -g)"
-  displayName: 'Set npm installation path'
-  condition: succeeded()
+  displayName: 'Set npm installation path for Windows'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DockerInstaller@0
   displayName: Docker Installer

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -57,27 +57,17 @@ steps:
 # Run each benchmark test separately so that failures in one don't block all the others
 - ${{ each test in parameters.tests }}:
   - task: DotNetCoreCLI@2
-    displayName: 'Run BenchmarkDotNet'
+    displayName: Run ${{ test }} suite
     env:
       TEST_SERVER: '$(testServer)'
       NODE_MODULES_PATH: '$(nodeModulesPath)'
-      AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-    inputs:
-      command: run
-      arguments: '-c ${{ parameters.configuration }} ${{ test }}'
-      workingDirectory: performance
-    condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run BenchmarkDotNet on Linux'
-    env:
       SA_PASSWORD: '$(serverPassword)'
       AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     inputs:
       command: run
       arguments: '-c ${{ parameters.configuration }} ${{ test }}'
       workingDirectory: performance
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+    condition: succeeded()
 
 - script: |
     docker stop sql1

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -44,6 +44,7 @@ steps:
   inputs:
     command: run
     arguments: '-c ${{ parameters.configuration }}'
+    workingDirectory: performance
   condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
 
 - task: DotNetCoreCLI@2
@@ -54,6 +55,7 @@ steps:
   inputs:
     command: run
     arguments: '-c ${{ parameters.configuration }}'
+    workingDirectory: performance
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -1,6 +1,19 @@
 parameters:
-  configuration: ''
-  testServer: ''
+  - name: configuration
+    default: ''
+  - name: testServer
+    default: ''
+  # The benchmarks we want to run, corresponds to the values in performance\SqlBindingBenchmarks.cs
+  - name: tests
+    type: object
+    default:
+      - input
+      - output
+      - trigger
+      - trigger_batch
+      - trigger_poll
+      - trigger_overrides
+      - trigger_parallel
 
 steps:
 - task: UseDotNet@2
@@ -41,28 +54,30 @@ steps:
   displayName: Start Server in Docker Container
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
-- task: DotNetCoreCLI@2
-  displayName: 'Run BenchmarkDotNet'
-  env:
-    TEST_SERVER: '$(testServer)'
-    NODE_MODULES_PATH: '$(nodeModulesPath)'
-    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-  inputs:
-    command: run
-    arguments: '-c ${{ parameters.configuration }}'
-    workingDirectory: performance
-  condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
+# Run each benchmark test separately so that failures in one don't block all the others
+- ${{ each test in parameters.tests }}:
+  - task: DotNetCoreCLI@2
+    displayName: 'Run BenchmarkDotNet'
+    env:
+      TEST_SERVER: '$(testServer)'
+      NODE_MODULES_PATH: '$(nodeModulesPath)'
+      AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+    inputs:
+      command: run
+      arguments: '-c ${{ parameters.configuration }} ${{ test }}'
+      workingDirectory: performance
+    condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
 
-- task: DotNetCoreCLI@2
-  displayName: 'Run BenchmarkDotNet on Linux'
-  env:
-    SA_PASSWORD: '$(serverPassword)'
-    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
-  inputs:
-    command: run
-    arguments: '-c ${{ parameters.configuration }}'
-    workingDirectory: performance
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+  - task: DotNetCoreCLI@2
+    displayName: 'Run BenchmarkDotNet on Linux'
+    env:
+      SA_PASSWORD: '$(serverPassword)'
+      AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+    inputs:
+      command: run
+      arguments: '-c ${{ parameters.configuration }} ${{ test }}'
+      workingDirectory: performance
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |
     docker stop sql1

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -14,6 +14,12 @@ steps:
 - script: npm install -g azurite
   displayName: 'Install Azurite Local Storage Emulator'
 
+# This step is necessary because npm installs to a non-traditional location on Windows hosted agents
+# This sets the path to npm global installations as a variable which then gets passed to the .NET run task
+- bash: echo "##vso[task.setvariable variable=nodeModulesPath]$(npm root -g)"
+  displayName: 'Set npm installation path for Windows'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
 - task: DockerInstaller@0
   displayName: Docker Installer
   inputs:
@@ -63,3 +69,6 @@ steps:
     docker rm sql1
   displayName: 'Stop and Remove SQL Server Image'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+
+- publish: $(System.DefaultWorkingDirectory)/performance/BenchmarkDotNet.Artifacts
+  artifact: BenchmarkDotNet.Artifacts

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -77,5 +77,5 @@ steps:
 
 - publish: $(System.DefaultWorkingDirectory)/performance/BenchmarkDotNet.Artifacts
   displayName: Publish BenchmarkDotNet.Artifacts
-  artifact: BenchmarkDotNet.Artifacts-$(variables['Agent.OS'])
+  artifact: BenchmarkDotNet.Artifacts-${{ variables['Agent.OS'] }}
   condition: succeededOrFailed()

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -1,0 +1,63 @@
+parameters:
+  configuration: ''
+  testServer: ''
+
+steps:
+- task: UseDotNet@2
+  displayName: 'Install .NET SDK'
+  inputs:
+    useGlobalJson: true
+
+- script: npm install -g azure-functions-core-tools
+  displayName: 'Install Azure Functions Core Tools'
+
+- script: npm install -g azurite
+  displayName: 'Install Azurite Local Storage Emulator'
+
+- task: DockerInstaller@0
+  displayName: Docker Installer
+  inputs:
+    dockerVersion: 17.09.0-ce
+    releaseType: stable
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+
+- script: docker pull mcr.microsoft.com/mssql/server:2019-latest
+  displayName: Pull MSSQL Docker Image
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+
+- bash: echo "##vso[task.setvariable variable=serverPassword]Test-$(Build.BuildNumber)-$(Get-Date -format yyyyMMdd-Hmmss)"
+  displayName: Generate password for test server
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+
+- script: 'docker run -e "ACCEPT_EULA=Y" -e "SA_PASSWORD=$(serverPassword)" -e "MSSQL_PID=Express"
+   -p 1433:1433 --name sql1 -h sql1
+   -d mcr.microsoft.com/mssql/server:2019-latest'
+  displayName: Start Server in Docker Container
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run BenchmarkDotNet'
+  env:
+    TEST_SERVER: '$(testServer)'
+    NODE_MODULES_PATH: '$(nodeModulesPath)'
+    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+  inputs:
+    command: run
+    arguments: '-c ${{ parameters.configuration }}'
+  condition: and(succeeded(), ne(variables['Agent.OS'], 'linux'))
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run BenchmarkDotNet on Linux'
+  env:
+    SA_PASSWORD: '$(serverPassword)'
+    AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
+  inputs:
+    command: run
+    arguments: '-c ${{ parameters.configuration }}'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
+
+- script: |
+    docker stop sql1
+    docker rm sql1
+  displayName: 'Stop and Remove SQL Server Image'
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -15,10 +15,6 @@ parameters:
       - trigger_overrides
       - trigger_parallel
 
-variables:
-  - serverPassword: ''
-  - nodeModulesPath: ''
-
 steps:
 - task: UseDotNet@2
   displayName: 'Install .NET SDK'

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -29,9 +29,10 @@ steps:
 
 # This step is necessary because npm installs to a non-traditional location on Windows hosted agents
 # This sets the path to npm global installations as a variable which then gets passed to the .NET run task
+# We do it for all OSes to ensure the variable is set correctly regardless
 - bash: echo "##vso[task.setvariable variable=nodeModulesPath]$(npm root -g)"
-  displayName: 'Set npm installation path for Windows'
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  displayName: 'Set npm installation path'
+  condition: succeeded()
 
 - task: DockerInstaller@0
   displayName: Docker Installer

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -54,7 +54,7 @@ steps:
   displayName: Start Server in Docker Container
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
-# Run each benchmark test separately so that failures in one don't block all the others
+# Run each benchmark test separately so that failures in one don't block all the others from running
 - ${{ each test in parameters.tests }}:
   - task: DotNetCoreCLI@2
     displayName: Run ${{ test }} suite
@@ -67,7 +67,7 @@ steps:
       command: run
       arguments: '-c ${{ parameters.configuration }} ${{ test }}'
       workingDirectory: performance
-    condition: succeeded()
+    continueOnError: true
 
 - script: |
     docker stop sql1
@@ -77,3 +77,4 @@ steps:
 
 - publish: $(System.DefaultWorkingDirectory)/performance/BenchmarkDotNet.Artifacts
   artifact: BenchmarkDotNet.Artifacts-$(variables['Agent.OS'])
+  condition: succeeded()

--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
     {
         public static void Main()
         {
-            BenchmarkRunner.Run<SqlInputBindingPerformance>();
-            BenchmarkRunner.Run<SqlOutputBindingPerformance>();
-            BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
-            BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
-            BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
-            BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
+            // BenchmarkRunner.Run<SqlInputBindingPerformance>();
+            // BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+            // BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
+            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
+            // BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
             BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
         }
     }

--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -1,21 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Linq;
 using BenchmarkDotNet.Running;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 {
     public class SqlBindingPerformance
     {
-        public static void Main()
+        public static void Main(string[] args)
         {
-            // BenchmarkRunner.Run<SqlInputBindingPerformance>();
-            // BenchmarkRunner.Run<SqlOutputBindingPerformance>();
-            // BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
-            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
-            // BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
-            // BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
-            BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
+            bool runAll = args.Length == 0;
+
+            // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
+            if (runAll || args.Contains("input"))
+            {
+                BenchmarkRunner.Run<SqlInputBindingPerformance>();
+            }
+            if (runAll || args.Contains("output"))
+            {
+                BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+            }
+            if (runAll || args.Contains("trigger"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+            }
+            if (runAll || args.Contains("trigger_batch"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
+            }
+            if (runAll || args.Contains("trigger_poll"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
+            }
+            if (runAll || args.Contains("trigger_overrides"))
+            {
+                BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
+            }
+            if (runAll || args.Contains("trigger_parallel"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
+            }
         }
     }
 }


### PR DESCRIPTION
Pipeline to use for running performance tests. 

Also added the ability to run just one of the benchmark suites for a couple reasons : 

1. The suite can take a long time to run currently so it's annoying to have to comment out ones
2. I'm still occasionally seeing failures - so I want to be able to tell in the pipeline which ones are failing so that flakey tests don't block the results of the rest of the tests