### PR TITLE
Use TryGetValue

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -668,9 +668,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 IList<JsonProperty> propertiesToSerialize = new List<JsonProperty>(properties.Count);
                 foreach (KeyValuePair<string, string> column in this._propertiesToSerialize)
                 {
-                    if (properties.ContainsKey(column.Key))
+                    if (properties.TryGetValue(column.Key, out JsonProperty value))
                     {
-                        JsonProperty sqlColumn = properties[column.Key];
+                        JsonProperty sqlColumn = value;
                         sqlColumn.PropertyName = sqlColumn.PropertyName;
                         propertiesToSerialize.Add(sqlColumn);
                     }


### PR DESCRIPTION
Removes potential double access of properties. This was showing up as an error when compiling with newer SDKs (which is likely to happen during dev when building a test function that directly referenced the project) as well so that makes it a little less annoying there as a bonus. 