### PR TITLE
Benchmark fixes

### DIFF
--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -13,9 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
         {
             bool runAll = args.Length == 0;
 
-
-
-            using var testFixture = new IntegrationTestFixture(false);
+            using var testFixture = new BaseTestFixture(false);
 
             // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
             if (runAll || args.Contains("input"))

--- a/performance/SqlBindingBenchmarks.cs
+++ b/performance/SqlBindingBenchmarks.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
 
 
 
-            using var testFixture = new IntegrationTestFixture();
+            using var testFixture = new IntegrationTestFixture(false);
+
             // **IMPORTANT** If changing these make sure to update template-steps-performance.yml as well
             if (runAll || args.Contains("input"))
             {

--- a/performance/SqlTriggerPerformance_Overrides.cs
+++ b/performance/SqlTriggerPerformance_Overrides.cs
@@ -12,10 +12,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
     [MemoryDiagnoser]
     public class SqlTriggerPerformance_Overrides : SqlTriggerBindingPerformanceTestBase
     {
-        [Params(1, 10, 100, 500)]
+        [Params(1, 500)]
         public int PollingIntervalMs;
 
-        [Params(500, 1000, 2000)]
+        [Params(500, 2000)]
         public int BatchSize;
 
         [GlobalSetup]

--- a/test/Integration/IntegrationTestFixture.cs
+++ b/test/Integration/IntegrationTestFixture.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
+using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
@@ -17,9 +20,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         private Process AzuriteHost;
 
-        public IntegrationTestFixture()
+        public IntegrationTestFixture(bool buildJava = true)
         {
             this.StartAzurite();
+            if (buildJava)
+            {
+                BuildJavaFunctionApps();
+            }
+
         }
 
         /// <summary>
@@ -39,6 +47,44 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             };
 
             this.AzuriteHost.Start();
+        }
+
+        /// <summary>
+        /// Build the samples-java and test-java projects.
+        /// </summary>
+        private static void BuildJavaFunctionApps()
+        {
+            string samplesJavaPath = Path.Combine(TestUtils.GetPathToBin(), "SqlExtensionSamples", "Java");
+            BuildJavaFunctionApp(samplesJavaPath);
+
+            string testJavaPath = Path.Combine(TestUtils.GetPathToBin(), "..", "..", "..", "Integration", "test-java");
+            BuildJavaFunctionApp(testJavaPath);
+        }
+
+        /// <summary>
+        /// Run `mvn clean package` to build the Java function app.
+        /// </summary>
+        private static void BuildJavaFunctionApp(string workingDirectory)
+        {
+            var maven = new Process()
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "mvn",
+                    Arguments = "clean package",
+                    WorkingDirectory = workingDirectory,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    UseShellExecute = true
+                }
+            };
+
+            maven.Start();
+
+            const int buildJavaAppTimeoutInMs = 60000;
+            maven.WaitForExit(buildJavaAppTimeoutInMs);
+
+            bool isCompleted = maven.ExitCode == 0;
+            Assert.True(isCompleted, "Java function app did not build successfully");
         }
 
         public void Dispose()

--- a/test/Integration/IntegrationTestFixture.cs
+++ b/test/Integration/IntegrationTestFixture.cs
@@ -12,7 +12,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
     /// <summary>
     /// Test fixture containing one-time setup code for Integration tests. See https://xunit.net/docs/shared-context for more details
     /// </summary>
-    public class IntegrationTestFixture : IDisposable
+    public class IntegrationTestFixture : BaseTestFixture
+    {
+        public IntegrationTestFixture() : base(true) { }
+    }
+
+    /// <summary>
+    /// Base test fixture - xUnit doesn't allow parameterized constructors so the benchmark tests will use this directly.
+    /// </summary>
+    public class BaseTestFixture : IDisposable
     {
         /// <summary>
         /// Host process for Azurite local storage emulator. This is required for non-HTTP trigger functions:
@@ -20,14 +28,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         private Process AzuriteHost;
 
-        public IntegrationTestFixture(bool buildJava = true)
+        public BaseTestFixture(bool buildJava)
         {
             this.StartAzurite();
             if (buildJava)
             {
                 BuildJavaFunctionApps();
             }
-
         }
 
         /// <summary>

--- a/test/Integration/IntegrationTestFixture.cs
+++ b/test/Integration/IntegrationTestFixture.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
-using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
-using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
@@ -23,7 +20,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         public IntegrationTestFixture()
         {
             this.StartAzurite();
-            BuildJavaFunctionApps();
         }
 
         /// <summary>
@@ -43,44 +39,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             };
 
             this.AzuriteHost.Start();
-        }
-
-        /// <summary>
-        /// Build the samples-java and test-java projects.
-        /// </summary>
-        private static void BuildJavaFunctionApps()
-        {
-            string samplesJavaPath = Path.Combine(TestUtils.GetPathToBin(), "SqlExtensionSamples", "Java");
-            BuildJavaFunctionApp(samplesJavaPath);
-
-            string testJavaPath = Path.Combine(TestUtils.GetPathToBin(), "..", "..", "..", "Integration", "test-java");
-            BuildJavaFunctionApp(testJavaPath);
-        }
-
-        /// <summary>
-        /// Run `mvn clean package` to build the Java function app.
-        /// </summary>
-        private static void BuildJavaFunctionApp(string workingDirectory)
-        {
-            var maven = new Process()
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "mvn",
-                    Arguments = "clean package",
-                    WorkingDirectory = workingDirectory,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    UseShellExecute = true
-                }
-            };
-
-            maven.Start();
-
-            const int buildJavaAppTimeoutInMs = 60000;
-            maven.WaitForExit(buildJavaAppTimeoutInMs);
-
-            bool isCompleted = maven.ExitCode == 0;
-            Assert.True(isCompleted, "Java function app did not build successfully");
         }
 
         public void Dispose()


### PR DESCRIPTION
- Fewer dimensions for the overrides tests, it's taking well over an hour currently with how many we have so trimming it down for now until I can spend some time seeing how else we can speed it up (like disabling debug logging)
- Add support for disabling java build in test fixture - we don't need that for benchmark tests. Had to split the fixture into two for this since xunit doesn't support parameterized constructors (and since we're likely to get rid of the java build stuff at some point anyways this seemed easiest as a temporary workaround vs adding in more test fixtures or something which would generally be how I approach this)