### PR TITLE
Default log level to debug

### DIFF
--- a/performance/Microsoft.Azure.WebJobs.Extensions.Sql.Performance.csproj
+++ b/performance/Microsoft.Azure.WebJobs.Extensions.Sql.Performance.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-	<ProjectReference Include="..\test\Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj" />
-	<ProjectReference Include="..\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj" />
+    <ProjectReference Include="..\test\Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj" />
+    <ProjectReference Include="..\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj" />
   </ItemGroup>
 
   <Target Name="CopySamples" AfterTargets="Build">

--- a/samples/samples-csharp/host.json
+++ b/samples/samples-csharp/host.json
@@ -6,6 +6,9 @@
             "samplingSettings": {
                 "isEnabled": true
             }
+        },
+        "logLevel": {
+          "default": "Debug"
         }
     }
 }

--- a/samples/samples-java/host.json
+++ b/samples/samples-java/host.json
@@ -1,5 +1,10 @@
 {
   "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Debug"
+    }
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
     "version": "[4.*, 5.0.0)"

--- a/samples/samples-js/host.json
+++ b/samples/samples-js/host.json
@@ -6,6 +6,9 @@
         "isEnabled": true,
         "excludedTypes": "Request"
       }
+    },
+    "logLevel": {
+      "default": "Debug"
     }
   },
   "extensionBundle": {

--- a/samples/samples-outofproc/host.json
+++ b/samples/samples-outofproc/host.json
@@ -1,11 +1,14 @@
 {
-    "version": "2.0",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            }
-        }
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    },
+    "logLevel": {
+      "default": "Debug"
     }
+  }
 }

--- a/samples/samples-powershell/host.json
+++ b/samples/samples-powershell/host.json
@@ -6,6 +6,9 @@
         "isEnabled": true,
         "excludedTypes": "Request"
       }
+    },
+    "logLevel": {
+      "default": "Debug"
     }
   },
   "extensionBundle": {

--- a/samples/samples-python/host.json
+++ b/samples/samples-python/host.json
@@ -6,6 +6,9 @@
         "isEnabled": true,
         "excludedTypes": "Request"
       }
+    },
+    "logLevel": {
+      "default": "Debug"
     }
   },
   "extensionBundle": {

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -630,8 +630,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             int calculatedTimeout = (int)(Math.Ceiling((double)changesToProcess / batchSize // The number of batches to process
                 / this.FunctionHostList.Count) // The number of function host processes
                 * pollingIntervalMs // The length to process each batch
-                * 2); // Double to add buffer time for processing results
-            return Math.Max(calculatedTimeout, 2000); // Always have a timeout of at least 2sec to ensure we have time for processing the results
+                * 2); // Double to add buffer time for processing results & writing log messages
+
+            // Always have a timeout of at least 10sec since there's a certain amount of overhead
+            // always expected from each run regardless of the number of batches being processed and the delay
+            // These tests aren't testing performance so giving extra processing time is fine as long as the
+            // results themselves are correct
+            return Math.Max(calculatedTimeout, 10000);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Azure/azure-functions-sql-extension/issues/438

This is primarily for our tests, although when I'm running locally I usually have debug enabled too. 

Along with this I updated the min timeout value since all that extra logging does eat up extra processing time. 10sec is probably a lot more than most cases need but given that these tests care about correctness and not necessarily performance that seems fine (and trying to guess what the exact execution time is going to be would be very difficult). 

This does mean that if users are copying the host.json directly they may have this enabled by accident too - but it's easy enough to change and is something I think that's actually useful for them to know about so doesn't seem like a terrible thing to have. (plus most people are going to create a new function and then copy the code over directly instead of copying the entire samples folder so this probably isn't even going to be a thing most people run in to). 