### PR TITLE
Fix mac integration function tools path

### DIFF
--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -275,10 +275,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                     }
                     throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath} or {usrBinFuncPath}");
                 }
-                else
-                {
-                    throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath}");
-                }
                 throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath}");
             }
 

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -265,6 +265,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                     }
                     throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath} or {programFilesFuncPath}");
                 }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    // Search Mac to see if brew installed location has azure function core tools
+                    string usrBinFuncPath = Path.Combine("/usr", "local", "bin", "func");
+                    if (File.Exists(usrBinFuncPath))
+                    {
+                        return usrBinFuncPath;
+                    }
+                    throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath} or {usrBinFuncPath}");
+                }
+                else
+                {
+                    throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath}");
+                }
                 throw new FileNotFoundException($"Azure Function Core Tools not found at {funcPath}");
             }
 


### PR DESCRIPTION
If users on Mac have Azure Function core tools installed via [Brew](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4%2Cmacos%2Ccsharp%2Cportal%2Cbash#install-the-azure-functions-core-tools). Then dotnet test will constantly fail.