### PR TITLE
Use aka.ms link to learn docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For further details on setup, usage and samples of the bindings see the language
 - [PowerShell](./docs/SetupGuide_PowerShell.md)
 - [Python](./docs/SetupGuide_Python.md)
 
-Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://aka.ms/sqlbindings).
+Further information on the Azure SQL binding for Azure Functions is also available in the [docs](https://aka.ms/sqlbindings).
 
 ## Supported SQL Server Versions
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For further details on setup, usage and samples of the bindings see the language
 - [PowerShell](./docs/SetupGuide_PowerShell.md)
 - [Python](./docs/SetupGuide_Python.md)
 
-Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://aka.ms/sqlbindings).
 
 ## Supported SQL Server Versions
 

--- a/docs/GeneralSetup.md
+++ b/docs/GeneralSetup.md
@@ -98,7 +98,7 @@ These steps can be done in the Terminal/CLI or with PowerShell.
     func init --worker-runtime powershell
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
 
     **.NET:** Install the extension.
 

--- a/docs/GeneralSetup.md
+++ b/docs/GeneralSetup.md
@@ -98,7 +98,7 @@ These steps can be done in the Terminal/CLI or with PowerShell.
     func init --worker-runtime powershell
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     **.NET:** Install the extension.
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -38,7 +38,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime dotnet
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Install the extension.
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -38,7 +38,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime dotnet
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
 
     Install the extension.
 

--- a/docs/SetupGuide_Java.md
+++ b/docs/SetupGuide_Java.md
@@ -35,7 +35,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime java
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_Java.md
+++ b/docs/SetupGuide_Java.md
@@ -35,7 +35,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime java
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_Javascript.md
+++ b/docs/SetupGuide_Javascript.md
@@ -35,7 +35,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime node --language javascript
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_Javascript.md
+++ b/docs/SetupGuide_Javascript.md
@@ -35,7 +35,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime node --language javascript
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_PowerShell.md
+++ b/docs/SetupGuide_PowerShell.md
@@ -34,7 +34,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime powershell
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_PowerShell.md
+++ b/docs/SetupGuide_PowerShell.md
@@ -34,7 +34,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime powershell
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_Python.md
+++ b/docs/SetupGuide_Python.md
@@ -36,7 +36,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime python
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/docs/SetupGuide_Python.md
+++ b/docs/SetupGuide_Python.md
@@ -36,7 +36,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime python
     ```
 
-3. Enable SQL bindings on the function app. More information can be found [in Microsoft Docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
     ```json

--- a/src/README.md
+++ b/src/README.md
@@ -7,6 +7,6 @@ Azure SQL bindings for Azure Functions adds input, output and trigger bindings f
 
 Get started quickly with the samples available in our [repository](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples)
 
-Further information on the Azure SQL binding for Azure Functions is also available in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+Further information on the Azure SQL binding for Azure Functions is also available in the [docs](https://aka.ms/sqlbindings).
 
 Find latest updates on our [Github Releases](https://github.com/Azure/azure-functions-sql-extension/releases/latest) page or the [Microsoft.Azure.Webjobs.Extensions.Sql package on Nuget.org](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Sql)

--- a/src/README.md
+++ b/src/README.md
@@ -7,6 +7,6 @@ Azure SQL bindings for Azure Functions adds input, output and trigger bindings f
 
 Get started quickly with the samples available in our [repository](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples)
 
-Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://docs.microsoft.com/azure/azure-functions/functions-bindings-azure-sql).
+Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://aka.ms/sqlbindings).
 
 Find latest updates on our [Github Releases](https://github.com/Azure/azure-functions-sql-extension/releases/latest) page or the [Microsoft.Azure.Webjobs.Extensions.Sql package on Nuget.org](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Sql)

--- a/src/README.md
+++ b/src/README.md
@@ -7,6 +7,6 @@ Azure SQL bindings for Azure Functions adds input, output and trigger bindings f
 
 Get started quickly with the samples available in our [repository](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples)
 
-Further information on the Azure SQL binding for Azure Functions is also available in the [Azure Functions docs](https://aka.ms/sqlbindings).
+Further information on the Azure SQL binding for Azure Functions is also available in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
 Find latest updates on our [Github Releases](https://github.com/Azure/azure-functions-sql-extension/releases/latest) page or the [Microsoft.Azure.Webjobs.Extensions.Sql package on Nuget.org](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Sql)


### PR DESCRIPTION
Part of https://github.com/Azure/azure-functions-sql-extension/issues/162 (along with other enhancements done to clean up README)

I'll be doing a follow up PR to improve the Nuget readme. 

Using aka.ms link in case we want to change the general docs location later for some reason. 