### PR TITLE
Fix GetProductsColumnTypesSerialization Test in Java

### DIFF
--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="lang">The language to run the test against</param>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.PowerShell, SupportedLanguages.OutOfProc)]
+        // Java issue: https://github.com/Azure/azure-functions-sql-extension/issues/521
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.PowerShell, SupportedLanguages.OutOfProc)]
         public void AddProductColumnTypesTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductColumnTypes), lang, true);

--- a/test/Integration/test-java/src/main/java/com/function/AddProductColumnTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/AddProductColumnTypes.java
@@ -17,7 +17,7 @@ import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
 import com.function.Common.ProductColumnTypes;
 
-import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.Optional;
 
 public class AddProductColumnTypes {
@@ -37,8 +37,8 @@ public class AddProductColumnTypes {
 
         ProductColumnTypes p = new ProductColumnTypes(
             Integer.parseInt(request.getQueryParameters().get("productId")),
-            new Date(System.currentTimeMillis()),
-            new Date(System.currentTimeMillis()));
+            new Timestamp(System.currentTimeMillis()),
+            new Timestamp(System.currentTimeMillis()));
         product.setValue(p);
 
         // Items were inserted successfully so return success, an exception would be thrown if there

--- a/test/Integration/test-java/src/main/java/com/function/Common/ProductColumnTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/Common/ProductColumnTypes.java
@@ -6,14 +6,14 @@
 
 package com.function.Common;
 
-import java.sql.Date;
+import java.sql.Timestamp;
 
 public class ProductColumnTypes {
     private int ProductId;
-    private Date Datetime;
-    private Date Datetime2;
+    private Timestamp Datetime;
+    private Timestamp Datetime2;
 
-    public ProductColumnTypes(int productId, Date datetime, Date datetime2) {
+    public ProductColumnTypes(int productId, Timestamp datetime, Timestamp datetime2) {
         ProductId = productId;
         Datetime = datetime;
         Datetime2 = datetime2;
@@ -23,19 +23,23 @@ public class ProductColumnTypes {
         return ProductId;
     }
 
-    public Date getDatetime() {
+    public void setProductId(int productId) {
+        ProductId = productId;
+    }
+
+    public Timestamp getDatetime() {
         return Datetime;
     }
 
-    public void setDatetime(Date datetime) {
+    public void setDatetime(Timestamp datetime) {
         Datetime = datetime;
     }
 
-    public Date getDatetime2() {
+    public Timestamp getDatetime2() {
         return Datetime2;
     }
 
-    public void setDatetime2(Date datetime2) {
+    public void setDatetime2(Timestamp datetime2) {
         Datetime2 = datetime2;
     }
 }

--- a/test/Integration/test-java/src/main/java/com/function/GetProductsColumnTypesSerialization.java
+++ b/test/Integration/test-java/src/main/java/com/function/GetProductsColumnTypesSerialization.java
@@ -22,6 +22,8 @@ import com.microsoft.azure.functions.sql.annotation.SQLInput;
 import java.text.SimpleDateFormat;
 import java.util.Optional;
 import java.util.logging.Level;
+import java.util.Calendar;
+import java.sql.Timestamp;
 
 public class GetProductsColumnTypesSerialization {
     @FunctionName("GetProductsColumnTypesSerialization")
@@ -44,6 +46,12 @@ public class GetProductsColumnTypesSerialization {
         SimpleDateFormat df = new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSXXX");
         mapper.setDateFormat(df);
         for (ProductColumnTypes product : products) {
+            // Convert the datetimes to UTC (Java worker returns the datetimes in local timezone)
+            long datetime = product.getDatetime().getTime();
+            long datetime2 = product.getDatetime2().getTime();
+            int offset = Calendar.getInstance().getTimeZone().getOffset(product.getDatetime().getTime());
+            product.setDatetime(new Timestamp(datetime - offset));
+            product.setDatetime2(new Timestamp(datetime2 - offset));
             context.getLogger().log(Level.INFO, mapper.writeValueAsString(product));
         }
         return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(mapper.writeValueAsString(products)).build();


### PR DESCRIPTION
This PR fixes: https://github.com/Azure/azure-functions-sql-extension/issues/515 and also reverts this PR https://github.com/Azure/azure-functions-sql-extension/pull/552. While testing I realized java.**sql**.Date does not include the time so we can't use that for sql DATETIME. The java types that map to sql DATETIME are java.**util**.Date and java.sql.Timestamp, both of which cause AddProductColumnTypesTest to fail on Linux because of the extra comma in the format (issue https://github.com/Azure/azure-functions-sql-extension/issues/521).