### PR TITLE
Add Known Null PowerShell issue for ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Databases on SQL Server, Azure SQL Database, or Azure SQL Managed Instance which
     * Use [dynamic (imperative)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-expressions-patterns#binding-at-runtime) bindings (.NET only)
     * Use [IAsyncCollector](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library?tabs=v2%2Ccmd#writing-multiple-output-values) and call `FlushAsync` in the order desired (.NET only)
 - For PowerShell Functions that use hashtables must use the `[ordered]@` for the request query or request body assertion in order to upsert the data to the SQL table properly. An example can be found [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1).
+- PowerShell Functions using Output bindings can not pass in null or empty values via the query string. Workaround is to use the `$TriggerMetadata[$keyName]` to retrieve the query property. Issue is tracked [here](https://github.com/Azure/azure-functions-powershell-worker/issues/895).
 
 ### Input Bindings
 - Input bindings against tables with columns of data types 'DATETIME', 'DATETIME2', or 'SMALLDATETIME' will assume that the values are in UTC format.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Databases on SQL Server, Azure SQL Database, or Azure SQL Managed Instance which
     * Use [dynamic (imperative)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-expressions-patterns#binding-at-runtime) bindings (.NET only)
     * Use [IAsyncCollector](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library?tabs=v2%2Ccmd#writing-multiple-output-values) and call `FlushAsync` in the order desired (.NET only)
 - For PowerShell Functions that use hashtables must use the `[ordered]@` for the request query or request body assertion in order to upsert the data to the SQL table properly. An example can be found [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/samples-powershell/AddProductsWithIdentityColumnArray/run.ps1).
-- PowerShell Functions using Output bindings can not pass in null or empty values via the query string. Workaround is to use the `$TriggerMetadata[$keyName]` to retrieve the query property. Issue is tracked [here](https://github.com/Azure/azure-functions-powershell-worker/issues/895).
+- PowerShell Functions using Output bindings cannot pass in null or empty values via the query string. The workaround is to use the `$TriggerMetadata[$keyName]` to retrieve the query property, an example can be found [here](https://github.com/Azure/azure-functions-sql-extension/blob/main/samples/samples-powershell/AddProductParams/run.ps1). Issue is tracked [here](https://github.com/Azure/azure-functions-powershell-worker/issues/895).
 
 ### Input Bindings
 - Input bindings against tables with columns of data types 'DATETIME', 'DATETIME2', or 'SMALLDATETIME' will assume that the values are in UTC format.


### PR DESCRIPTION
Adds known issue for PowerShell that is further documented in the powershell worker repo: https://github.com/Azure/azure-functions-powershell-worker/issues/895. 

This will not be updated until they release PowerShell worker using PowerShell 7.4.

As such I will close this issue:
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/535.