### PR TITLE
Fixes DefaultPK test for PowerShell

### DIFF
--- a/samples/samples-powershell/AddProductWithDefaultPK/run.ps1
+++ b/samples/samples-powershell/AddProductWithDefaultPK/run.ps1
@@ -11,15 +11,19 @@ Write-Host "PowerShell function with SQL Output Binding processed a request."
 
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
-$req_body = $Request.Body
+# Output bindings require the [ordered] attribute. See https://github.com/Azure/azure-functions-sql-extension#output-bindings for more details.
+$req_query = [ordered]@{
+    Name=$Request.QUERY.name;
+    Cost=$Request.QUERY.cost;
+};
 
 # Assign the value we want to pass to the SQL Output binding. 
 # The -Name value corresponds to the name property in the function.json for the binding
-Push-OutputBinding -Name products -Value $req_body
+Push-OutputBinding -Name products -Value $req_query
 
 # Assign the value to return as the HTTP response. 
 # The -Name value matches the name property in the function.json for the binding
 Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
     StatusCode = [HttpStatusCode]::OK
-    Body = $req_body
+    Body = $req_query
 })

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -355,9 +355,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        // Currently PowerShell gives an unknown error (when testing locally we get a missing primary key error)
-        // Issue link: https://github.com/Azure/azure-functions-sql-extension/issues/448
-        [UnsupportedLanguages(SupportedLanguages.PowerShell)]
         public void AddProductWithDefaultPKTest(SupportedLanguages lang)
         {
             this.StartFunctionHost(nameof(AddProductWithDefaultPK), lang);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/448.

A similar issue that was discussed [here](https://github.com/Azure/azure-functions-sql-extension/pull/581) was happening where the ordered of JSON is being randomly ordered. 

This completes all PowerShell Integration Test fixes.