### PR TITLE
Remove build status link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Azure SQL bindings for Azure Functions - Preview
 
-[![Build Status](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_apis/build/status/SQL%20Bindings/SQL%20Bindings%20-%20Nightly?branchName=main)](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/latest?definitionId=481&branchName=main)
-
 ## Table of Contents
 - [Azure SQL bindings for Azure Functions - Preview](#azure-sql-bindings-for-azure-functions---preview)
   - [Table of Contents](#table-of-contents)


### PR DESCRIPTION
Remove build status from README, since this is also leveraged on [NuGet.org](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Sql/), and doesn't really serve any purpose there:

![image](https://user-images.githubusercontent.com/40371649/211442607-68d90610-d590-4c60-a0f4-7afddcc2a41b.png)