### PR TITLE
Use test fixture for global setup of integration tests

### DIFF
--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using System.Linq;
 using BenchmarkDotNet.Running;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 {
@@ -13,58 +13,38 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
         {
             bool runAll = args.Length == 0;
 
-            // Start Azurite once before the tests run - there were issues
-            // with it not getting cleaned up properly between test runs
-            // TODO: This should be a more general thing for all tests
-            var azuriteHost = new Process()
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "azurite",
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    UseShellExecute = true
-                }
-            };
-            azuriteHost.Start();
 
-            try
-            {
-                // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
-                if (runAll || args.Contains("input"))
-                {
-                    BenchmarkRunner.Run<SqlInputBindingPerformance>();
-                }
-                if (runAll || args.Contains("output"))
-                {
-                    BenchmarkRunner.Run<SqlOutputBindingPerformance>();
-                }
-                if (runAll || args.Contains("trigger"))
-                {
-                    BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
-                }
-                if (runAll || args.Contains("trigger_batch"))
-                {
-                    BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
-                }
-                if (runAll || args.Contains("trigger_poll"))
-                {
-                    BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
-                }
-                if (runAll || args.Contains("trigger_overrides"))
-                {
-                    BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
-                }
-                if (runAll || args.Contains("trigger_parallel"))
-                {
-                    BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
-                }
-            }
-            finally
-            {
-                azuriteHost.Kill(true);
-                azuriteHost.Dispose();
-            }
 
+            using var testFixture = new IntegrationTestFixture();
+            // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
+            if (runAll || args.Contains("input"))
+            {
+                BenchmarkRunner.Run<SqlInputBindingPerformance>();
+            }
+            if (runAll || args.Contains("output"))
+            {
+                BenchmarkRunner.Run<SqlOutputBindingPerformance>();
+            }
+            if (runAll || args.Contains("trigger"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance>();
+            }
+            if (runAll || args.Contains("trigger_batch"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance_BatchOverride>();
+            }
+            if (runAll || args.Contains("trigger_poll"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance_PollingIntervalOverride>();
+            }
+            if (runAll || args.Contains("trigger_overrides"))
+            {
+                BenchmarkRunner.Run<SqlTriggerPerformance_Overrides>();
+            }
+            if (runAll || args.Contains("trigger_parallel"))
+            {
+                BenchmarkRunner.Run<SqlTriggerBindingPerformance_Parallelization>();
+            }
         }
     }
 }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -8,3 +8,4 @@ dotnet_diagnostic.CA1305.severity = silent # Specify IFormatProvider - this isn'
 dotnet_diagnostic.CA1707.severity = silent # Identifiers should not contain underscores - this helps make test names more readable
 dotnet_diagnostic.CA2201.severity = silent # Do not raise reserved exception types - tests can throw whatever they want
 dotnet_diagnostic.CS0659.severity = silent # overrides Object.Equals but does not override Object.GetHashCode() - not necessary for our tests
+dotnet_diagnostic.CA1711.severity = silent # Identifiers should not have incorrect suffix - Fine for tests

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -35,12 +35,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         protected List<Process> FunctionHostList { get; } = new List<Process>();
 
         /// <summary>
-        /// Host process for Azurite local storage emulator. This is required for non-HTTP trigger functions:
-        /// https://docs.microsoft.com/azure/azure-functions/functions-develop-local
-        /// </summary>
-        private Process AzuriteHost;
-
-        /// <summary>
         /// Connection to the database for the current test.
         /// </summary>
         private DbConnection Connection;
@@ -75,7 +69,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         {
             this.TestOutput = output;
             this.SetupDatabase();
-            this.StartAzurite();
         }
 
         /// <summary>
@@ -162,24 +155,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 this.LogOutput($"Executing script ${file}");
                 this.ExecuteNonQuery(File.ReadAllText(file));
             }
-        }
-
-        /// <summary>
-        /// This starts the Azurite storage emulator.
-        /// </summary>
-        protected void StartAzurite()
-        {
-            this.AzuriteHost = new Process()
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "azurite",
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    UseShellExecute = true
-                }
-            };
-
-            this.AzuriteHost.Start();
         }
 
         /// <summary>
@@ -397,16 +372,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             }
 
             this.DisposeFunctionHosts();
-
-            try
-            {
-                this.AzuriteHost?.Kill(true);
-                this.AzuriteHost?.Dispose();
-            }
-            catch (Exception e3)
-            {
-                this.LogOutput($"Failed to stop Azurite, Error: {e3.Message}");
-            }
 
             try
             {

--- a/test/Integration/IntegrationTestFixture.cs
+++ b/test/Integration/IntegrationTestFixture.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
+{
+    /// <summary>
+    /// Test fixture containing one-time setup code for Integration tests. See https://xunit.net/docs/shared-context for more details
+    /// </summary>
+    public class IntegrationTestFixture : IDisposable
+    {
+        /// <summary>
+        /// Host process for Azurite local storage emulator. This is required for non-HTTP trigger functions:
+        /// https://docs.microsoft.com/azure/azure-functions/functions-develop-local
+        /// </summary>
+        private Process AzuriteHost;
+
+        public IntegrationTestFixture()
+        {
+            this.StartAzurite();
+        }
+
+        /// <summary>
+        /// This starts the Azurite storage emulator.
+        /// </summary>
+        protected void StartAzurite()
+        {
+            Console.WriteLine("Starting Azurite Host...");
+            this.AzuriteHost = new Process()
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "azurite",
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    UseShellExecute = true
+                }
+            };
+
+            this.AzuriteHost.Start();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                this.AzuriteHost.Kill(true);
+                this.AzuriteHost.Dispose();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Failed to stop Azurite, Error: {e.Message}");
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/test/Integration/IntegrationTestsCollection.cs
+++ b/test/Integration/IntegrationTestsCollection.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
+{
+    [CollectionDefinition(Name)]
+    public class IntegrationTestsCollection : ICollectionFixture<IntegrationTestFixture>
+    {
+        public const string Name = "IntegrationTests";
+
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.
+    }
+}

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -12,12 +12,13 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
-    [Collection("IntegrationTests")]
+    [Collection(IntegrationTestsCollection.Name)]
     public class SqlInputBindingIntegrationTests : IntegrationTestBase
     {
         public SqlInputBindingIntegrationTests(ITestOutputHelper output) : base(output)
         {
         }
+
         [Theory]
         [SqlInlineData(0, 100)]
         [SqlInlineData(1, -500)]

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
-    [Collection("IntegrationTests")]
+    [Collection(IntegrationTestsCollection.Name)]
     public class SqlOutputBindingIntegrationTests : IntegrationTestBase
     {
         public SqlOutputBindingIntegrationTests(ITestOutputHelper output) : base(output)

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -21,7 +21,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
-    [Collection("IntegrationTests")]
+    [Collection(IntegrationTestsCollection.Name)]
     public class SqlTriggerBindingIntegrationTests : IntegrationTestBase
     {
         public SqlTriggerBindingIntegrationTests(ITestOutputHelper output = null) : base(output)


### PR DESCRIPTION
For integration tests we were starting up the azurite host for each class instance - not a ton of overhead but definitely unnecessary and opens us up to more risk of issues. (this was something I had worked around in the benchmark tests but now have consolidated all into the same place)

xUnit doesn't have a global setup attribute or anything like that - but it does provide the ability to create shared contexts. https://xunit.net/docs/shared-context

In this case the collection context serves as a global setup - it's created once before any tests are ran and disposed once all tests are finished. 