### PR TITLE
Add connection retry logic for trigger binding loops

### DIFF
--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     }
                     await conn.OpenAsync(token);
                     logger.LogInformation($"Successfully re-established {connectionName}!");
-                    logger.LogDebugWithThreadId("END RetryOpenChangeConsumptionConnection");
+                    logger.LogDebugWithThreadId($"END RetryOpen{connectionName}");
                     return true;
                 }
                 catch (Exception e)


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/593

Previously any errors that occurred with the connection after the loops had been started were logged and ignored - so if the connection was broken then it would never attempt to reconnect and the function would need to be restarted.

This adds detection for when a fatal SQL Exception occurs (Class >= 20 per https://learn.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqlexception?view=sqlclient-dotnet-standard-5.0#remarks) and when that happens or when the connection is detected to be in a Closed/Broken state then it will attempt to re-establish the connection before continuing on with the loop.

It will continue trying to re-establish the connection forever until the connection is successfully made, there is currently no configuration planned for letting users control this or for anything else (such as forcing the function to be restarted) to occur. 

Note that originally I had expected to be able to just check the ConnectionState for it being Closed/Broken, but as detailed in https://github.com/dotnet/SqlClient/issues/1874 that isn't always the case and so I am checking for Class 20 or higher as a fallback, since those all indicate critical errors that will usually require reconnection. 

These checks are only necessary for trigger bindings since the other ones establish a new connection every time they're executed, so won't get stuck like the trigger bindings would. A future improvement could be to add automatic retries to those as well, but that's out of the scope of this PR. 