### PR TITLE
Copy sql dll to extension bundle during Integration tests

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -39,10 +39,6 @@ steps:
   displayName: 'Set npm installation path for Windows'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-- bash: echo "##vso[task.setvariable variable=azureFunctionsExtensionBundlePath]$(func GetExtensionBundlePath)"
-  displayName: 'Set Azure Functions extension bundle path'
-  workingDirectory: $(Build.SourcesDirectory)/samples/samples-js
-
 - task: DockerInstaller@0
   displayName: Docker Installer
   inputs:
@@ -77,14 +73,6 @@ steps:
     command: build
     projects: '${{ parameters.solution }}'
     arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }}'
-
-- task: CopyFiles@2
-  displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
-  inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
-    contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
-    overWrite: true
 
 - script: |
     npm install

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -121,6 +121,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 }
             };
             getExtensionBundlePath.OutputDataReceived += ExtensionBundlePathHandler;
+            getExtensionBundlePath.OutputDataReceived += this.GetTestOutputHandler(maven.Id);
+            getExtensionBundlePath.ErrorDataReceived += this.GetTestOutputHandler(maven.Id);
             getExtensionBundlePath.Start();
             getExtensionBundlePath.BeginOutputReadLine();
             this.LogOutput("Getting extension bundle path...");


### PR DESCRIPTION
Moving this step from the pipeline to IntegrationTestBase so that we don't have to manually copy the dll to the bundle when running integration tests locally.

I couldn't find a way to specify the extension bundle path when running func start. The instructions for testing local extension bundles also use the copy method: https://github.com/Azure/azure-functions-extension-bundles#test-an-extension-bundle