### PR TITLE
Add metrics integration test

### DIFF
--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -228,6 +228,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 this._logger.LogError($"Failed to query count of unprocessed changes for table '{this._userTable.FullName}' due to exception: {ex.GetType()}. Exception message: {ex.Message}");
                 TelemetryInstance.TrackException(TelemetryErrorName.GetUnprocessedChangeCount, ex, this._telemetryProps);
+                throw;
             }
 
             return unprocessedChangeCount;

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -8,4 +8,3 @@ dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn'
 dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
 dotnet_diagnostic.CA2201.severity = silent # Do not raise reserved exception types - tests can throw whatever they want
 dotnet_diagnostic.CS0659.severity = silent # overrides Object.Equals but does not override Object.GetHashCode() - not necessary for our tests
-dotnet_diagnostic.CA1051.severity = silent # Do not declare visible instance fields - doesn't matter for tests

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -8,3 +8,4 @@ dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn'
 dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
 dotnet_diagnostic.CA2201.severity = silent # Do not raise reserved exception types - tests can throw whatever they want
 dotnet_diagnostic.CS0659.severity = silent # overrides Object.Equals but does not override Object.GetHashCode() - not necessary for our tests
+dotnet_diagnostic.CA1051.severity = silent # Do not declare visible instance fields - doesn't matter for tests

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <summary>
         /// Connection string to the master database on the test server, mainly used for database setup and teardown.
         /// </summary>
-        protected string MasterConnectionString;
+        private string MasterConnectionString;
 
         /// <summary>
         /// Connection string to the database created for the test
         /// </summary>
-        protected string DbConnectionString;
+        protected string DbConnectionString { get; private set; }
 
         /// <summary>
         /// Name of the database used for the current test.

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -48,7 +48,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <summary>
         /// Connection string to the master database on the test server, mainly used for database setup and teardown.
         /// </summary>
-        private string MasterConnectionString;
+        protected string MasterConnectionString;
+
+        /// <summary>
+        /// Connection string to the database created for the test
+        /// </summary>
+        protected string DbConnectionString;
 
         /// <summary>
         /// Name of the database used for the current test.
@@ -135,7 +140,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             // Setup connection
             connectionStringBuilder.InitialCatalog = this.DatabaseName;
-            this.Connection = new SqlConnection(connectionStringBuilder.ToString());
+            this.DbConnectionString = connectionStringBuilder.ToString();
+            this.Connection = new SqlConnection(this.DbConnectionString);
             this.Connection.Open();
 
             // Create the database definition

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -14,6 +14,7 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
 using Microsoft.Azure.WebJobs.Host.Executors;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Moq;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
@@ -484,7 +485,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         {
             this.SetChangeTrackingForTable("Products");
             IConfiguration configuration = new ConfigurationBuilder().Build();
-            var listener = new SqlTriggerListener<Product>(this.DbConnectionString, "dbo.Products", "func-id", new Moq.Mock<ITriggeredFunctionExecutor>().Object, new Moq.Mock<ILogger>().Object, configuration);
+            var listener = new SqlTriggerListener<Product>(this.DbConnectionString, "dbo.Products", "func-id", Mock.Of<ITriggeredFunctionExecutor>(), Mock.Of<ILogger>(), configuration);
             var tokenSource = new CancellationTokenSource();
             await listener.StartAsync(tokenSource.Token);
             // Cancel immediately so the listener doesn't start processing the changes

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -486,10 +486,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.SetChangeTrackingForTable("Products");
             IConfiguration configuration = new ConfigurationBuilder().Build();
             var listener = new SqlTriggerListener<Product>(this.DbConnectionString, "dbo.Products", "func-id", Mock.Of<ITriggeredFunctionExecutor>(), Mock.Of<ILogger>(), configuration);
-            var tokenSource = new CancellationTokenSource();
-            await listener.StartAsync(tokenSource.Token);
+            await listener.StartAsync(CancellationToken.None);
             // Cancel immediately so the listener doesn't start processing the changes
-            tokenSource.Cancel();
+            await listener.StopAsync(CancellationToken.None);
             SqlTriggerMetrics metrics = await listener.GetMetricsAsync();
             Assert.True(metrics.UnprocessedChangeCount == 0, "There should initially be 0 unprocessed changes");
             this.InsertProducts(1, 5);

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -6,10 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
@@ -469,6 +473,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 nameof(ProductsTrigger),
                 false,
                 "Could not find change tracking enabled for table: 'dbo.Products'.");
+        }
+
+        /// <summary>
+        /// Tests that the GetMetrics call works correctly.
+        /// </summary>
+        /// <remarks>We call this directly since there isn't a way to test scaling locally - with this we at least verify the methods called don't throw unexpectedly.</remarks>
+        [Fact]
+        public async void GetMetricsTest()
+        {
+            this.SetChangeTrackingForTable("Products");
+            IConfiguration configuration = new ConfigurationBuilder().Build();
+            var listener = new SqlTriggerListener<Product>(this.DbConnectionString, "dbo.Products", "func-id", new Moq.Mock<ITriggeredFunctionExecutor>().Object, new Moq.Mock<ILogger>().Object, configuration);
+            await listener.StartAsync(CancellationToken.None);
+            SqlTriggerMetrics metrics = await listener.GetMetricsAsync();
+            Assert.True(metrics.UnprocessedChangeCount == 0, "There should initially be 0 unprocessed changes");
+            this.InsertProducts(1, 5);
+            metrics = await listener.GetMetricsAsync();
+            Assert.True(metrics.UnprocessedChangeCount == 5, $"There should be 5 unprocessed changes after insertion. Actual={metrics.UnprocessedChangeCount}");
         }
 
         private void EnableChangeTrackingForDatabase()

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -485,7 +485,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.SetChangeTrackingForTable("Products");
             IConfiguration configuration = new ConfigurationBuilder().Build();
             var listener = new SqlTriggerListener<Product>(this.DbConnectionString, "dbo.Products", "func-id", new Moq.Mock<ITriggeredFunctionExecutor>().Object, new Moq.Mock<ILogger>().Object, configuration);
-            await listener.StartAsync(CancellationToken.None);
+            var tokenSource = new CancellationTokenSource();
+            await listener.StartAsync(tokenSource.Token);
+            // Cancel immediately so the listener doesn't start processing the changes
+            tokenSource.Cancel();
             SqlTriggerMetrics metrics = await listener.GetMetricsAsync();
             Assert.True(metrics.UnprocessedChangeCount == 0, "There should initially be 0 unprocessed changes");
             this.InsertProducts(1, 5);


### PR DESCRIPTION
Closes https://github.com/Azure/azure-functions-sql-extension/issues/500

Help prevent issues like https://github.com/Azure/azure-functions-sql-extension/issues/488

Right now I'm just calling the GetMetrics method directly since there isn't a way (I know of) to test scaling locally. But given how simple the process is this seems fine - it does what it intends and will make sure that any future changes don't break this.

I also changed it to throw an exception if the query fails - silently failing makes it harder to track this stuff down and if a user has scaling enabled and we aren't actually getting valid values (it defaulted to 0) then we shouldn't act like there's no unprocessed changes. 

(note that we already have unit tests to test the other parts of the scaling logic, specifically the stuff that determines scale-in vs scale-out. So that isn't necessary to test here since that stuff is all easily unit-testable)