### PR TITLE
Increase build + test timeout

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -41,6 +41,8 @@ stages:
     workspace:
       clean: all
 
+    timeoutInMinutes: '90'
+
     steps:
     - template: 'template-steps-build-test.yml'
       parameters:

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -50,6 +50,8 @@ stages:
     workspace:
       clean: all
 
+    timeoutInMinutes: '90'
+
     steps:
       - template: 'template-steps-build-test.yml'
         parameters:
@@ -67,6 +69,8 @@ stages:
 
     workspace:
       clean: all
+
+    timeoutInMinutes: '90'
 
     steps:
       - template: 'template-steps-build-test.yml'


### PR DESCRIPTION
With the additional test languages being added the test task is pushing the limits of the default 60min timeout. 