### PR TITLE
Remove noisy event

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -323,7 +323,6 @@ This extension collect usage data in order to help us improve your experience. T
     /// </summary>
     public enum TelemetryEventName
     {
-        AddAsync,
         Convert,
         Create,
         FlushAsync,
@@ -340,8 +339,7 @@ This extension collect usage data in order to help us improve your experience. T
         TableInfoCacheMiss,
         TriggerFunction,
         TriggerMonitorStart,
-        UpsertEnd,
-        UpsertStart,
+        Upsert
     }
 
     /// <summary>
@@ -384,6 +382,7 @@ This extension collect usage data in order to help us improve your experience. T
         GetUnprocessedChangesDurationMs,
         InsertGlobalStateTableRowDurationMs,
         MaxChangesPerWorker,
+        NumRows,
         PollingIntervalMs,
         ReleaseLeasesDurationMs,
         RetryAttemptNumber,


### PR DESCRIPTION
AddAsync is called for every row being upserted, of which there could be any number per function invocation. This resulted in that event being responsible for half of our total event volume.

 There isn't really any reason we need to track every call to AddAsync so just removing it. 
 
 Also did a few smaller cleanup items : 
 
 - Changed method to take in IList directly so that we don't have to iterate over the entire list to get the count
 - Removed UpsertStart - this goes along with the rest of the removed Start/End events that I did earlier to again reduce overall event volume since having both the start and end events wasn't really that useful. It just doubled the number of events we sent
 - Added a few more useful properties to the Upsert event