### PR TITLE
Only generate packages for packaged projects

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,6 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <PackageProjectUrl>https://github.com/Azure/azure-functions-sql-extension</PackageProjectUrl>

--- a/Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj
+++ b/Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj
@@ -11,6 +11,7 @@
 		<PackageTags>Microsoft Azure WebJobs AzureFunctions Isolated DotnetIsolated SQL AzureSQL Worker</PackageTags>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<IsPackable>true</IsPackable>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj
+++ b/Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj
@@ -11,7 +11,7 @@
 		<PackageTags>Microsoft Azure WebJobs AzureFunctions Isolated DotnetIsolated SQL AzureSQL Worker</PackageTags>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<IsPackable>true</IsPackable>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -9,6 +9,7 @@
     <!-- Default Version for dev -->
     <Version>99.99.99</Version>
     <IsPackable>true</IsPackable>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Microsoft.Azure.WebJobs.Extensions.Sql</PackageId>
     <PackageTags>Microsoft Azure WebJobs AzureFunctions SQL AzureSQL</PackageTags>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>


### PR DESCRIPTION
Started seeing this warning 

`warning : This project cannot be packaged because packaging has been disabled. Add <IsPackable>true</IsPackable> to the project file to enable producing a package from this project. [C:\src\azure-functions-sql-extension\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj]`

due to GeneratePackageOnBuild being set to true for all projects - even non-packaged ones. So just removing it from the global props and only adding it to the ones that are actually packaged. 