### PR TITLE
Test fix and logging improvement

### DIFF
--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -43,11 +43,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// <param name="commandText">The scalar T-SQL command.</param>
         /// <param name="catchException">Optional exception handling.  Pass back 'true' to handle the
         /// exception, 'false' to throw. If Null is passed in then all exceptions are thrown.</param>
+        /// <param name="message">Optional message to write when this query is executed. Defaults to writing the query commandText</param>
         /// <returns>The number of rows affected</returns>
         public static int ExecuteNonQuery(
             IDbConnection connection,
             string commandText,
-            Predicate<Exception> catchException = null)
+            Predicate<Exception> catchException = null,
+            string message = null)
         {
             if (connection == null)
             {
@@ -57,6 +59,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
             {
                 throw new ArgumentNullException(nameof(commandText));
             }
+            message ??= $"Executing non-query {commandText}";
 
             using (IDbCommand cmd = connection.CreateCommand())
             {
@@ -65,8 +68,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 
                     cmd.CommandText = commandText;
                     cmd.CommandType = CommandType.Text;
-                    cmd.CommandTimeout = 60000; // Increase from default 30s to prevent timeouts while connecting to Azure SQL DB
-                    Console.WriteLine($"Executing non-query {commandText}");
+                    cmd.CommandTimeout = 60; // Increase from default 30s to prevent timeouts while connecting to Azure SQL DB
+                    Console.WriteLine(message);
                     return cmd.ExecuteNonQuery();
                 }
                 catch (Exception ex)

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -354,9 +354,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <summary>
         /// Executes a command against the current connection.
         /// </summary>
-        protected void ExecuteNonQuery(string commandText)
+        /// <param name="command">Command text to execute</param>
+        /// <param name="message">Optional message to write when this query is executed. Defaults to writing the query commandText</param>
+        protected void ExecuteNonQuery(string commandText, string message = null)
         {
-            TestUtils.ExecuteNonQuery(this.Connection, commandText);
+            TestUtils.ExecuteNonQuery(this.Connection, commandText, message: message);
         }
 
         /// <summary>
@@ -460,7 +462,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 queryBuilder.AppendLine($"INSERT INTO dbo.Products VALUES({p.ProductID}, '{p.Name}', {p.Cost});");
             }
 
-            this.ExecuteNonQuery(queryBuilder.ToString());
+            this.ExecuteNonQuery(queryBuilder.ToString(), $"Inserting {products.Length} products");
         }
 
         protected static Product[] GetProducts(int n, int cost)

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -530,6 +530,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         protected void InsertProducts(int firstId, int lastId)
         {
+            string message = $"Inserting products with ID from {firstId}-{lastId}";
             // Only 1000 items are allowed to be inserted into a single INSERT statement so if we have more than 1000 batch them up into separate statements
             var builder = new StringBuilder();
             do
@@ -538,7 +539,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 builder.Append($"INSERT INTO [dbo].[Products] VALUES {string.Join(",\n", Enumerable.Range(firstId, batchCount).Select(id => $"({id}, 'Product {id}', {id * 100})"))}; ");
                 firstId += batchCount;
             } while (firstId < lastId);
-            this.ExecuteNonQuery(builder.ToString());
+            this.ExecuteNonQuery(builder.ToString(), message);
         }
 
         protected void UpdateProducts(int firstId, int lastId)


### PR DESCRIPTION
1. Allow overriding message printed out when running queries during tests - some like the INSERT statements can be extremely long so to reduce the amount of text to sift through shortening those
2. Fix query timeout - the timeout value is in seconds (so it was waiting 60,000 seconds instead of the more reasonable 60 seconds)