### PR TITLE
Set default log level to Information and add pipeline override

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -70,6 +70,10 @@ steps:
     command: restore
     projects: '${{ parameters.solution }}'
 
+- powershell: $(System.DefaultWorkingDirectory)/builds/scripts/UpdateLogLevel.ps1
+  displayName: Set logging level
+  condition: and(succeeded(), ne(variables['AFSQLEXT_TEST_LOGLEVEL'], ''))
+
   # Don't generate package so we can sign it before packaging
 - task: DotNetCoreCLI@2
   displayName: '.NET Build'

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -54,6 +54,10 @@ steps:
   displayName: Start Server in Docker Container
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
+- powershell: $(System.DefaultWorkingDirectory)/builds/scripts/UpdateLogLevel.ps1
+  displayName: Set logging level
+  condition: and(succeeded(), ne(variables['AFSQLEXT_TEST_LOGLEVEL'], ''))
+
 # Run each benchmark test separately so that failures in one don't block all the others from running
 - ${{ each test in parameters.tests }}:
   - task: DotNetCoreCLI@2

--- a/builds/scripts/UpdateLogLevel.ps1
+++ b/builds/scripts/UpdateLogLevel.ps1
@@ -1,0 +1,12 @@
+# Update the default logging level for all host.json files to the value specified in the AFSQLEXT_TEST_LOGLEVEL environment variable
+
+Write-Host Setting logLevel.default to $ENV:AFSQLEXT_TEST_LOGLEVEL
+# Ignore bin/target output folders - we only want to update the src files
+Get-ChildItem -Recurse -Filter host.json | Where-Object {$_.DirectoryName -notmatch "bin|target"} |
+    ForEach-Object {
+        Write-Host Updating $_.FullName...
+        $json = Get-Content $_.FullName -raw | ConvertFrom-Json
+        $json.logging.logLevel.default = $ENV:AFSQLEXT_TEST_LOGLEVEL
+        # Default depth is only 2, so to ensure we write content correctly set depth of 32
+        $json | ConvertTo-Json -depth 32 | Set-Content $_.FullName
+    }

--- a/samples/samples-csharp/host.json
+++ b/samples/samples-csharp/host.json
@@ -8,7 +8,7 @@
             }
         },
         "logLevel": {
-          "default": "Debug"
+          "default": "Warning"
         }
     }
 }

--- a/samples/samples-csharp/host.json
+++ b/samples/samples-csharp/host.json
@@ -8,7 +8,7 @@
             }
         },
         "logLevel": {
-          "default": "Warning"
+          "default": "Information"
         }
     }
 }

--- a/samples/samples-java/host.json
+++ b/samples/samples-java/host.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Warning"
+      "default": "Information"
     }
   },
   "extensionBundle": {

--- a/samples/samples-java/host.json
+++ b/samples/samples-java/host.json
@@ -2,7 +2,7 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Debug"
+      "default": "Warning"
     }
   },
   "extensionBundle": {

--- a/samples/samples-js/host.json
+++ b/samples/samples-js/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Warning"
+      "default": "Information"
     }
   },
   "extensionBundle": {

--- a/samples/samples-js/host.json
+++ b/samples/samples-js/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Debug"
+      "default": "Warning"
     }
   },
   "extensionBundle": {

--- a/samples/samples-outofproc/host.json
+++ b/samples/samples-outofproc/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Debug"
+      "default": "Warning"
     }
   }
 }

--- a/samples/samples-outofproc/host.json
+++ b/samples/samples-outofproc/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Warning"
+      "default": "Information"
     }
   }
 }

--- a/samples/samples-powershell/host.json
+++ b/samples/samples-powershell/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Warning"
+      "default": "Information"
     }
   },
   "extensionBundle": {

--- a/samples/samples-powershell/host.json
+++ b/samples/samples-powershell/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Debug"
+      "default": "Warning"
     }
   },
   "extensionBundle": {

--- a/samples/samples-python/host.json
+++ b/samples/samples-python/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Warning"
+      "default": "Information"
     }
   },
   "extensionBundle": {

--- a/samples/samples-python/host.json
+++ b/samples/samples-python/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Debug"
+      "default": "Warning"
     }
   },
   "extensionBundle": {

--- a/test/Integration/test-java/host.json
+++ b/test/Integration/test-java/host.json
@@ -1,5 +1,16 @@
 {
   "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    },
+    "logLevel": {
+      "default": "Information"
+    }
+  },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle.Preview",
     "version": "[4.*, 5.0.0)"

--- a/test/README.md
+++ b/test/README.md
@@ -109,3 +109,5 @@ Enabling debug logging can greatly increase the information available which can 
 ```
 
 WARNING : Doing this will add a not-insignificant overhead to the test run duration from writing all the additional content to the log files, which may cause timeouts to occur in tests. If this happens you can temporarily increase those timeouts while debug logging is enabled to avoid having unexpected failures.
+
+To enable debug logging in the pipelines set the `AFSQLEXT_TEST_LOGLEVEL` pipeline variable to the desired value (such as `Debug`) and it will use that value when running tests instead of the default.


### PR DESCRIPTION
Having debug enabled was causing major delays when running tests (especially benchmark tests) and so I'm reverting my change to enable debug by default and instead have a setting that can be enabled in the pipeline to add more verbose logging. 

This has the downside that if a transient error occurs then it'll be a bit harder to track down as we'll have to rely on it happening again or Information logging being enough - but our runs have generally been stable enough that this should be fine for normal runs (and then debug logging can be enabled for getting additional logs during pipeline runs)

Times before (with debug logging enabled)

![image](https://user-images.githubusercontent.com/28519865/204397684-6c6371e8-d34d-458d-ae13-e0d9d633afdb.png)

Times after (with default Information logging)

![image](https://user-images.githubusercontent.com/28519865/204397793-9498b04a-12bd-4317-ac64-0e7bc606d00b.png)
