### PR TITLE
Fix AddProductColumnTypesTest for Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Databases on SQL Server, Azure SQL Database, or Azure SQL Managed Instance which
 
 - Output bindings against tables with columns of data types `NTEXT`, `TEXT`, or `IMAGE` are not supported and data upserts will fail. These types [will be removed](https://docs.microsoft.com/sql/t-sql/data-types/ntext-text-and-image-transact-sql) in a future version of SQL Server and are not compatible with the `OPENJSON` function used by this Azure Functions binding.
 - Input bindings against tables with columns of data types 'DATETIME', 'DATETIME2', or 'SMALLDATETIME' will assume that the values are in UTC format.
+- For Java Functions using Output bindings against a table with columns of data types 'DATETIME', 'DATETIME2', or 'SMALLDATETIME', use java.util.Date type to ensure the datetime is formatted correctly.
 - Trigger bindings will exhibit undefined behavior if the SQL table schema gets modified while the user application is running, for example, if a column is added, renamed or deleted or if the primary key is modified or deleted. In such cases, restarting the application should help resolve any errors.
 
 ## Telemetry

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -108,15 +108,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         }
 
         /// <summary>
-        /// Test compatability with converting various data types to their respective
+        /// Test compatibility with converting various data types to their respective
         /// SQL server types.
         /// </summary>
         /// <param name="lang">The language to run the test against</param>
         [Theory]
         [SqlInlineData()]
-        // This test is currrently failing in the Linux pipeline for Java
-        // https://github.com/Azure/azure-functions-sql-extension/issues/521
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.PowerShell, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.PowerShell, SupportedLanguages.OutOfProc)]
         public void AddProductColumnTypesTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductColumnTypes), lang, true);

--- a/test/Integration/test-java/src/main/java/com/function/AddProductColumnTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/AddProductColumnTypes.java
@@ -17,7 +17,7 @@ import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
 import com.function.Common.ProductColumnTypes;
 
-import java.sql.Timestamp;
+import java.sql.Date;
 import java.util.Optional;
 
 public class AddProductColumnTypes {
@@ -35,8 +35,10 @@ public class AddProductColumnTypes {
                 connectionStringSetting = "SqlConnectionString")
                 OutputBinding<ProductColumnTypes> product) {
 
-        ProductColumnTypes p = new ProductColumnTypes(0, new Timestamp(System.currentTimeMillis()),
-            new Timestamp(System.currentTimeMillis()));
+        ProductColumnTypes p = new ProductColumnTypes(
+            Integer.parseInt(request.getQueryParameters().get("productId")),
+            new Date(System.currentTimeMillis()),
+            new Date(System.currentTimeMillis()));
         product.setValue(p);
 
         // Items were inserted successfully so return success, an exception would be thrown if there

--- a/test/Integration/test-java/src/main/java/com/function/Common/ProductColumnTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/Common/ProductColumnTypes.java
@@ -6,14 +6,14 @@
 
 package com.function.Common;
 
-import java.sql.Timestamp;
+import java.sql.Date;
 
 public class ProductColumnTypes {
     private int ProductId;
-    private Timestamp Datetime;
-    private Timestamp Datetime2;
+    private Date Datetime;
+    private Date Datetime2;
 
-    public ProductColumnTypes(int productId, Timestamp datetime, Timestamp datetime2) {
+    public ProductColumnTypes(int productId, Date datetime, Date datetime2) {
         ProductId = productId;
         Datetime = datetime;
         Datetime2 = datetime2;
@@ -23,19 +23,19 @@ public class ProductColumnTypes {
         return ProductId;
     }
 
-    public Timestamp getDatetime() {
+    public Date getDatetime() {
         return Datetime;
     }
 
-    public void setDatetime(Timestamp datetime) {
+    public void setDatetime(Date datetime) {
         Datetime = datetime;
     }
 
-    public Timestamp getDatetime2() {
+    public Date getDatetime2() {
         return Datetime2;
     }
 
-    public void setDatetime2(Timestamp datetime2) {
+    public void setDatetime2(Date datetime2) {
         Datetime2 = datetime2;
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-functions-sql-extension/issues/521

The test was failing on the linux pipeline because the timestamp object being sent to the database had an extra comma between the date and the time.
Mac/Windows: "Dec 1, 2022 11:55:45 AM"
Linux: "Dec 1, 2022, 4:45:52 PM"

Using java.sql.Date instead of java.sql.Timestamp fixes the issue.
