### PR TITLE
Add copyright header and remove comments

### DIFF
--- a/docs/SetupGuide_PowerShell.md
+++ b/docs/SetupGuide_PowerShell.md
@@ -156,7 +156,6 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 
     Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-    # Update req_body with the body of the request
     $req_body = @(
         @{
             EmployeeId=1,

--- a/samples/samples-powershell/AddProduct/run.ps1
+++ b/samples/samples-powershell/AddProduct/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = $Request.Body

--- a/samples/samples-powershell/AddProductParams/run.ps1
+++ b/samples/samples-powershell/AddProductParams/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_query with the query of the request
 # Currently the Powershell worker does not allow empty/null values to be passed through the
 # query parameters. We use TriggerMetadata here as a workaround for that issue. 
 # Issue link: https://github.com/Azure/azure-functions-powershell-worker/issues/895

--- a/samples/samples-powershell/AddProductWithDefaultPK/run.ps1
+++ b/samples/samples-powershell/AddProductWithDefaultPK/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = $Request.Body

--- a/samples/samples-powershell/AddProductWithIdentityColumn/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumn/run.ps1
@@ -9,7 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Known Issue with [ordered] found here: https://github.com/Azure/azure-functions-sql-extension#output-bindings
+# Output bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
 $req_query = [ordered]@{
     Name=$Request.QUERY.name;
     Cost=$Request.QUERY.cost;

--- a/samples/samples-powershell/AddProductWithIdentityColumn/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumn/run.ps1
@@ -9,6 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
+# Known Issue with [ordered] found here: https://github.com/Azure/azure-functions-sql-extension#output-bindings
 $req_query = [ordered]@{
     Name=$Request.QUERY.name;
     Cost=$Request.QUERY.cost;

--- a/samples/samples-powershell/AddProductWithIdentityColumn/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumn/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_query with the query of the request
 $req_query = @{
     Name=$Request.QUERY.name;
     Cost=$Request.QUERY.cost;

--- a/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
@@ -9,6 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
+# Known Issue with [ordered] found here: https://github.com/Azure/azure-functions-sql-extension#output-bindings
 $req_query = [ordered]@{
     ProductId= if($Request.QUERY.productId) { [int]$Request.QUERY.productId } else { $null };
     Name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
@@ -9,7 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Known Issue with [ordered] found here: https://github.com/Azure/azure-functions-sql-extension#output-bindings
+# KOutput bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
 $req_query = [ordered]@{
     ProductId= if($Request.QUERY.productId) { [int]$Request.QUERY.productId } else { $null };
     Name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
@@ -9,7 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# KOutput bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
+# Output bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
 $req_query = [ordered]@{
     ProductId= if($Request.QUERY.productId) { [int]$Request.QUERY.productId } else { $null };
     Name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
+++ b/samples/samples-powershell/AddProductWithIdentityColumnIncluded/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_query with the body of the request
 $req_query = @{
     ProductId= if($Request.QUERY.productId) { [int]$Request.QUERY.productId } else { $null };
     Name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductWithMultiplePrimaryColumnsAndIdentity/run.ps1
+++ b/samples/samples-powershell/AddProductWithMultiplePrimaryColumnsAndIdentity/run.ps1
@@ -9,6 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
+# Known Issue with [ordered] found here: https://github.com/Azure/azure-functions-sql-extension#output-bindings
 $req_query = [ordered]@{
     ExternalId=$Request.QUERY.externalId;
     Name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductWithMultiplePrimaryColumnsAndIdentity/run.ps1
+++ b/samples/samples-powershell/AddProductWithMultiplePrimaryColumnsAndIdentity/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_query with the body of the request
 $req_query = @{
     externalId=$Request.QUERY.externalId;
     name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductWithMultiplePrimaryColumnsAndIdentity/run.ps1
+++ b/samples/samples-powershell/AddProductWithMultiplePrimaryColumnsAndIdentity/run.ps1
@@ -9,7 +9,7 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Known Issue with [ordered] found here: https://github.com/Azure/azure-functions-sql-extension#output-bindings
+# Output bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
 $req_query = [ordered]@{
     ExternalId=$Request.QUERY.externalId;
     Name=$Request.QUERY.name;

--- a/samples/samples-powershell/AddProductsArray/run.ps1
+++ b/samples/samples-powershell/AddProductsArray/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = $Request.Body

--- a/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1
+++ b/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1
@@ -11,6 +11,7 @@ Write-Host "PowerShell function with SQL Output Binding processed a request."
 
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
+# Known Issue with using [ordered] found https://github.com/Azure/azure-functions-sql-extension#output-bindings
 $req_body = @([ordered]@{
     Name="Cup";
     Cost=2;

--- a/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1
+++ b/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = @(@{

--- a/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1
+++ b/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1
@@ -11,7 +11,7 @@ Write-Host "PowerShell function with SQL Output Binding processed a request."
 
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
-# Known Issue with using [ordered] found https://github.com/Azure/azure-functions-sql-extension#output-bindings
+# Output bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
 $req_body = @([ordered]@{
     Name="Cup";
     Cost=2;

--- a/samples/samples-powershell/GetAndAddProducts/run.ps1
+++ b/samples/samples-powershell/GetAndAddProducts/run.ps1
@@ -1,8 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # This function uses a SQL input binding to get products from the Products table
 # and upsert those products to the ProductsWithIdentity table.
-
 param($Request, $TriggerMetadata, $products)
 
 Push-OutputBinding -Name productsWithIdentity -Value $products

--- a/samples/samples-powershell/GetProductNamesView/run.ps1
+++ b/samples/samples-powershell/GetProductNamesView/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger and input binding data are passed in via the param block.

--- a/samples/samples-powershell/GetProducts/run.ps1
+++ b/samples/samples-powershell/GetProducts/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger and input binding data are passed in via the param block.

--- a/samples/samples-powershell/GetProductsNameEmpty/run.ps1
+++ b/samples/samples-powershell/GetProductsNameEmpty/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger and input binding data are passed in via the param block.

--- a/samples/samples-powershell/GetProductsStoredProcedure/run.ps1
+++ b/samples/samples-powershell/GetProductsStoredProcedure/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger and input binding data are passed in via the param block.

--- a/samples/samples-powershell/GetProductsStoredProcedureFromAppSetting/run.ps1
+++ b/samples/samples-powershell/GetProductsStoredProcedureFromAppSetting/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger and input binding data are passed in via the param block.

--- a/samples/samples-powershell/QueueTriggerProducts/run.ps1
+++ b/samples/samples-powershell/QueueTriggerProducts/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block

--- a/samples/samples-powershell/QueueTriggerProducts/run.ps1
+++ b/samples/samples-powershell/QueueTriggerProducts/run.ps1
@@ -9,7 +9,6 @@ $totalUpserts = 100;
 # Write to the Azure Functions log stream.
 Write-Host "[QueueTrigger]: $Get-Date starting execution $queueMessage. Rows to generate=$totalUpserts."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $start = Get-Date

--- a/samples/samples-powershell/TimerTriggerProducts/run.ps1
+++ b/samples/samples-powershell/TimerTriggerProducts/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 param($myTimer, $TriggerMetadata)

--- a/test/Integration/test-powershell/AddProductColumnTypes/run.ps1
+++ b/test/Integration/test-powershell/AddProductColumnTypes/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_query = @{ 

--- a/test/Integration/test-powershell/AddProductExtraColumns/run.ps1
+++ b/test/Integration/test-powershell/AddProductExtraColumns/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = @{ 

--- a/test/Integration/test-powershell/AddProductIncorrectCasing/run.ps1
+++ b/test/Integration/test-powershell/AddProductIncorrectCasing/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # This output binding should throw an error since the casing of the POCO field 'ProductID'

--- a/test/Integration/test-powershell/AddProductMissingColumns/run.ps1
+++ b/test/Integration/test-powershell/AddProductMissingColumns/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = @{

--- a/test/Integration/test-powershell/AddProductMissingColumnsExceptionFunction/run.ps1
+++ b/test/Integration/test-powershell/AddProductMissingColumnsExceptionFunction/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block
@@ -6,7 +9,6 @@ param($Request, $TriggerMetadata)
 # Write to the Azure Functions log stream.
 Write-Host "PowerShell function with SQL Output Binding processed a request."
 
-# Update req_body with the body of the request
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
 $req_body = @{

--- a/test/Integration/test-powershell/AddProductsNoPartialUpsert/run.ps1
+++ b/test/Integration/test-powershell/AddProductsNoPartialUpsert/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger binding data passed in via param block

--- a/test/Integration/test-powershell/GetProductsColumnTypesSerialization/run.ps1
+++ b/test/Integration/test-powershell/GetProductsColumnTypesSerialization/run.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
 using namespace System.Net
 
 # Trigger and input binding data are passed in via the param block.


### PR DESCRIPTION
Adding copyright header to all PowerShell samples and tests. Removed unnecessary comments. Fixes https://github.com/Azure/azure-functions-sql-extension/issues/610.

I have looked into Invoke-PSScriptAnalyzer but have not found it to be a reliable automatic linting solution to check our ps1 files. So while I will still investigate and wait to hear back from the PS team in regard to alternatives and will submit a future PR once a reliable solution is found.