### PR TITLE
Cleanup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 [![Build Status](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_apis/build/status/SQL%20Bindings/SQL%20Bindings%20-%20Nightly?branchName=main)](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/latest?definitionId=481&branchName=main)
 
 ## Table of Contents
+- [Azure SQL bindings for Azure Functions - Preview](#azure-sql-bindings-for-azure-functions---preview)
+  - [Table of Contents](#table-of-contents)
   - [Introduction](#introduction)
+  - [Supported SQL Server Versions](#supported-sql-server-versions)
   - [Known Issues](#known-issues)
   - [Telemetry](#telemetry)
   - [Trademarks](#trademarks)
@@ -16,13 +19,16 @@ This repository contains the Azure SQL bindings for Azure Functions extension co
 - **Output Binding**: takes a list of rows and upserts them into the user table (i.e. If a row doesn't already exist, it is added. If it does, it is updated).
 - **Trigger Binding**: monitors the user table for changes (i.e., row inserts, updates, and deletes) and invokes the function with updated rows.
 
-See the language-specific guides for further details on support and usage of the Azure SQL bindings for Azure Functions in the supported languages:
+For a more detailed overview of the different types of bindings see the [Bindings Overview](./docs/BindingsOverview.md).
 
-- [.NET (C# in-process)](./docs/BindingsGuide_Dotnet.md)
-- [Java](./docs/BindingsGuide_Java.md)
-- [Javascript](./docs/BindingsGuide_Javascript.md)
-- [Python](./docs/BindingsGuide_Python.md)
-- [PowerShell](./docs/BindingsGuide_PowerShell.md)
+For further details on setup, usage and samples of the bindings see the language-specific guides below:
+
+- [.NET (C# in-process)](./docs/SetupGuide_Dotnet.md)
+- [.NET (C# out-of-proc)](./docs/SetupGuide_DotnetOutOfProc.md)
+- [Java](./docs/SetupGuide_Java.md)
+- [Javascript](./docs/SetupGuide_Javascript.md)
+- [PowerShell](./docs/SetupGuide_PowerShell.md)
+- [Python](./docs/SetupGuide_Python.md)
 
 Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
 

--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -1,5 +1,24 @@
 # Azure SQL bindings for Azure Functions - Overview
 
+## Table of Contents
+- [Azure SQL bindings for Azure Functions - Overview](#azure-sql-bindings-for-azure-functions---overview)
+  - [Table of Contents](#table-of-contents)
+  - [Input Binding](#input-binding)
+  - [Output Binding](#output-binding)
+    - [Primary Key Special Cases](#primary-key-special-cases)
+      - [Identity Columns](#identity-columns)
+      - [Columns with Default Values](#columns-with-default-values)
+  - [Trigger Binding](#trigger-binding)
+    - [Change Tracking](#change-tracking)
+    - [Internal State Tables](#internal-state-tables)
+      - [az\_func.GlobalState](#az_funcglobalstate)
+      - [az\_func.Leases\_\*](#az_funcleases_)
+    - [Configuration for Trigger Bindings](#configuration-for-trigger-bindings)
+      - [Sql\_Trigger\_BatchSize](#sql_trigger_batchsize)
+      - [Sql\_Trigger\_PollingIntervalMs](#sql_trigger_pollingintervalms)
+      - [Sql\_Trigger\_MaxChangesPerWorker](#sql_trigger_maxchangesperworker)
+    - [Scaling for Trigger Bindings](#scaling-for-trigger-bindings)
+
 ## Input Binding
 
 Azure SQL Input bindings take a SQL query to run and returns the output of the query in the function.

--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -1,0 +1,110 @@
+# Azure SQL bindings for Azure Functions - Overview
+
+## Input Binding
+
+Azure SQL Input bindings take a SQL query to run and returns the output of the query in the function.
+
+## Output Binding
+
+Azure SQL Output bindings take a list of rows and upserts them to the user table. Upserting means that if the primary key values of the row already exists in the table, the row is interpreted as an update, meaning that the values of the other columns in the table for that row are updated. If the primary key values do not exist in the table, the row values are inserted as new values. The upserting of the rows is batched by the output binding code.
+
+  > **NOTE:** By default the Output binding uses the T-SQL [MERGE](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql) statement which requires [SELECT](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql#permissions) permissions on the target database.
+
+### Primary Key Special Cases
+
+Typically Output Bindings require two things :
+
+1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
+2. Each of those columns must be present in the POCO object used in the attribute
+
+Normally either of these are false then an error will be thrown. Below are the situations in which this is not the case :
+
+#### Identity Columns
+In the case where one of the primary key columns is an identity column, there are two options based on how the function defines the output object:
+
+1. If the identity column isn't included in the output object then a straight insert is always performed with the other column values. See [AddProductWithIdentityColumn](../samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumn.cs) for an example.
+2. If the identity column is included (even if it's an optional nullable value) then a merge is performed similar to what happens when no identity column is present. This merge will either insert a new row or update an existing row based on the existence of a row that matches the primary keys (including the identity column). See [AddProductWithIdentityColumnIncluded](../samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumnIncluded.cs) for an example.
+
+#### Columns with Default Values
+In the case where one of the primary key columns has a default value, there are also two options based on how the function defines the output object:
+1. If the column with a default value is not included in the output object, then a straight insert is always performed with the other values. See [AddProductWithDefaultPK](../samples/samples-csharp/OutputBindingSamples/AddProductWithDefaultPK.cs) for an example.
+2. If the column with a default value is included then a merge is performed similar to what happens when no default column is present. If there is a nullable column with a default value, then the provided column value in the output object will be upserted even if it is null.
+
+## Trigger Binding
+
+Azure SQL Trigger bindings monitor the user table for changes (i.e., row inserts, updates, and deletes) and invokes the function with updated rows.
+
+### Change Tracking
+
+Azure SQL Trigger bindings utilize SQL [change tracking](https://docs.microsoft.com/sql/relational-databases/track-changes/about-change-tracking-sql-server) functionality to monitor the user table for changes. As such, it is necessary to enable change tracking on the SQL database and the SQL table before using the trigger support. The change tracking can be enabled through the following two queries.
+
+1. Enabling change tracking on the SQL database:
+
+    ```sql
+    ALTER DATABASE ['your database name']
+    SET CHANGE_TRACKING = ON
+    (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
+    ```
+
+    The `CHANGE_RETENTION` option specifies the duration for which the changes are retained in the change tracking table. This may affect the trigger functionality. For example, if the user application is turned off for several days and then resumed, it will only be able to catch the changes that occurred in past two days with the above query. Hence, please update the value of `CHANGE_RETENTION` to suit your requirements. The `AUTO_CLEANUP` option is used to enable or disable the clean-up task that removes the stale data. Please refer to SQL Server documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-database) for more information.
+
+1. Enabling change tracking on the SQL table:
+
+    ```sql
+    ALTER TABLE dbo.Employees
+    ENABLE CHANGE_TRACKING;
+    ```
+
+    For more information, please refer to the documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-table). The trigger needs to have read access on the table being monitored for changes as well as to the change tracking system tables. It also needs write access to an `az_func` schema within the database, where it will create additional leases tables to store the trigger states and leases. Each function trigger will thus have an associated change tracking table and leases table.
+
+    > **NOTE:** The leases table contains all columns corresponding to the primary key from the user table and three additional columns named `_az_func_ChangeVersion`, `_az_func_AttemptCount` and `_az_func_LeaseExpirationTime`. If any of the primary key columns happen to have the same name, that will result in an error message listing any conflicts. In this case, the listed primary key columns must be renamed for the trigger to work.
+
+### Internal State Tables
+
+The trigger functionality creates several tables to use for tracking the current state of the trigger. This allows state to be persisted across sessions and for multiple instances of a trigger binding to execute in parallel (for scaling purposes).
+
+In addition, a schema named `az_func` will be created that the tables will belong to.
+
+The login the trigger is configured to use must be given permissions to create these tables and schema. If not, then an error will be thrown and the trigger will fail to run.
+
+If the tables are deleted or modified, then unexpected behavior may occur. To reset the state of the triggers, first stop all currently running functions with trigger bindings and then either truncate or delete the tables. The next time a function with a trigger binding is started, it will recreate the tables as necessary.
+
+#### az_func.GlobalState
+
+This table stores information about each function being executed, what table that function is watching and what the [last sync state](https://learn.microsoft.com/sql/relational-databases/track-changes/work-with-change-tracking-sql-server) that has been processed.
+
+#### az_func.Leases_*
+
+A `Leases_*` table is created for every unique instance of a function and table. The full name will be in the format `Leases_<FunctionId>_<TableId>` where `<FunctionId>` is generated from the function ID and `<TableId>` is the object ID of the table being tracked. Such as `Leases_7d12c06c6ddff24c_1845581613`.
+
+This table is used to ensure that all changes are processed and that no change is processed more than once. This table consists of two groups of columns:
+
+   * A column for each column in the primary key of the target table - used to identify the row that it maps to in the target table
+   * A couple columns for tracking the state of each row. These are:
+     * `_az_func_ChangeVersion` for the change version of the row currently being processed
+     * `_az_func_AttemptCount` for tracking the number of times that a change has attempted to be processed to avoid getting stuck trying to process a change it's unable to handle
+     * `_az_func_LeaseExpirationTime` for tracking when the lease on this row for a particular instance is set to expire. This ensures that if an instance exits unexpectedly another instance will be able to pick up and process any changes it had leases for after the expiration time has passed.
+
+A row is created for every row in the target table that is modified. These are then cleaned up after the changes are processed for a set of changes corresponding to a change tracking sync version.
+
+### Configuration for Trigger Bindings
+
+This section goes over some of the configuration values you can use to customize SQL trigger bindings. See [How to Use Azure Function App Settings](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings) to learn more.
+
+#### Sql_Trigger_BatchSize
+
+This controls the number of changes processed at once before being sent to the triggered function.
+
+#### Sql_Trigger_PollingIntervalMs
+
+This controls the delay in milliseconds between processing each batch of changes.
+
+#### Sql_Trigger_MaxChangesPerWorker
+
+This controls the upper limit on the number of pending changes in the user table that are allowed per application-worker. If the count of changes exceeds this limit, it may result in a scale out. The setting only applies for Azure Function Apps with runtime driven scaling enabled. See the [Scaling](#scaling-for-trigger-bindings) section for more information.
+
+### Scaling for Trigger Bindings
+
+If your application containing functions with SQL trigger bindings is running as an Azure function app, it will be scaled automatically based on the amount of changes that are pending to be processed in the user table. As of today, we only support scaling of function apps running in Elastic Premium plan. To enable scaling, you will need to go the function app resource's page on Azure Portal, then to Configuration > 'Function runtime settings' and turn on 'Runtime Scale Monitoring'. For more information, check documentation on [Runtime Scaling](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling#runtime-scaling). You can configure scaling parameters by going to 'Scale out (App Service plan)' setting on the function app's page. To understand various scale settings, please check the respective sections in [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan?tabs=portal#eliminate-cold-starts)'s documentation.
+
+There are a couple of checks made to decide on whether the host application needs to be scaled in or out. The rationale behind these checks is to ensure that the count of pending changes per application-worker stays below a certain maximum limit, which is defaulted to 1000, while also ensuring that the number of workers running stays minimal. The scaling decision is made based on the latest count of the pending changes and whether the last 5 times we checked the count, we found it to be continuously increasing or decreasing.

--- a/docs/GeneralSetup.md
+++ b/docs/GeneralSetup.md
@@ -195,8 +195,8 @@ Once you have your Function App you need to configure it for use with Azure SQL 
 
 You have setup your local environment and are now ready to create your first Azure Function with SQL bindings! Continue to the language specific guides for the next steps in creating and configuration your function!
 
-- [.NET](./BindingsGuide_Dotnet.md)
-- [Java](./BindingsGuide_Java.md)
-- [Javascript](./BindingsGuide_Javascript.md)
-- [Python](./BindingsGuide_Python.md)
-- [PowerShell](./BindingsGuide_PowerShell.md)
+- [.NET](./SetupGuide_Dotnet.md)
+- [Java](./SetupGuide_Java.md)
+- [Javascript](./SetupGuide_Javascript.md)
+- [Python](./SetupGuide_Python.md)
+- [PowerShell](./SetupGuide_PowerShell.md)

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -1,5 +1,30 @@
 # Azure SQL bindings for Azure Functions - .NET
 
+## Table of Contents
+- [Azure SQL bindings for Azure Functions - .NET](#azure-sql-bindings-for-azure-functions---net)
+  - [Table of Contents](#table-of-contents)
+  - [Setup Function App](#setup-function-app)
+  - [Input Binding](#input-binding)
+    - [SqlAttribute for Input Bindings](#sqlattribute-for-input-bindings)
+    - [Setup for Input Bindings](#setup-for-input-bindings)
+    - [Samples for Input Bindings](#samples-for-input-bindings)
+      - [Query String](#query-string)
+      - [Empty Parameter Value](#empty-parameter-value)
+      - [Null Parameter Value](#null-parameter-value)
+      - [Stored Procedure](#stored-procedure)
+      - [IAsyncEnumerable](#iasyncenumerable)
+  - [Output Binding](#output-binding)
+    - [SqlAttribute for Output Bindings](#sqlattribute-for-output-bindings)
+    - [Setup for Output Bindings](#setup-for-output-bindings)
+    - [Samples for Output Bindings](#samples-for-output-bindings)
+      - [ICollector\<T\>/IAsyncCollector\<T\>](#icollectortiasynccollectort)
+      - [Array](#array)
+      - [Single Row](#single-row)
+  - [Trigger Binding](#trigger-binding)
+    - [SqlTriggerAttribute](#sqltriggerattribute)
+    - [Setup for Trigger Bindings](#setup-for-trigger-bindings)
+
+
 ## Setup Function App
 
 These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
@@ -23,9 +48,11 @@ These instructions will guide you through creating your Function App and adding 
 
 ## Input Binding
 
+See [Input Binding Overview](./BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
+
 ### SqlAttribute for Input Bindings
 
-An input binding takes four [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs):
+The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Input bindings takes four arguments:
 
 - **CommandText**: Passed as a constructor argument to the binding. Represents either a query string or the name of a stored procedure.
 - **CommandType**: Specifies whether CommandText is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`)
@@ -214,13 +241,11 @@ public static async Task<IActionResult> Run(
 
 ## Output Binding
 
+See [Output Binding Overview](./BindingsOverview.md#output-binding) for general information about the Azure SQL Output binding.
+
 ### SqlAttribute for Output Bindings
 
-The output binding takes a list of rows to be upserted into a user table. If the primary key value of the row already exists in the table, the row is interpreted as an update, meaning that the values of the other columns in the table for that primary key are updated. If the primary key value does not exist in the table, the row is interpreted as an insert. The upserting of the rows is batched by the output binding code.
-
-  > **NOTE:** By default the Output binding uses the T-SQL [MERGE](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql) statement which requires [SELECT](https://docs.microsoft.com/sql/t-sql/statements/merge-transact-sql#permissions) permissions on the target database.
-
-The output binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs):
+The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Output bindings takes two arguments:
 
 - **CommandText**: Passed as a constructor argument to the binding. Represents the name of the table into which rows will be upserted.
 - **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
@@ -375,31 +400,13 @@ public static IActionResult Run(
 }
 ```
 
-### Primary Key Special Cases
-
-Typically Output Bindings require two things :
-
-1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
-2. Each of those columns must be present in the POCO object used in the attribute
-
-Normally either of these are false then an error will be thrown. Below are the situations in which this is not the case :
-
-#### Identity Columns
-In the case where one of the primary key columns is an identity column, there are two options based on how the function defines the output object:
-
-1. If the identity column isn't included in the output object then a straight insert is always performed with the other column values. See [AddProductWithIdentityColumn](../samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumn.cs) for an example.
-2. If the identity column is included (even if it's an optional nullable value) then a merge is performed similar to what happens when no identity column is present. This merge will either insert a new row or update an existing row based on the existence of a row that matches the primary keys (including the identity column). See [AddProductWithIdentityColumnIncluded](../samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumnIncluded.cs) for an example.
-
-#### Columns with Default Values
-In the case where one of the primary key columns has a default value, there are also two options based on how the function defines the output object:
-1. If the column with a default value is not included in the output object, then a straight insert is always performed with the other values. See [AddProductWithDefaultPK](../samples/samples-csharp/OutputBindingSamples/AddProductWithDefaultPK.cs) for an example.
-2. If the column with a default value is included then a merge is performed similar to what happens when no default column is present. If there is a nullable column with a default value, then the provided column value in the output object will be upserted even if it is null.
-
 ## Trigger Binding
+
+See [Trigger Binding Overview](./BindingsOverview.md#trigger-binding) for general information about the Azure SQL Trigger binding.
 
 ### SqlTriggerAttribute
 
-The trigger binding takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)
+The SqlAttribute for Trigger bindings takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)
 
 - **TableName**: Passed as a constructor argument to the binding. Represents the name of the table to be monitored for changes.
 - **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
@@ -411,59 +418,6 @@ The trigger binding can bind to type `IReadOnlyList<SqlChange<T>>`:
 Note that for insert and update operations, the user function receives POCO object containing the latest values of table columns. For delete operation, only the properties corresponding to the primary keys of the row are populated.
 
 Any time when the changes happen to the "Products" table, the user function will be invoked with a batch of changes. The changes are processed sequentially, so if there are a large number of changes pending to be processed, the function will be passed a batch containing the earliest changes first.
-
-### Change Tracking
-
-The trigger binding utilizes SQL [change tracking](https://docs.microsoft.com/sql/relational-databases/track-changes/about-change-tracking-sql-server) functionality to monitor the user table for changes. As such, it is necessary to enable change tracking on the SQL database and the SQL table before using the trigger support. The change tracking can be enabled through the following two queries.
-
-1. Enabling change tracking on the SQL database:
-
-    ```sql
-    ALTER DATABASE ['your database name']
-    SET CHANGE_TRACKING = ON
-    (CHANGE_RETENTION = 2 DAYS, AUTO_CLEANUP = ON);
-    ```
-
-    The `CHANGE_RETENTION` option specifies the duration for which the changes are retained in the change tracking table. This may affect the trigger functionality. For example, if the user application is turned off for several days and then resumed, it will only be able to catch the changes that occurred in past two days with the above query. Hence, please update the value of `CHANGE_RETENTION` to suit your requirements. The `AUTO_CLEANUP` option is used to enable or disable the clean-up task that removes the stale data. Please refer to SQL Server documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-database) for more information.
-
-1. Enabling change tracking on the SQL table:
-
-    ```sql
-    ALTER TABLE dbo.Employees
-    ENABLE CHANGE_TRACKING;
-    ```
-
-    For more information, please refer to the documentation [here](https://docs.microsoft.com/sql/relational-databases/track-changes/enable-and-disable-change-tracking-sql-server#enable-change-tracking-for-a-table). The trigger needs to have read access on the table being monitored for changes as well as to the change tracking system tables. It also needs write access to an `az_func` schema within the database, where it will create additional leases tables to store the trigger states and leases. Each function trigger will thus have an associated change tracking table and leases table.
-
-    > **NOTE:** The leases table contains all columns corresponding to the primary key from the user table and three additional columns named `_az_func_ChangeVersion`, `_az_func_AttemptCount` and `_az_func_LeaseExpirationTime`. If any of the primary key columns happen to have the same name, that will result in an error message listing any conflicts. In this case, the listed primary key columns must be renamed for the trigger to work.
-
-### Internal State Tables
-
-The trigger functionality creates several tables to use for tracking the current state of the trigger. This allows state to be persisted across sessions and for multiple instances of a trigger binding to execute in parallel (for scaling purposes).
-
-In addition, a schema named `az_func` will be created that the tables will belong to.
-
-The login the trigger is configured to use must be given permissions to create these tables and schema. If not, then an error will be thrown and the trigger will fail to run.
-
-If the tables are deleted or modified, then unexpected behavior may occur. To reset the state of the triggers, first stop all currently running functions with trigger bindings and then either truncate or delete the tables. The next time a function with a trigger binding is started, it will recreate the tables as necessary.
-
-#### az_func.GlobalState
-
-This table stores information about each function being executed, what table that function is watching and what the [last sync state](https://learn.microsoft.com/sql/relational-databases/track-changes/work-with-change-tracking-sql-server) that has been processed.
-
-#### az_func.Leases_*
-
-A `Leases_*` table is created for every unique instance of a function and table. The full name will be in the format `Leases_<FunctionId>_<TableId>` where `<FunctionId>` is generated from the function ID and `<TableId>` is the object ID of the table being tracked. Such as `Leases_7d12c06c6ddff24c_1845581613`.
-
-This table is used to ensure that all changes are processed and that no change is processed more than once. This table consists of two groups of columns:
-
-   * A column for each column in the primary key of the target table - used to identify the row that it maps to in the target table
-   * A couple columns for tracking the state of each row. These are:
-     * `_az_func_ChangeVersion` for the change version of the row currently being processed
-     * `_az_func_AttemptCount` for tracking the number of times that a change has attempted to be processed to avoid getting stuck trying to process a change it's unable to handle
-     * `_az_func_LeaseExpirationTime` for tracking when the lease on this row for a particular instance is set to expire. This ensures that if an instance exits unexpectedly another instance will be able to pick up and process any changes it had leases for after the expiration time has passed.
-
-A row is created for every row in the target table that is modified. These are then cleaned up after the changes are processed for a set of changes corresponding to a change tracking sync version.
 
 ### Setup for Trigger Bindings
 
@@ -520,25 +474,3 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Update, insert, or delete rows in your SQL table while the function app is running and observe the function logs.
 - You should see the new log messages in the Visual Studio Code terminal containing the values of row-columns after the update operation.
 - Congratulations! You have successfully created your first SQL trigger binding!
-
-### Configuration for Trigger Bindings
-
-This section goes over some of the configuration values you can use to customize the SQL bindings. See [How to Use Azure Function App Settings](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings) to learn more.
-
-#### Sql_Trigger_BatchSize
-
-This controls the number of changes processed at once before being sent to the triggered function.
-
-#### Sql_Trigger_PollingIntervalMs
-
-This controls the delay in milliseconds between processing each batch of changes.
-
-#### Sql_Trigger_MaxChangesPerWorker
-
-This controls the upper limit on the number of pending changes in the user table that are allowed per application-worker. If the count of changes exceeds this limit, it may result in a scale out. The setting only applies for Azure Function Apps with runtime driven scaling enabled. See the [Scaling](#scaling) section for more information.
-
-### Scaling for Trigger Bindings
-
-If your application containing functions with SQL trigger bindings is running as an Azure function app, it will be scaled automatically based on the amount of changes that are pending to be processed in the user table. As of today, we only support scaling of function apps running in Elastic Premium plan. To enable scaling, you will need to go the function app resource's page on Azure Portal, then to Configuration > 'Function runtime settings' and turn on 'Runtime Scale Monitoring'. For more information, check documentation on [Runtime Scaling](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling#runtime-scaling). You can configure scaling parameters by going to 'Scale out (App Service plan)' setting on the function app's page. To understand various scale settings, please check the respective sections in [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan?tabs=portal#eliminate-cold-starts)'s documentation.
-
-There are a couple of checks made to decide on whether the host application needs to be scaled in or out. The rationale behind these checks is to ensure that the count of pending changes per application-worker stays below a certain maximum limit, which is defaulted to 1000, while also ensuring that the number of workers running stays minimal. The scaling decision is made based on the latest count of the pending changes and whether the last 5 times we checked the count, we found it to be continuously increasing or decreasing.

--- a/docs/SetupGuide_Java.md
+++ b/docs/SetupGuide_Java.md
@@ -1,5 +1,27 @@
 # Azure SQL bindings for Azure Functions - Java
 
+## Table of Contents
+- [Azure SQL bindings for Azure Functions - Java](#azure-sql-bindings-for-azure-functions---java)
+  - [Table of Contents](#table-of-contents)
+  - [Setup Function App](#setup-function-app)
+  - [Input Binding](#input-binding)
+    - [SQLInput Attribute](#sqlinput-attribute)
+    - [Setup for Input Bindings](#setup-for-input-bindings)
+    - [Samples for Input Bindings](#samples-for-input-bindings)
+      - [Query String](#query-string)
+      - [Empty Parameter Value](#empty-parameter-value)
+      - [Null Parameter Value](#null-parameter-value)
+      - [Stored Procedure](#stored-procedure)
+      - [IAsyncEnumerable](#iasyncenumerable)
+  - [Output Binding](#output-binding)
+    - [SQLOutput Attribute](#sqloutput-attribute)
+    - [Setup for Output Bindings](#setup-for-output-bindings)
+    - [Samples for Output Bindings](#samples-for-output-bindings)
+      - [ICollector\<T\>/IAsyncCollector\<T\>](#icollectortiasynccollectort)
+      - [Array](#array)
+      - [Single Row](#single-row)
+  - [Trigger Binding](#trigger-binding)
+
 ## Setup Function App
 
 These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
@@ -25,12 +47,15 @@ These instructions will guide you through creating your Function App and adding 
 
 ## Input Binding
 
+See [Input Binding Overview](./BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
+
 ### SQLInput Attribute
 
 In the Java functions runtime library, use the @SQLInput annotation (com.microsoft.azure.functions.sql.annotation.SQLInput) on parameters whose value comes from the query specified by commandText. This annotation supports the following elements:
+
 | Element |Description|
 |---------|---------|
-|**name** |  Required. The variable name used in function.json. | 
+|**name** |  Required. The variable name used in function.json. |
 | **commandText** | Required. The Transact-SQL query command or name of the stored procedure executed by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database against which the query or stored procedure is being executed. This value isn't the actual connection string and must instead resolve to an environment variable name.  Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 | **commandType** | A [CommandType](https://learn.microsoft.com/dotnet/api/system.data.commandtype) value, which is [Text](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a query and [StoredProcedure](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a stored procedure. |
@@ -143,7 +168,7 @@ _TODO_
 
 #### Stored Procedure
 
-_TODO_f
+_TODO_
 
 #### IAsyncEnumerable
 
@@ -151,13 +176,15 @@ _TODO_
 
 ## Output Binding
 
+See [Output Binding Overview](./BindingsOverview.md#output-binding) for general information about the Azure SQL Output binding.
+
 ### SQLOutput Attribute
 
 In the Java functions runtime library, use the @SQLOutput annotation (com.microsoft.azure.functions.sql.annotation.SQLOutput) on parameters whose values you want to upsert into the target table. This annotation supports the following elements:
 
 | Element |Description|
 |---------|---------|
-|**name** |  Required. The variable name used in function.json. | 
+|**name** |  Required. The variable name used in function.json. |
 | **commandText** | Required. The name of the table being written to by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database to which data is being written. This isn't the actual connection string and must instead resolve to an environment variable. Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 
@@ -212,26 +239,6 @@ _TODO_
 
 _TODO_
 
-### Primary Key Special Cases
-
-Typically Output Bindings require two things :
-
-1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
-2. Each of those columns must be present in the POCO object used in the attribute
-
-Normally either of these are false then an error will be thrown. Below are the situations in which this is not the case :
-
-#### Identity Columns
-In the case where one of the primary key columns is an identity column, there are two options based on how the function defines the output object:
-
-1. If the identity column isn't included in the output object then a straight insert is always performed with the other column values. See [AddProductWithIdentityColumn](../samples/samples-java/src/main/java/com/function/AddProductWithIdentityColumn.java) for an example.
-2. If the identity column is included (even if it's an optional nullable value) then a merge is performed similar to what happens when no identity column is present. This merge will either insert a new row or update an existing row based on the existence of a row that matches the primary keys (including the identity column). See [AddProductWithIdentityColumnIncluded](../samples/samples-java/src/main/java/com/function/AddProductWithIdentityColumnIncluded.java) for an example.
-
-#### Columns with Default Values
-In the case where one of the primary key columns has a default value, there are also two options based on how the function defines the output object:
-1. If the column with a default value is not included in the output object, then a straight insert is always performed with the other values. See [AddProductWithDefaultPK](../samples/samples-java/src/main/java/com/function/AddProductWithDefaultPK.java) for an example.
-2. If the column with a default value is included then a merge is performed similar to what happens when no default column is present. If there is a nullable column with a default value, then the provided column value in the output object will be upserted even if it is null.
-
 ## Trigger Binding
 
-> Trigger binding support is only available for C# functions at present.
+> Trigger binding support is only available for in-proc C# functions at present.

--- a/docs/SetupGuide_Javascript.md
+++ b/docs/SetupGuide_Javascript.md
@@ -1,4 +1,26 @@
-# Azure SQL bindings for Azure Functions - PowerShell
+# Azure SQL bindings for Azure Functions - Javascript
+
+## Table of Contents
+- [Azure SQL bindings for Azure Functions - Javascript](#azure-sql-bindings-for-azure-functions---javascript)
+  - [Table of Contents](#table-of-contents)
+  - [Setup Function App](#setup-function-app)
+  - [Input Binding](#input-binding)
+    - [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings)
+    - [Setup for Input Bindings](#setup-for-input-bindings)
+    - [Samples for Input Bindings](#samples-for-input-bindings)
+      - [Query String](#query-string)
+      - [Empty Parameter Value](#empty-parameter-value)
+      - [Null Parameter Value](#null-parameter-value)
+      - [Stored Procedure](#stored-procedure)
+      - [IAsyncEnumerable](#iasyncenumerable)
+  - [Output Binding](#output-binding)
+    - [function.json Properties for Output Bindings](#functionjson-properties-for-output-bindings)
+    - [Setup for Output Bindings](#setup-for-output-bindings)
+    - [Samples for Output Bindings](#samples-for-output-bindings)
+      - [ICollector\<T\>/IAsyncCollector\<T\>](#icollectortiasynccollectort)
+      - [Array](#array)
+      - [Single Row](#single-row)
+  - [Trigger Binding](#trigger-binding)
 
 ## Setup Function App
 
@@ -6,11 +28,11 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for PowerShell:
+2. Create a function app for Javascript:
     ```bash
     mkdir MyApp
     cd MyApp
-    func init --worker-runtime powershell
+    func init --worker-runtime node --language javascript
     ```
 
 3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
@@ -25,6 +47,8 @@ These instructions will guide you through creating your Function App and adding 
 
 ## Input Binding
 
+See [Input Binding Overview](./BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
+
 ### function.json Properties for Input Bindings
 
 The following table explains the binding configuration properties that you set in the *function.json* file.
@@ -33,7 +57,7 @@ The following table explains the binding configuration properties that you set i
 |---------|----------------------|
 |**type** |  Required. Must be set to `sql`. |
 |**direction** | Required. Must be set to `in`. |
-|**name** |  Required. The name of the variable that represents the query results in function code. | 
+|**name** |  Required. The name of the variable that represents the query results in function code. |
 | **commandText** | Required. The Transact-SQL query command or name of the stored procedure executed by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database against which the query or stored procedure is being executed. This value isn't the actual connection string and must instead resolve to an environment variable name.  Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 | **commandType** | Required. A [CommandType](https://learn.microsoft.com/dotnet/api/system.data.commandtype) value, which is [Text](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a query and [StoredProcedure](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a stored procedure. |
@@ -46,19 +70,15 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> anonymous
-- In the file that opens (`run.ps1`), replace the code within the file the below code.
+- In the file that opens (`index.js`), replace the `module.exports = async function (context, req)` block with the below code.
 
-    ```powershell
-    using namespace System.Net
-
-    param($Request, $employee)
-    
-    Write-Host "PowerShell function with SQL Input Binding processed a request."
-    
-    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
-        StatusCode = [System.Net.HttpStatusCode]::OK
-        Body = $employee
-    })
+    ```javascript
+    module.exports = async function (context, req, employee) {
+        return {
+            status: 200,
+            body: employee
+        };
+    }
     ```
 
 - We also need to add the SQL input binding for the `employee` parameter. Open the function.json file.
@@ -101,7 +121,13 @@ _TODO_
 
 _TODO_
 
+#### IAsyncEnumerable
+
+_TODO_
+
 ## Output Binding
+
+See [Output Binding Overview](./BindingsOverview.md#output-binding) for general information about the Azure SQL Output binding.
 
 ### function.json Properties for Output Bindings
 
@@ -111,7 +137,7 @@ The following table explains the binding configuration properties that you set i
 |---------|----------------------|
 |**type** | Required. Must be set to `sql`.|
 |**direction** | Required. Must be set to `out`. |
-|**name** | Required. The name of the variable that represents the entity in function code. | 
+|**name** | Required. The name of the variable that represents the entity in function code. |
 | **commandText** | Required. The name of the table being written to by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database to which data is being written. This isn't the actual connection string and must instead resolve to an environment variable. Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 
@@ -122,43 +148,36 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Open your app in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger ->  (Provide a function name) -> anonymous
-- In the file that opens (`run.ps1`), replace the code within the file the below code.
+- In the file that opens (`index.js`), replace the `module.exports = async function (context, req)` block with the below code.
 
-   ```powershell
-    using namespace System.Net
+    ```javascript
+    module.exports = async function (context, req) {
+        const employees = [
+            {
+                EmployeeId : 1,
+                FirstName : "Hello",
+                LastName : "World",
+                Company : "Microsoft",
+                Team : "Functions"
+            },
+            {
+                EmployeeId : 2,
+                FirstName : "Hi",
+                LastName : "SQLupdate",
+                Company : "Microsoft",
+                Team : "Functions"
+            }
+        ];
+        context.bindings.employee = employees;
 
-    param($Request)
-
-    Write-Host "PowerShell function with SQL Output Binding processed a request."
-
-    # Update req_body with the body of the request
-    $req_body = @(
-        @{
-            EmployeeId=1,
-            FirstName="Hello",
-            LastName="World",
-            Company="Microsoft",
-            Team="Functions"
-        },
-        @{
-            EmployeeId=2,
-            FirstName="Hi",
-            LastName="SQLupdate",
-            Company="Microsoft",
-            Team="Functions"
-        }
-    );
-    # Assign the value we want to pass to the SQL Output binding. 
-    # The -Name value corresponds to the name property in the function.json for the binding
-    Push-OutputBinding -Name employee -Value $req_body
-
-    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
-        StatusCode = [HttpStatusCode]::OK
-        Body = $req_body
-    })
+        return {
+            status: 201,
+            body: employees
+        };
+    }
     ```
 
-- We also need to add the SQL output binding for the `employee` parameter. Open the function.json file.
+- We also need to add the SQL output binding for the `context.bindings.employee` property. Open the function.json file.
 - Paste the below in the file as an additional entry to the "bindings": [] array.
 
     ```json
@@ -189,26 +208,6 @@ _TODO_
 
 _TODO_
 
-### Primary Key Special Cases
-
-Typically Output Bindings require two things:
-
-1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
-2. Each of those columns must be present in the POCO object used in the attribute
-
-Normally either of these are false then an error will be thrown. Below are the situations in which this is not the case:
-
-#### Identity Columns
-In the case where one of the primary key columns is an identity column, there are two options based on how the function defines the output object:
-
-1. If the identity column isn't included in the output object then a straight insert is always performed with the other column values. See [AddProductWithIdentityColumn](../samples/samples-powershell/AddProductWithIdentityColumn/run.ps1) for an example.
-2. If the identity column is included (even if it's an optional nullable value) then a merge is performed similar to what happens when no identity column is present. This merge will either insert a new row or update an existing row based on the existence of a row that matches the primary keys (including the identity column). See [AddProductWithIdentityColumnIncluded](../samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1) for an example.
-
-#### Columns with Default Values
-In the case where one of the primary key columns has a default value, there are also two options based on how the function defines the output object:
-1. If the column with a default value is not included in the output object, then a straight insert is always performed with the other values. See [AddProductWithDefaultPK](../samples/samples-powershell/AddProductWithDefaultPK/run.ps1) for an example.
-2. If the column with a default value is included then a merge is performed similar to what happens when no default column is present. If there is a nullable column with a default value, then the provided column value in the output object will be upserted even if it is null.
-
 ## Trigger Binding
 
-> Trigger binding support is only available for C# functions at present.
+> Trigger binding support is only available for in-proc C# functions at present.

--- a/docs/SetupGuide_PowerShell.md
+++ b/docs/SetupGuide_PowerShell.md
@@ -1,4 +1,25 @@
-# Azure SQL bindings for Azure Functions - Python
+# Azure SQL bindings for Azure Functions - PowerShell
+
+## Table of Contents
+- [Azure SQL bindings for Azure Functions - PowerShell](#azure-sql-bindings-for-azure-functions---powershell)
+  - [Table of Contents](#table-of-contents)
+  - [Setup Function App](#setup-function-app)
+  - [Input Binding](#input-binding)
+    - [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings)
+    - [Setup for Input Bindings](#setup-for-input-bindings)
+    - [Samples for Input Bindings](#samples-for-input-bindings)
+      - [Query String](#query-string)
+      - [Empty Parameter Value](#empty-parameter-value)
+      - [Null Parameter Value](#null-parameter-value)
+      - [Stored Procedure](#stored-procedure)
+  - [Output Binding](#output-binding)
+    - [function.json Properties for Output Bindings](#functionjson-properties-for-output-bindings)
+    - [Setup for Output Bindings](#setup-for-output-bindings)
+    - [Samples for Output Bindings](#samples-for-output-bindings)
+      - [ICollector\<T\>/IAsyncCollector\<T\>](#icollectortiasynccollectort)
+      - [Array](#array)
+      - [Single Row](#single-row)
+  - [Trigger Binding](#trigger-binding)
 
 ## Setup Function App
 
@@ -6,12 +27,11 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for Python:
-    *See [#250](https://github.com/Azure/azure-functions-sql-extension/issues/250) before starting.*
+2. Create a function app for PowerShell:
     ```bash
     mkdir MyApp
     cd MyApp
-    func init --worker-runtime python
+    func init --worker-runtime powershell
     ```
 
 3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
@@ -26,13 +46,17 @@ These instructions will guide you through creating your Function App and adding 
 
 ## Input Binding
 
+See [Input Binding Overview](./BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
+
 ### function.json Properties for Input Bindings
+
+The following table explains the binding configuration properties that you set in the *function.json* file.
 
 |function.json property | Description|
 |---------|----------------------|
 |**type** |  Required. Must be set to `sql`. |
 |**direction** | Required. Must be set to `in`. |
-|**name** |  Required. The name of the variable that represents the query results in function code. | 
+|**name** |  Required. The name of the variable that represents the query results in function code. |
 | **commandText** | Required. The Transact-SQL query command or name of the stored procedure executed by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database against which the query or stored procedure is being executed. This value isn't the actual connection string and must instead resolve to an environment variable name.  Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 | **commandType** | Required. A [CommandType](https://learn.microsoft.com/dotnet/api/system.data.commandtype) value, which is [Text](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a query and [StoredProcedure](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a stored procedure. |
@@ -45,29 +69,27 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> anonymous
-- In the file that opens (`__init__.py`), replace the generated function with the following
+- In the file that opens (`run.ps1`), replace the code within the file the below code.
 
-    ```python
-    import azure.functions as func
-    import json
+    ```powershell
+    using namespace System.Net
 
-    def main(req: func.HttpRequest, employees: func.SqlRowList) -> func.HttpResponse:
-        rows = list(map(lambda r: json.loads(r.to_json()), employees))
+    param($Request, $employee)
 
-        return func.HttpResponse(
-            json.dumps(rows),
-            status_code=200,
-            mimetype="application/json"
-        )
+    Write-Host "PowerShell function with SQL Input Binding processed a request."
+
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+        StatusCode = [System.Net.HttpStatusCode]::OK
+        Body = $employee
+    })
     ```
 
-- Add an import json statement to the top of the file.
-- We also need to add the SQL input binding for the `employees` parameter. Open the function.json file.
+- We also need to add the SQL input binding for the `employee` parameter. Open the function.json file.
 - Paste the below in the file as an additional entry to the "bindings": [] array.
 
     ```json
     {
-      "name": "employees",
+      "name": "employee",
       "type": "sql",
       "direction": "in",
       "commandText": "select * from Employees",
@@ -102,11 +124,9 @@ _TODO_
 
 _TODO_
 
-#### IAsyncEnumerable
-
-_TODO_
-
 ## Output Binding
+
+See [Output Binding Overview](./BindingsOverview.md#output-binding) for general information about the Azure SQL Output binding.
 
 ### function.json Properties for Output Bindings
 
@@ -116,7 +136,7 @@ The following table explains the binding configuration properties that you set i
 |---------|----------------------|
 |**type** | Required. Must be set to `sql`.|
 |**direction** | Required. Must be set to `out`. |
-|**name** | Required. The name of the variable that represents the entity in function code. | 
+|**name** | Required. The name of the variable that represents the entity in function code. |
 | **commandText** | Required. The name of the table being written to by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database to which data is being written. This isn't the actual connection string and must instead resolve to an environment variable. Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 
@@ -127,29 +147,43 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Open your app in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger ->  (Provide a function name) -> anonymous
-- In the file that opens (`__init__.py`), replace the `def main(req: func.HttpRequest) -> func.HttpResponse:` block with the below code.
+- In the file that opens (`run.ps1`), replace the code within the file the below code.
 
-    ```python
-    def main(req: func.HttpRequest, employee: func.Out[func.SqlRow]) -> func.HttpResponse:
-        newEmployee = {
-            EmployeeId = 1,
-            FirstName = "Hello",
-            LastName = "World",
-            Company = "Microsoft",
-            Team = "Functions"
+   ```powershell
+    using namespace System.Net
+
+    param($Request)
+
+    Write-Host "PowerShell function with SQL Output Binding processed a request."
+
+    # Update req_body with the body of the request
+    $req_body = @(
+        @{
+            EmployeeId=1,
+            FirstName="Hello",
+            LastName="World",
+            Company="Microsoft",
+            Team="Functions"
+        },
+        @{
+            EmployeeId=2,
+            FirstName="Hi",
+            LastName="SQLupdate",
+            Company="Microsoft",
+            Team="Functions"
         }
-        row = func.SqlRow(newEmployee)
-        employee.set(row);
+    );
+    # Assign the value we want to pass to the SQL Output binding.
+    # The -Name value corresponds to the name property in the function.json for the binding
+    Push-OutputBinding -Name employee -Value $req_body
 
-        return func.HttpResponse(
-            body=json.dumps(newEmployee),
-            status_code=201,
-            mimetype="application/json"
-        )
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+        StatusCode = [HttpStatusCode]::OK
+        Body = $req_body
+    })
     ```
 
-- Add an import json statement to the top of the file.
-- We also need to add the SQL output binding for the `context.bindings.employee` property. Open the function.json file.
+- We also need to add the SQL output binding for the `employee` parameter. Open the function.json file.
 - Paste the below in the file as an additional entry to the "bindings": [] array.
 
     ```json
@@ -180,26 +214,6 @@ _TODO_
 
 _TODO_
 
-### Primary Key Special Cases
-
-Typically Output Bindings require two things :
-
-1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
-2. Each of those columns must be present in the POCO object used in the attribute
-
-Normally either of these are false then an error will be thrown. Below are the situations in which this is not the case :
-
-#### Identity Columns
-In the case where one of the primary key columns is an identity column, there are two options based on how the function defines the output object:
-
-1. If the identity column isn't included in the output object then a straight insert is always performed with the other column values. See [AddProductWithIdentityColumn](../samples/samples-python/AddProductWithIdentityColumn/__init__.py) for an example.
-2. If the identity column is included (even if it's an optional nullable value) then a merge is performed similar to what happens when no identity column is present. This merge will either insert a new row or update an existing row based on the existence of a row that matches the primary keys (including the identity column). See [AddProductWithIdentityColumnIncluded](../samples/samples-python/AddProductWithIdentityColumnIncluded/__init__.py) for an example.
-
-#### Columns with Default Values
-In the case where one of the primary key columns has a default value, there are also two options based on how the function defines the output object:
-1. If the column with a default value is not included in the output object, then a straight insert is always performed with the other values.
-2. If the column with a default value is included then a merge is performed similar to what happens when no default column is present. If there is a nullable column with a default value, then the provided column value in the output object will be upserted even if it is null.
-
 ## Trigger Binding
 
-> Trigger binding support is only available for C# functions at present.
+> Trigger binding support is only available for in-proc C# functions at present.

--- a/docs/SetupGuide_Python.md
+++ b/docs/SetupGuide_Python.md
@@ -1,4 +1,26 @@
-# Azure SQL bindings for Azure Functions - Javascript
+# Azure SQL bindings for Azure Functions - Python
+
+## Table of Contents
+- [Azure SQL bindings for Azure Functions - Python](#azure-sql-bindings-for-azure-functions---python)
+  - [Table of Contents](#table-of-contents)
+  - [Setup Function App](#setup-function-app)
+  - [Input Binding](#input-binding)
+    - [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings)
+    - [Setup for Input Bindings](#setup-for-input-bindings)
+    - [Samples for Input Bindings](#samples-for-input-bindings)
+      - [Query String](#query-string)
+      - [Empty Parameter Value](#empty-parameter-value)
+      - [Null Parameter Value](#null-parameter-value)
+      - [Stored Procedure](#stored-procedure)
+      - [IAsyncEnumerable](#iasyncenumerable)
+  - [Output Binding](#output-binding)
+    - [function.json Properties for Output Bindings](#functionjson-properties-for-output-bindings)
+    - [Setup for Output Bindings](#setup-for-output-bindings)
+    - [Samples for Output Bindings](#samples-for-output-bindings)
+      - [ICollector\<T\>/IAsyncCollector\<T\>](#icollectortiasynccollectort)
+      - [Array](#array)
+      - [Single Row](#single-row)
+  - [Trigger Binding](#trigger-binding)
 
 ## Setup Function App
 
@@ -6,15 +28,16 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for Javascript:
+2. Create a function app for Python:
+    *See [#250](https://github.com/Azure/azure-functions-sql-extension/issues/250) before starting.*
     ```bash
     mkdir MyApp
     cd MyApp
-    func init --worker-runtime node --language javascript
+    func init --worker-runtime python
     ```
 
 3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
-    
+
     Update the `host.json` file to the preview extension bundle.
     ```json
     "extensionBundle": {
@@ -25,15 +48,15 @@ These instructions will guide you through creating your Function App and adding 
 
 ## Input Binding
 
-### function.json Properties for Input Bindings
+See [Input Binding Overview](./BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.
 
-The following table explains the binding configuration properties that you set in the *function.json* file.
+### function.json Properties for Input Bindings
 
 |function.json property | Description|
 |---------|----------------------|
 |**type** |  Required. Must be set to `sql`. |
 |**direction** | Required. Must be set to `in`. |
-|**name** |  Required. The name of the variable that represents the query results in function code. | 
+|**name** |  Required. The name of the variable that represents the query results in function code. |
 | **commandText** | Required. The Transact-SQL query command or name of the stored procedure executed by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database against which the query or stored procedure is being executed. This value isn't the actual connection string and must instead resolve to an environment variable name.  Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 | **commandType** | Required. A [CommandType](https://learn.microsoft.com/dotnet/api/system.data.commandtype) value, which is [Text](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a query and [StoredProcedure](https://learn.microsoft.com/dotnet/api/system.data.commandtype#fields) for a stored procedure. |
@@ -46,32 +69,38 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> anonymous
-- In the file that opens (`index.js`), replace the `module.exports = async function (context, req)` block with the below code.
+- In the file that opens (`__init__.py`), replace the generated function with the following
 
-    ```javascript
-    module.exports = async function (context, req, employee) {
-        return {
-            status: 200,
-            body: employee
-        };
-    }
+    ```python
+    import azure.functions as func
+    import json
+
+    def main(req: func.HttpRequest, employees: func.SqlRowList) -> func.HttpResponse:
+        rows = list(map(lambda r: json.loads(r.to_json()), employees))
+
+        return func.HttpResponse(
+            json.dumps(rows),
+            status_code=200,
+            mimetype="application/json"
+        )
     ```
 
-- We also need to add the SQL input binding for the `employee` parameter. Open the function.json file.
+- Add an import json statement to the top of the file.
+- We also need to add the SQL input binding for the `employees` parameter. Open the function.json file.
 - Paste the below in the file as an additional entry to the "bindings": [] array.
 
     ```json
     {
-      "name": "employee",
+      "name": "employees",
       "type": "sql",
       "direction": "in",
-      "commandText": "select * from Employees",
+      "commandText": "SELECT * FROM Employees",
       "commandType": "Text",
       "connectionStringSetting": "SqlConnectionString"
     }
     ```
 
-    *In the above, "select * from Employees" is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings) section*
+    *In the above, `SELECT * FROM Employees` is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings) section*
 
 - Open the local.settings.json file, and in the brackets for "Values," verify there is a 'SqlConnectionString.' If not, add it.
 - Hit 'F5' to run your code. This will start up the Functions Host with a local HTTP Trigger and SQL Input Binding.
@@ -103,6 +132,8 @@ _TODO_
 
 ## Output Binding
 
+See [Output Binding Overview](./BindingsOverview.md#output-binding) for general information about the Azure SQL Output binding.
+
 ### function.json Properties for Output Bindings
 
 The following table explains the binding configuration properties that you set in the *function.json* file.
@@ -111,7 +142,7 @@ The following table explains the binding configuration properties that you set i
 |---------|----------------------|
 |**type** | Required. Must be set to `sql`.|
 |**direction** | Required. Must be set to `out`. |
-|**name** | Required. The name of the variable that represents the entity in function code. | 
+|**name** | Required. The name of the variable that represents the entity in function code. |
 | **commandText** | Required. The name of the table being written to by the binding.  |
 | **connectionStringSetting** | Required. The name of an app setting that contains the connection string for the database to which data is being written. This isn't the actual connection string and must instead resolve to an environment variable. Optional keywords in the connection string value are [available to refine SQL bindings connectivity](https://aka.ms/sqlbindings#sql-connection-string). |
 
@@ -122,35 +153,28 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 - Open your app in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger ->  (Provide a function name) -> anonymous
-- In the file that opens (`index.js`), replace the `module.exports = async function (context, req)` block with the below code.
+- In the file that opens (`__init__.py`), replace the `def main(req: func.HttpRequest) -> func.HttpResponse:` block with the below code.
 
-    ```javascript
-    module.exports = async function (context, req) {
-        const employees = [
-            {
-                EmployeeId : 1,
-                FirstName : "Hello",
-                LastName : "World",
-                Company : "Microsoft",
-                Team : "Functions"
-            },
-            {
-                EmployeeId : 2,
-                FirstName : "Hi",
-                LastName : "SQLupdate",
-                Company : "Microsoft",
-                Team : "Functions"
-            }
-        ];
-        context.bindings.employee = employees;
+    ```python
+    def main(req: func.HttpRequest, employee: func.Out[func.SqlRow]) -> func.HttpResponse:
+        newEmployee = {
+            EmployeeId = 1,
+            FirstName = "Hello",
+            LastName = "World",
+            Company = "Microsoft",
+            Team = "Functions"
+        }
+        row = func.SqlRow(newEmployee)
+        employee.set(row);
 
-        return {
-            status: 201,
-            body: employees
-        };
-    }
+        return func.HttpResponse(
+            body=json.dumps(newEmployee),
+            status_code=201,
+            mimetype="application/json"
+        )
     ```
 
+- Add an import json statement to the top of the file.
 - We also need to add the SQL output binding for the `context.bindings.employee` property. Open the function.json file.
 - Paste the below in the file as an additional entry to the "bindings": [] array.
 
@@ -182,26 +206,6 @@ _TODO_
 
 _TODO_
 
-### Primary Key Special Cases
-
-Typically Output Bindings require two things :
-
-1. The table being upserted to contains a Primary Key constraint (composed of one or more columns)
-2. Each of those columns must be present in the POCO object used in the attribute
-
-Normally either of these are false then an error will be thrown. Below are the situations in which this is not the case :
-
-#### Identity Columns
-In the case where one of the primary key columns is an identity column, there are two options based on how the function defines the output object:
-
-1. If the identity column isn't included in the output object then a straight insert is always performed with the other column values. See [AddProductWithIdentityColumn](../samples/samples-js/AddProductWithIdentityColumn/index.js) for an example.
-2. If the identity column is included (even if it's an optional nullable value) then a merge is performed similar to what happens when no identity column is present. This merge will either insert a new row or update an existing row based on the existence of a row that matches the primary keys (including the identity column). See [AddProductWithIdentityColumnIncluded](../samples/samples-js/AddProductWithIdentityColumnIncluded/index.js) for an example.
-
-#### Columns with Default Values
-In the case where one of the primary key columns has a default value, there are also two options based on how the function defines the output object:
-1. If the column with a default value is not included in the output object, then a straight insert is always performed with the other values. See [AddProductWithDefaultPK](../samples/samples-js/AddProductWithDefaultPK/index.js) for an example.
-2. If the column with a default value is included then a merge is performed similar to what happens when no default column is present. If there is a nullable column with a default value, then the provided column value in the output object will be upserted even if it is null.
-
 ## Trigger Binding
 
-> Trigger binding support is only available for C# functions at present.
+> Trigger binding support is only available for in-proc C# functions at present.


### PR DESCRIPTION
1. Change names from BindingsGuide_* -> SetupGuide_* since those should only contain language specific setup/samples.
2. Move all "common" sections (like descriptions of the bindings and general information about using them) into a single overview page
3. Added TOC's to the pages for easier navigation
4. Random other small fixes/improvements