### PR TITLE
Kill entire process tree after tests

### DIFF
--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
             }
             finally
             {
-                azuriteHost.Kill();
+                azuriteHost.Kill(true);
                 azuriteHost.Dispose();
             }
 

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             try
             {
-                this.AzuriteHost?.Kill();
+                this.AzuriteHost?.Kill(true);
                 this.AzuriteHost?.Dispose();
             }
             catch (Exception e3)

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -436,7 +436,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             {
                 try
                 {
-                    functionHost.Kill();
+                    functionHost.Kill(true);
                     functionHost.Dispose();
                 }
                 catch (Exception ex)

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             bool isCompleted = tcs.Task.Wait(TimeSpan.FromSeconds(BufferTimeForErrorInSeconds));
 
             this.FunctionHost.OutputDataReceived -= OutputHandler;
-            this.FunctionHost.Kill();
+            this.FunctionHost.Kill(true);
 
             Assert.True(isCompleted, "Functions host did not log failure to start SQL trigger listener within specified time.");
             Assert.Equal(expectedErrorMessage, errorMessage);


### PR DESCRIPTION
We weren't killing the entire process tree of the processes that we start up during tests (azurite and func). This meant that we'd be left with the child processes from those still running (for example, azurite starts as a script which spawns a node.js process) which could impact later tests. 

https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill?view=net-7.0#system-diagnostics-process-kill(system-boolean)