### PR TITLE
Upsert logging improvements

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -560,13 +560,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     var cmdCollation = new SqlCommand(getDatabaseCollationQuery, sqlConnection);
                     using (SqlDataReader rdr = await cmdCollation.ExecuteReaderAsync())
                     {
+                        string collation = "";
                         while (await rdr.ReadAsync())
                         {
-                            caseSensitive = GetCaseSensitivityFromCollation(rdr[Collation].ToString());
+                            collation = rdr[Collation].ToString();
+                            caseSensitive = GetCaseSensitivityFromCollation(collation);
                         }
                         caseSensitiveSw.Stop();
                         TelemetryInstance.TrackDuration(TelemetryEventName.GetCaseSensitivity, caseSensitiveSw.ElapsedMilliseconds, sqlConnProps);
-                        logger.LogDebugWithThreadId($"END GetCaseSensitivity Duration={caseSensitiveSw.ElapsedMilliseconds}ms");
+                        logger.LogDebugWithThreadId($"END GetCaseSensitivity Collation={collation} CaseSensitive={caseSensitive} Duration={caseSensitiveSw.ElapsedMilliseconds}ms");
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Was investigating an issue and found a couple places we could improve debug logging : 

1. Case sensitivity/collation retrieved from database
2. Listing the object column names in addition to the table columns (since we use the object columns to generate the merge query)
3. The query executed for each merge/insert statement

I also wrapped the exception thrown if an error occurs upserting the rows to provide a bit more context - before it would just give the direct exception that occurred (usually some generic SqlClient error) which doesn't tell the user where the issue might have come from. At least with this it should make it clearer where it happened which can help track it down. 