### PR TITLE
fix-json-serialization

### DIFF
--- a/performance/SqlOutputBindingPerformance.cs
+++ b/performance/SqlOutputBindingPerformance.cs
@@ -7,7 +7,6 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples;
-using Newtonsoft.Json;
 using BenchmarkDotNet.Attributes;
 
 
@@ -30,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Performance
         public async Task<HttpResponseMessage> AddProductsArrayTest(int count)
         {
             Product[] productsToAdd = GetProductsWithSameCost(count, 100);
-            return await this.SendOutputPostRequest("addproducts-array", JsonConvert.SerializeObject(productsToAdd));
+            return await this.SendOutputPostRequest("addproducts-array", Utils.SerializeObject(productsToAdd));
         }
 
         [IterationCleanup]

--- a/samples/samples-csharp/TriggerBindingSamples/ProductsTrigger.cs
+++ b/samples/samples-csharp/TriggerBindingSamples/ProductsTrigger.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples
 {
@@ -17,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples
             ILogger logger)
         {
             // The output is used to inspect the trigger binding parameter in test methods.
-            logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
+            logger.LogInformation("SQL Changes: " + Utils.SerializeObject(changes));
         }
     }
 }

--- a/src/SqlAsyncEnumerable.cs
+++ b/src/SqlAsyncEnumerable.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     }
                     if (await this._reader.ReadAsync())
                     {
-                        this.Current = JsonConvert.DeserializeObject<T>(this.SerializeRow());
+                        this.Current = Utils.DeserializeObject<T>(this.SerializeRow());
                         return true;
                     }
                 }
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     DateFormatString = ISO_8061_DATETIME_FORMAT
                 };
-                return JsonConvert.SerializeObject(SqlBindingUtilities.BuildDictionaryFromSqlRow(this._reader), jsonSerializerSettings);
+                return Utils.SerializeObject(SqlBindingUtilities.BuildDictionaryFromSqlRow(this._reader), jsonSerializerSettings);
             }
         }
     }

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 try
                 {
                     string json = await this.BuildItemFromAttributeAsync(attribute, ConvertType.IEnumerable);
-                    IEnumerable<T> result = JsonConvert.DeserializeObject<IEnumerable<T>>(json);
+                    IEnumerable<T> result = Utils.DeserializeObject<IEnumerable<T>>(json);
                     this._logger.LogDebugWithThreadId($"END ConvertAsync (IEnumerable) Duration={sw.ElapsedMilliseconds}ms");
                     return result;
                 }
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         DateFormatString = ISO_8061_DATETIME_FORMAT
                     };
-                    return JsonConvert.SerializeObject(dataTable, jsonSerializerSettings);
+                    return Utils.SerializeObject(dataTable, jsonSerializerSettings);
                 }
 
             }

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -723,7 +723,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     ? this._primaryKeyColumns.ToDictionary(col => col.name, col => row[col.name])
                     : this._userTableColumns.ToDictionary(col => col, col => row[col]);
 
-                changes.Add(new SqlChange<T>(operation, JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(item))));
+                changes.Add(new SqlChange<T>(operation, Utils.DeserializeObject<T>(Utils.SerializeObject(item))));
             }
             this._logger.LogDebugWithThreadId("END ProcessChanges");
             return changes;
@@ -892,7 +892,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
             var command = new SqlCommand(query, connection, transaction);
             SqlParameter par = command.Parameters.Add(rowDataParameter, SqlDbType.NVarChar, -1);
-            string rowData = JsonConvert.SerializeObject(rows);
+            string rowData = Utils.SerializeObject(rows);
             par.Value = rowData;
             return command;
         }
@@ -953,7 +953,7 @@ WHERE l.{LeasesTableChangeVersionColumnName} <= cte.{SysChangeVersionColumnName}
 
             var command = new SqlCommand(releaseLeasesQuery, connection, transaction);
             SqlParameter par = command.Parameters.Add(rowDataParameter, SqlDbType.NVarChar, -1);
-            string rowData = JsonConvert.SerializeObject(this._rows);
+            string rowData = Utils.SerializeObject(this._rows);
             par.Value = rowData;
             return command;
         }

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -6,12 +6,24 @@ using System.Linq;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MoreLinq;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
     public static class Utils
     {
+        private static readonly JsonSerializerSettings _jsonSerializationSettings;
+
+        static Utils()
+        {
+            _jsonSerializationSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new DefaultContractResolver()
+            };
+        }
+
         /// <summary>
         /// Gets the specified environment variable and converts it to a boolean.
         /// </summary>
@@ -103,6 +115,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         public static void LogInformationWithThreadId(this ILogger logger, string message, params object[] args)
         {
             logger.LogInformation($"TID:{Environment.CurrentManagedThreadId} {message}", args);
+        }
+
+        public static string SerializeObject(object obj)
+        {
+            return JsonConvert.SerializeObject(obj, _jsonSerializationSettings);
+        }
+
+        public static T DeserializeObject<T>(string json)
+        {
+            return JsonConvert.DeserializeObject<T>(json, _jsonSerializationSettings);
         }
     }
 }

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             // Verify result
             string actualResponse = await response.Content.ReadAsStringAsync();
-            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
+            Product[] actualProductResponse = Utils.DeserializeObject<Product[]>(actualResponse);
 
             Assert.Equal(products, actualProductResponse);
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             // Verify result
             string actualResponse = await response.Content.ReadAsStringAsync();
