### PR TITLE
Add section on supported server versions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,9 @@ Further information on the Azure SQL binding for Azure Functions is also availab
 
 ## Supported SQL Server Versions
 
-This extension uses the [OPENJSON](https://learn.microsoft.com/sql/t-sql/functions/openjson-transact-sql) statement which requires SQL Server 2016 or higher and a database compatibility level of 130+. Older versions will currently fail to execute properly.
+This extension uses the [OPENJSON](https://learn.microsoft.com/sql/t-sql/functions/openjson-transact-sql) statement which requires a database compatibility level of 130 or higher (2016 or higher). To view or change the compatibility level of your database, see [this documentation article](https://learn.microsoft.com/sql/relational-databases/databases/view-or-change-the-compatibility-level-of-a-database) for more information.
 
-For more information about options to upgrade versions see the [SQL Server end of support options](https://learn.microsoft.com/sql/sql-server/end-of-support/sql-server-end-of-support-overview) page.
-
-Azure SQL Databases are fully supported.
+Databases on SQL Server, Azure SQL Database, or Azure SQL Managed Instance which meet the compatibility level requirement above are supported.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ See the language-specific guides for further details on support and usage of the
 
 Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
 
+## Supported SQL Server Versions
+
+This extension supports all versions of SQL Server currently in support under the [Product and Services Lifecycle](https://learn.microsoft.com/lifecycle/products) (currently SQL Server 2014 or higher). Using versions of SQL Server that are out of support may result in unexpected or incorrect behavior, so it is recommended to only use supported versions with this extension.
+
+For more information about options with out-of-support versions see the [SQL Server end of support options](https://learn.microsoft.com/sql/sql-server/end-of-support/sql-server-end-of-support-overview) page.
+
 ## Known Issues
 
 - Output bindings against tables with columns of data types `NTEXT`, `TEXT`, or `IMAGE` are not supported and data upserts will fail. These types [will be removed](https://docs.microsoft.com/sql/t-sql/data-types/ntext-text-and-image-transact-sql) in a future version of SQL Server and are not compatible with the `OPENJSON` function used by this Azure Functions binding.

--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ Further information on the Azure SQL binding for Azure Functions is also availab
 
 ## Supported SQL Server Versions
 
-This extension supports all versions of SQL Server currently in support under the [Product and Services Lifecycle](https://learn.microsoft.com/lifecycle/products) (currently SQL Server 2014 or higher). Using versions of SQL Server that are out of support may result in unexpected or incorrect behavior, so it is recommended to only use supported versions with this extension.
+This extension uses the [OPENJSON](https://learn.microsoft.com/sql/t-sql/functions/openjson-transact-sql) statement which requires SQL Server 2016 or higher and a database compatibility level of 130+. Older versions will currently fail to execute properly.
 
-For more information about options with out-of-support versions see the [SQL Server end of support options](https://learn.microsoft.com/sql/sql-server/end-of-support/sql-server-end-of-support-overview) page.
+For more information about options to upgrade versions see the [SQL Server end of support options](https://learn.microsoft.com/sql/sql-server/end-of-support/sql-server-end-of-support-overview) page.
 
 ## Known Issues
 
 - Output bindings against tables with columns of data types `NTEXT`, `TEXT`, or `IMAGE` are not supported and data upserts will fail. These types [will be removed](https://docs.microsoft.com/sql/t-sql/data-types/ntext-text-and-image-transact-sql) in a future version of SQL Server and are not compatible with the `OPENJSON` function used by this Azure Functions binding.
 - Input bindings against tables with columns of data types 'DATETIME', 'DATETIME2', or 'SMALLDATETIME' will assume that the values are in UTC format.
-
 - Trigger bindings will exhibit undefined behavior if the SQL table schema gets modified while the user application is running, for example, if a column is added, renamed or deleted or if the primary key is modified or deleted. In such cases, restarting the application should help resolve any errors.
 
 ## Telemetry

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This extension uses the [OPENJSON](https://learn.microsoft.com/sql/t-sql/functio
 
 For more information about options to upgrade versions see the [SQL Server end of support options](https://learn.microsoft.com/sql/sql-server/end-of-support/sql-server-end-of-support-overview) page.
 
+Azure SQL Databases are fully supported.
+
 ## Known Issues
 
 - Output bindings against tables with columns of data types `NTEXT`, `TEXT`, or `IMAGE` are not supported and data upserts will fail. These types [will be removed](https://docs.microsoft.com/sql/t-sql/data-types/ntext-text-and-image-transact-sql) in a future version of SQL Server and are not compatible with the `OPENJSON` function used by this Azure Functions binding.


### PR DESCRIPTION
Closes https://github.com/Azure/azure-functions-sql-extension/issues/457

I have to actually go through and test out MI - but according to the docs for supported features it should work so I'm preemptively assuming it will and will merge this in once I've verified that. 