### PR TITLE
Start Azurite once before performance tests

### DIFF
--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
             }
             finally
             {
-                azuriteHost.Kill()
+                azuriteHost.Kill();
                 azuriteHost.Dispose();
             }
 

--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Linq;
 using BenchmarkDotNet.Running;
 
@@ -12,35 +13,58 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
         {
             bool runAll = args.Length == 0;
 
-            // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
-            if (runAll || args.Contains("input"))
+            // Start Azurite once before the tests run - there were issues
+            // with it not getting cleaned up properly between test runs
+            // TODO: This should be a more general thing for all tests
+            var azuriteHost = new Process()
             {
-                BenchmarkRunner.Run<SqlInputBindingPerformance>();
-            }
-            if (runAll || args.Contains("output"))
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "azurite",
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    UseShellExecute = true
+                }
+            };
+            azuriteHost.Start();
+
+            try
             {
-                BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+                // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
+                if (runAll || args.Contains("input"))
+                {
+                    BenchmarkRunner.Run<SqlInputBindingPerformance>();
+                }
+                if (runAll || args.Contains("output"))
+                {
+                    BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+                }
+                if (runAll || args.Contains("trigger"))
+                {
+                    BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+                }
+                if (runAll || args.Contains("trigger_batch"))
+                {
+                    BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
+                }
+                if (runAll || args.Contains("trigger_poll"))
+                {
+                    BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
+                }
+                if (runAll || args.Contains("trigger_overrides"))
+                {
+                    BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
+                }
+                if (runAll || args.Contains("trigger_parallel"))
+                {
+                    BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
+                }
             }
-            if (runAll || args.Contains("trigger"))
+            finally
             {
-                BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+                azuriteHost.Kill()
+                azuriteHost.Dispose();
             }
-            if (runAll || args.Contains("trigger_batch"))
-            {
-                BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
-            }
-            if (runAll || args.Contains("trigger_poll"))
-            {
-                BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
-            }
-            if (runAll || args.Contains("trigger_overrides"))
-            {
-                BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
-            }
-            if (runAll || args.Contains("trigger_parallel"))
-            {
-                BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
-            }
+
         }
     }
 }


### PR DESCRIPTION
Was seeing some issues with Azurite getting stuck and causing the performance tests to fail in the pipeline. So to fix that we start up Azurite once before all the tests run (the tests will still each try to start up Azurite but then fail because the ports are in use, but this is fine as long as the first one is running because we currently don't actually check that it started up successfully)

This is just a temporary workaround while I investigate the root cause and other solutions