### PR TITLE
convert date to iso 8061 format

### DIFF
--- a/test-outofproc/AddProductColumnTypes.cs
+++ b/test-outofproc/AddProductColumnTypes.cs
@@ -26,7 +26,7 @@ namespace DotnetIsolatedTests
             var product = new ProductColumnTypes()
             {
                 ProductID = int.Parse(queryStrings["productId"], null),
-                Datetime = DateTime.Parse(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", System.Globalization.CultureInfo.InvariantCulture)),
+                Datetime = DateTime.Parse(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", System.Globalization.CultureInfo.InvariantCulture), System.Globalization.CultureInfo.InvariantCulture),
                 Datetime2 = DateTime.UtcNow
             };
 

--- a/test-outofproc/AddProductColumnTypes.cs
+++ b/test-outofproc/AddProductColumnTypes.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using Microsoft.Azure.Functions.Worker.Extension.Sql;
 using DotnetIsolatedTests.Common;
 using System;
+using System.Data.SqlTypes;
 
 namespace DotnetIsolatedTests
 {
@@ -15,7 +16,7 @@ namespace DotnetIsolatedTests
     {
         /// <summary>
         /// This function is used to test compatability with converting various data types to their respective
-        /// SQL server types. 
+        /// SQL server types.
         /// </summary>
         [Function(nameof(AddProductColumnTypes))]
         [SqlOutput("dbo.ProductsColumnTypes", ConnectionStringSetting = "SqlConnectionString")]
@@ -26,12 +27,9 @@ namespace DotnetIsolatedTests
             var product = new ProductColumnTypes()
             {
                 ProductID = int.Parse(queryStrings["productId"], null),
-                Datetime = DateTime.ParseExact(DateTime.UtcNow.ToString(System.Globalization.CultureInfo.InvariantCulture), "yyyy-MM-ddTHH:mm:ss.fffZ", null),
+                Datetime = new SqlDateTime(DateTime.UtcNow).Value,
                 Datetime2 = DateTime.UtcNow
             };
-
-            // Items were inserted successfully so return success, an exception would be thrown if there
-            // was any issues
             return product;
         }
     }

--- a/test-outofproc/AddProductColumnTypes.cs
+++ b/test-outofproc/AddProductColumnTypes.cs
@@ -26,7 +26,7 @@ namespace DotnetIsolatedTests
             var product = new ProductColumnTypes()
             {
                 ProductID = int.Parse(queryStrings["productId"], null),
-                Datetime = DateTime.Parse(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", System.Globalization.CultureInfo.InvariantCulture), System.Globalization.CultureInfo.InvariantCulture),
+                Datetime = DateTime.ParseExact(DateTime.UtcNow.ToString(System.Globalization.CultureInfo.InvariantCulture), "yyyy-MM-ddTHH:mm:ss.fffZ", null),
                 Datetime2 = DateTime.UtcNow
             };
 

--- a/test-outofproc/AddProductColumnTypes.cs
+++ b/test-outofproc/AddProductColumnTypes.cs
@@ -26,7 +26,7 @@ namespace DotnetIsolatedTests
             var product = new ProductColumnTypes()
             {
                 ProductID = int.Parse(queryStrings["productId"], null),
-                Datetime = DateTime.UtcNow.Date,
+                Datetime = DateTime.Parse(DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", System.Globalization.CultureInfo.InvariantCulture)),
                 Datetime2 = DateTime.UtcNow
             };
 

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="lang">The language to run the test against</param>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.PowerShell)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.PowerShell)]
         public void AddProductColumnTypesTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductColumnTypes), lang, true);

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="lang">The language to run the test against</param>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.PowerShell, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.PowerShell)]
         public void AddProductColumnTypesTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductColumnTypes), lang, true);


### PR DESCRIPTION
Fixes #548 
The OOP function sends the date in the below format:
2022-12-01T02:39:56.098554Z and Sql fails with the following error: System.Private.CoreLib: Exception while executing function: Functions.AddProductColumnTypes. Microsoft.Azure.WebJobs.Host: Error while handling parameter _binder after function returned:. Core Microsoft SqlClient Data Provider: Conversion failed when converting date and/or time from character string.

In order for SQL to accept that format, datatype of that field should be DateTime2. Explicitly converting the datetime to ISO 8061 with milliseconds: yyyy-MM-ddTHH:mm:ss.fffZ and sending it so it's acceptable on SQL server.