### PR TITLE
Cleanup error events

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -423,7 +423,6 @@ This extension collect usage data in order to help us improve your experience. T
         GetScaleStatus,
         GetUnprocessedChangeCount,
         GetUnprocessedChangeCountRollback,
-        InvalidConfigurationValue,
         MissingPrimaryKeys,
         NoPrimaryKeys,
         ProcessChanges,
@@ -435,6 +434,7 @@ This extension collect usage data in order to help us improve your experience. T
         RenewLeasesLoop,
         RenewLeasesRollback,
         StartListener,
+        TriggerFunction,
         Upsert,
         UpsertRollback,
     }

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         // In the future might make sense to retry executing the function, but for now we just let
                         // another worker try.
                         this._logger.LogError($"Failed to trigger user function for table: '{this._userTable.FullName} due to exception: {result.Exception.GetType()}. Exception message: {result.Exception.Message}");
-                        TelemetryInstance.TrackException(TelemetryErrorName.ProcessChanges, result.Exception, this._telemetryProps, measures);
+                        TelemetryInstance.TrackException(TelemetryErrorName.TriggerFunction, result.Exception, this._telemetryProps, measures);
 
                         await this.ClearRowsAsync();
                     }


### PR DESCRIPTION
1. ProcessChanges was being used in multiple places so making the event when an exception from executing user code was done its own separate name to be able to better tell where an error happened
2. Removed old error name we don't use anymore (and isn't something I see being useful to track currently)