-            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
+            Product[] actualProductResponse = Utils.DeserializeObject<Product[]>(actualResponse);
 
             Assert.Equal(products, actualProductResponse);
         }
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             // Verify result
             string actualResponse = await response.Content.ReadAsStringAsync();
-            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
+            Product[] actualProductResponse = Utils.DeserializeObject<Product[]>(actualResponse);
 
             Assert.Equal(products, actualProductResponse);
         }
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             // Verify result
             string actualResponse = await response.Content.ReadAsStringAsync();
-            Product[] actualProductResponse = JsonConvert.DeserializeObject<Product[]>(actualResponse);
+            Product[] actualProductResponse = Utils.DeserializeObject<Product[]>(actualResponse);
 
             Assert.Equal(productsWithCost100, actualProductResponse);
         }
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             HttpResponseMessage response = await this.SendInputRequest("getproducts-columntypesserializationasyncenumerable", $"?culture={culture}");
             // We expect the datetime and datetime2 fields to be returned in UTC format
             string actualResponse = await response.Content.ReadAsStringAsync();
-            ProductColumnTypes[] actualProductResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>(actualResponse);
+            ProductColumnTypes[] actualProductResponse = Utils.DeserializeObject<ProductColumnTypes[]>(actualResponse);
             Assert.Equal(expectedResponse, actualProductResponse);
         }
 
@@ -181,9 +181,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
             HttpResponseMessage response = await this.SendInputRequest("getproducts-columntypesserialization");
             // We expect the datetime and datetime2 fields to be returned in UTC format
-            ProductColumnTypes[] expectedResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\"}]");
+            ProductColumnTypes[] expectedResponse = Utils.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\"}]");
             string actualResponse = await response.Content.ReadAsStringAsync();
-            ProductColumnTypes[] actualProductResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>(actualResponse);
+            ProductColumnTypes[] actualProductResponse = Utils.DeserializeObject<ProductColumnTypes[]>(actualResponse);
 
             Assert.Equal(expectedResponse, actualProductResponse);
         }

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 { "cost", cost }
             };
 
-            this.SendOutputPostRequest("addproduct", JsonConvert.SerializeObject(query)).Wait();
+            this.SendOutputPostRequest("addproduct", Utils.SerializeObject(query)).Wait();
 
             // Verify result
             Assert.Equal(name, this.ExecuteScalar($"select Name from Products where ProductId={id}"));
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 }
             };
 
-            this.SendOutputPostRequest("addproducts-array", JsonConvert.SerializeObject(prods)).Wait();
+            this.SendOutputPostRequest("addproducts-array", Utils.SerializeObject(prods)).Wait();
 
             // Function call changes first 2 rows to (1, 'Cup', 2) and (2, 'Glasses', 12)
             Assert.Equal(1, this.ExecuteScalar("SELECT COUNT(1) FROM Products WHERE Cost = 100"));
@@ -425,8 +425,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 { "cost", 1 }
             };
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithDefaultPK"));
-            this.SendOutputPostRequest("addproductwithdefaultpk", JsonConvert.SerializeObject(product)).Wait();
-            this.SendOutputPostRequest("addproductwithdefaultpk", JsonConvert.SerializeObject(product)).Wait();
+            this.SendOutputPostRequest("addproductwithdefaultpk", Utils.SerializeObject(product)).Wait();
+            this.SendOutputPostRequest("addproductwithdefaultpk", Utils.SerializeObject(product)).Wait();
             Assert.Equal(2, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithDefaultPK"));
         }
 

--- a/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                     IReadOnlyList<SqlChange<Product>> changes;
                     try
                     {
-                        changes = JsonConvert.DeserializeObject<IReadOnlyList<SqlChange<Product>>>(json);
+                        changes = Utils.DeserializeObject<IReadOnlyList<SqlChange<Product>>>(json);
                     }
                     catch (Exception ex)
                     {

--- a/test/Integration/test-csharp/MultiFunctionTrigger.cs
+++ b/test/Integration/test-csharp/MultiFunctionTrigger.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             IReadOnlyList<SqlChange<Product>> products,
             ILogger logger)
         {
-            logger.LogInformation("Trigger1 Changes: " + JsonConvert.SerializeObject(products));
+            logger.LogInformation("Trigger1 Changes: " + Utils.SerializeObject(products));
         }
 
         [FunctionName(nameof(MultiFunctionTrigger2))]
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             IReadOnlyList<SqlChange<Product>> products,
             ILogger logger)
         {
-            logger.LogInformation("Trigger2 Changes: " + JsonConvert.SerializeObject(products));
+            logger.LogInformation("Trigger2 Changes: " + Utils.SerializeObject(products));
         }
     }
 }

--- a/test/Integration/test-csharp/ProductsTriggerWithValidation.cs
+++ b/test/Integration/test-csharp/ProductsTriggerWithValidation.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 throw new Exception($"Invalid batch size, got {changes.Count} changes but expected {expectedBatchSize}");
             }
             // The output is used to inspect the trigger binding parameter in test methods.
-            logger.LogInformation("SQL Changes: " + JsonConvert.SerializeObject(changes));
+            logger.LogInformation("SQL Changes: " + Utils.SerializeObject(changes));
         }
     }
 }


### PR DESCRIPTION
PR to resolve #588.

In order to avoid conflicting with global settings a consumer may have setup, static JsonSerializationSettings will be used when serializing or deserializing. This was put inside the `Utils` class so the code is centralized throughout the project.  Tests have also been updated to use the `Utils` operations to ensure this does not break anything.