### PR TITLE
Increase perf pipeline timeout to 120 minutes

### DIFF
--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -18,7 +18,7 @@ stages:
   jobs:
   - job: BuildTest
     displayName: 'Build and Test on '
-
+    timeoutInMinutes: "90"
     strategy:
       matrix:
         # Disabling performance tests on macOS due to issues with running MSSQL on Docker

--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -18,7 +18,7 @@ stages:
   jobs:
   - job: BuildTest
     displayName: 'Build and Test on '
-    timeoutInMinutes: "120"
+    timeoutInMinutes: '120'
     strategy:
       matrix:
         # Disabling performance tests on macOS due to issues with running MSSQL on Docker

--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -18,7 +18,7 @@ stages:
   jobs:
   - job: BuildTest
     displayName: 'Build and Test on '
-    timeoutInMinutes: "90"
+    timeoutInMinutes: "120"
     strategy:
       matrix:
         # Disabling performance tests on macOS due to issues with running MSSQL on Docker

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -8,12 +8,12 @@ parameters:
     type: object
     default:
       - input
-      # - output
-      # - trigger
-      # - trigger_batch
-      # - trigger_poll
-      # - trigger_overrides
-      # - trigger_parallel
+      - output
+      - trigger
+      - trigger_batch
+      - trigger_poll
+      - trigger_overrides
+      - trigger_parallel
 
 steps:
 - task: UseDotNet@2

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -8,12 +8,12 @@ parameters:
     type: object
     default:
       - input
-      - output
-      - trigger
-      - trigger_batch
-      - trigger_poll
-      - trigger_overrides
-      - trigger_parallel
+      # - output
+      # - trigger
+      # - trigger_batch
+      # - trigger_poll
+      # - trigger_overrides
+      # - trigger_parallel
 
 steps:
 - task: UseDotNet@2
@@ -77,5 +77,5 @@ steps:
 
 - publish: $(System.DefaultWorkingDirectory)/performance/BenchmarkDotNet.Artifacts
   displayName: Publish BenchmarkDotNet.Artifacts
-  artifact: BenchmarkDotNet.Artifacts-${{ variables['Agent.OS'] }}
+  artifact: BenchmarkDotNet.Artifacts-$(Agent.OS)
   condition: succeededOrFailed()

--- a/performance/SqlTriggerPerformance_Overrides.cs
+++ b/performance/SqlTriggerPerformance_Overrides.cs
@@ -33,10 +33,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 
         [Benchmark]
         [Arguments(0.1)]
-        [Arguments(0.5)]
         [Arguments(1)]
         [Arguments(5)]
-        [Arguments(10)]
         public async Task Run(double numBatches)
         {
             int count = (int)(numBatches * this.BatchSize);


### PR DESCRIPTION
The tests can take a while so we were hitting timeouts with the default 60 minutes

I also removed a few cases for the override tests since those were taking >1hr by themselves and we don't really need THAT many variations on the tests. They still take 40min so I still plan on coming back and seeing what we can do to speed it up even more but this is fine enough for now. 

And finally fixed the artifacts name to use the correct substitution