### PR TITLE
Enable AddProductParam test for Python

### DIFF
--- a/samples/samples-python/AddProductParams/__init__.py
+++ b/samples/samples-python/AddProductParams/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-import azure.functions as func
 from urllib.parse import parse_qs, urlparse
+
+import azure.functions as func
 from Common.product import Product
 
 def main(req: func.HttpRequest, product: func.Out[func.SqlRow]) -> func.HttpResponse:

--- a/samples/samples-python/AddProductParams/__init__.py
+++ b/samples/samples-python/AddProductParams/__init__.py
@@ -2,10 +2,13 @@
 # Licensed under the MIT License.
 
 import azure.functions as func
+from urllib.parse import parse_qs, urlparse
 from Common.product import Product
 
 def main(req: func.HttpRequest, product: func.Out[func.SqlRow]) -> func.HttpResponse:
-    row = func.SqlRow(Product(req.params["productId"], req.params["name"], req.params["cost"]))
+    # The Python worker discards empty query parameters so use parse_qs as a workaround.
+    params = parse_qs(urlparse(req.url).query, keep_blank_values=True)
+    row = func.SqlRow(Product(params["productId"][0], params["name"][0], params["cost"][0]))
     product.set(row)
 
     return func.HttpResponse(

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData(1, "Test", 5)]
         [SqlInlineData(0, "", 0)]
         [SqlInlineData(-500, "ABCD", 580)]
-        // Currently Java and Python functions return null when the parameter for name is an empty string
+        // Currently Java functions return null when the parameter for name is an empty string
         // Issue link: https://github.com/Azure/azure-functions-sql-extension/issues/517
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.Python)]
+        [UnsupportedLanguages(SupportedLanguages.Java)]
         public void AddProductParamsTest(int id, string name, int cost, SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductParams), lang);


### PR DESCRIPTION
Using the workaround mentioned in this issue https://github.com/Azure/azure-functions-python-worker/issues/894 to get the empty string query parameter.