### PR TITLE
Add binary types to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Databases on SQL Server, Azure SQL Database, or Azure SQL Managed Instance which
 
 ## Known Issues
 - The table used by a SQL binding or SQL trigger cannot contain two columns that only differ by casing (Ex. 'Name' and 'name'). 
+- Non-CSharp functions using SQL bindings against tables with columns of data types `BINARY` or `VARBINARY` need to map those columns to a string type. Input bindings will return the binary value as a base64 encoded string. Output bindings require the value upserted to binary columns to be a base64 encoded string.
 
 ### Output Bindings
 - Output bindings against tables with columns of data types `NTEXT`, `TEXT`, or `IMAGE` are not supported and data upserts will fail. These types [will be removed](https://docs.microsoft.com/sql/t-sql/data-types/ntext-text-and-image-transact-sql) in a future version of SQL Server and are not compatible with the `OPENJSON` function used by this Azure Functions binding.

--- a/test-outofproc/Product.cs
+++ b/test-outofproc/Product.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 using System.Collections.Generic;
 using System;
+using System.Linq;
 
 namespace DotnetIsolatedTests.Common
 {
@@ -138,6 +139,10 @@ namespace DotnetIsolatedTests.Common
 
         public string Nvarchar { get; set; }
 
+        public byte[] Binary { get; set; }
+
+        public byte[] Varbinary { get; set; }
+
         public override bool Equals(object obj)
         {
             if (obj is ProductColumnTypes)
@@ -149,7 +154,8 @@ namespace DotnetIsolatedTests.Common
                     this.FloatType == that.FloatType && this.Real == that.Real && this.Date == that.Date &&
                     this.Datetime == that.Datetime && this.Datetime2 == that.Datetime2 && this.DatetimeOffset == that.DatetimeOffset &&
                     this.SmallDatetime == that.SmallDatetime && this.Time == that.Time && this.CharType == that.CharType &&
-                    this.Varchar == that.Varchar && this.Nchar == that.Nchar && this.Nvarchar == that.Nvarchar;
+                    this.Varchar == that.Varchar && this.Nchar == that.Nchar && this.Nvarchar == that.Nvarchar &&
+                    this.Binary.SequenceEqual(that.Binary) && this.Varbinary.SequenceEqual(that.Varbinary);
             }
             return false;
         }

--- a/test/Common/ProductColumnTypes.cs
+++ b/test/Common/ProductColumnTypes.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 {
@@ -49,6 +50,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 
         public string Nvarchar { get; set; }
 
+        public byte[] Binary { get; set; }
+
+        public byte[] Varbinary { get; set; }
+
         public override bool Equals(object obj)
         {
             if (obj is ProductColumnTypes)
@@ -60,14 +65,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                     this.FloatType == that.FloatType && this.Real == that.Real && this.Date == that.Date &&
                     this.Datetime == that.Datetime && this.Datetime2 == that.Datetime2 && this.DatetimeOffset == that.DatetimeOffset &&
                     this.SmallDatetime == that.SmallDatetime && this.Time == that.Time && this.CharType == that.CharType &&
-                    this.Varchar == that.Varchar && this.Nchar == that.Nchar && this.Nvarchar == that.Nvarchar;
+                    this.Varchar == that.Varchar && this.Nchar == that.Nchar && this.Nvarchar == that.Nvarchar &&
+                    this.Binary.SequenceEqual(that.Binary) && this.Varbinary.SequenceEqual(that.Varbinary);
             }
             return false;
         }
 
         public override string ToString()
         {
-            return $"[{this.ProductId}, {this.BigInt}, {this.Bit}, {this.DecimalType}, {this.Money}, {this.Numeric}, {this.SmallInt}, {this.SmallMoney}, {this.TinyInt}, {this.FloatType}, {this.Real}, {this.Date}, {this.Datetime}, {this.Datetime2}, {this.DatetimeOffset}, {this.SmallDatetime}, {this.Time}, {this.CharType}, {this.Varchar}, {this.Nchar}, {this.Nvarchar}]";
+            return $"[{this.ProductId}, {this.BigInt}, {this.Bit}, {this.DecimalType}, {this.Money}, {this.Numeric}, {this.SmallInt}, {this.SmallMoney}, {this.TinyInt}, {this.FloatType}, {this.Real}, {this.Date}, {this.Datetime}, {this.Datetime2}, {this.DatetimeOffset}, {this.SmallDatetime}, {this.Time}, {this.CharType}, {this.Varchar}, {this.Nchar}, {this.Nvarchar}, {this.Binary}, {this.Varbinary}]";
         }
     }
 }

--- a/test/Database/Tables/ProductsColumnTypes.sql
+++ b/test/Database/Tables/ProductsColumnTypes.sql
@@ -20,4 +20,6 @@
     [Varchar] [varchar](100),
     [Nchar] [nchar](4),
     [Nvarchar] [nvarchar](100),
+    [Binary] [binary](4),
+    [Varbinary] [varbinary](100)
 )

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.StartFunctionHost(nameof(GetProductsColumnTypesSerializationAsyncEnumerable), lang, true);
 
             string datetime = "2022-10-20 12:39:13.123";
-            ProductColumnTypes[] expectedResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"BigInt\":999,\"Bit\":false,\"DecimalType\":1.2345,\"Money\":1.2345,\"Numeric\":1.2345,\"SmallInt\":1,\"SmallMoney\":1.2345,\"TinyInt\":1,\"FloatType\":0.1,\"Real\":0.1,\"Date\":\"2022-10-20T00:00:00.000Z\",\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\",\"DatetimeOffset\":\"2022-10-20T12:39:13.123Z\",\"SmallDatetime\":\"2022-10-20T12:39:00.000Z\",\"Time\":\"12:39:13.1230000\",\"CharType\":\"test\",\"Varchar\":\"test\",\"Nchar\":\"\uFFFD\u0020\u0020\u0020\",\"Nvarchar\":\"\uFFFD\"}]");
+            ProductColumnTypes[] expectedResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"BigInt\":999,\"Bit\":false,\"DecimalType\":1.2345,\"Money\":1.2345,\"Numeric\":1.2345,\"SmallInt\":1,\"SmallMoney\":1.2345,\"TinyInt\":1,\"FloatType\":0.1,\"Real\":0.1,\"Date\":\"2022-10-20T00:00:00.000Z\",\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\",\"DatetimeOffset\":\"2022-10-20T12:39:13.123Z\",\"SmallDatetime\":\"2022-10-20T12:39:00.000Z\",\"Time\":\"12:39:13.1230000\",\"CharType\":\"test\",\"Varchar\":\"test\",\"Nchar\":\"\uFFFD\u0020\u0020\u0020\",\"Nvarchar\":\"\uFFFD\",\"Binary\":\"dGVzdA==\",\"Varbinary\":\"dGVzdA==\"}]");
 
             this.ExecuteNonQuery("INSERT INTO [dbo].[ProductsColumnTypes] VALUES (" +
                 "999, " + // ProductId,
@@ -166,7 +166,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 "'test', " + // CharType
                 "'test', " + // Varchar
                 "NCHAR(0xD84C), " + // Nchar
-                "NCHAR(0xD84C))"); // Nvarchar
+                "NCHAR(0xD84C), " +  // Nvarchar
+                "CONVERT(BINARY, 'test'), " + // Binary
+                "CONVERT(VARBINARY, 'test'))"); // Varbinary
 
             HttpResponseMessage response = await this.SendInputRequest("getproducts-columntypesserializationasyncenumerable", $"?culture={culture}");
             // We expect the datetime and datetime2 fields to be returned in UTC format
@@ -206,11 +208,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 "'test', " + // CharType
                 "'test', " + // Varchar
                 "NCHAR(0xD84C), " + // Nchar
-                "NCHAR(0xD84C))"); // Nvarchar
+                "NCHAR(0xD84C), " +  // Nvarchar
+                "CONVERT(BINARY, 'test'), " + // Binary
+                "CONVERT(VARBINARY, 'test'))"); // Varbinary
 
             HttpResponseMessage response = await this.SendInputRequest("getproducts-columntypesserialization");
             // We expect the date fields to be returned in UTC format
-            ProductColumnTypes[] expectedResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"BigInt\":999,\"Bit\":false,\"DecimalType\":1.2345,\"Money\":1.2345,\"Numeric\":1.2345,\"SmallInt\":1,\"SmallMoney\":1.2345,\"TinyInt\":1,\"FloatType\":0.1,\"Real\":0.1,\"Date\":\"2022-10-20T00:00:00.000Z\",\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\",\"DatetimeOffset\":\"2022-10-20T12:39:13.123Z\",\"SmallDatetime\":\"2022-10-20T12:39:00.000Z\",\"Time\":\"12:39:13.1230000\",\"CharType\":\"test\",\"Varchar\":\"test\",\"Nchar\":\"\uFFFD\u0020\u0020\u0020\",\"Nvarchar\":\"\uFFFD\"}]");
+            ProductColumnTypes[] expectedResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>("[{\"ProductId\":999,\"BigInt\":999,\"Bit\":false,\"DecimalType\":1.2345,\"Money\":1.2345,\"Numeric\":1.2345,\"SmallInt\":1,\"SmallMoney\":1.2345,\"TinyInt\":1,\"FloatType\":0.1,\"Real\":0.1,\"Date\":\"2022-10-20T00:00:00.000Z\",\"Datetime\":\"2022-10-20T12:39:13.123Z\",\"Datetime2\":\"2022-10-20T12:39:13.123Z\",\"DatetimeOffset\":\"2022-10-20T12:39:13.123Z\",\"SmallDatetime\":\"2022-10-20T12:39:00.000Z\",\"Time\":\"12:39:13.1230000\",\"CharType\":\"test\",\"Varchar\":\"test\",\"Nchar\":\"\uFFFD\u0020\u0020\u0020\",\"Nvarchar\":\"\uFFFD\",\"Binary\":\"dGVzdA==\",\"Varbinary\":\"dGVzdA==\"}]");
             string actualResponse = await response.Content.ReadAsStringAsync();
             ProductColumnTypes[] actualProductResponse = JsonConvert.DeserializeObject<ProductColumnTypes[]>(actualResponse);
 

--- a/test/Integration/test-java/src/main/java/com/function/AddProductColumnTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/AddProductColumnTypes.java
@@ -58,7 +58,9 @@ public class AddProductColumnTypes {
             "test",
             "test",
             "\u2649",
-            "\u2649");
+            "\u2649",
+            "dGVzdA==",
+            "dGVzdA==");
         product.setValue(p);
 
         // Items were inserted successfully so return success, an exception would be thrown if there

--- a/test/Integration/test-java/src/main/java/com/function/Common/ProductColumnTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/Common/ProductColumnTypes.java
@@ -31,12 +31,14 @@ public class ProductColumnTypes {
     private String Varchar;
     private String Nchar;
     private String Nvarchar;
+    private String Binary;
+    private String Varbinary;
 
 
     public ProductColumnTypes(int productId, long bigInt, boolean bit, BigDecimal decimalType, BigDecimal money,
     BigDecimal numeric, short smallInt, BigDecimal smallMoney, short tinyInt, double floatType, double real, Timestamp date,
     Timestamp datetime, Timestamp datetime2, Timestamp datetimeOffset, Timestamp smallDatetime, String time, String charType,
-    String varchar, String nchar, String nvarchar) {
+    String varchar, String nchar, String nvarchar, String binary, String varbinary) {
         ProductId = productId;
         BigInt = bigInt;
         Bit = bit;
@@ -58,6 +60,8 @@ public class ProductColumnTypes {
         Varchar = varchar;
         Nchar = nchar;
         Nvarchar = nvarchar;
+        Binary = binary;
+        Varbinary = varbinary;
     }
 
     public int getProductId() {
@@ -222,5 +226,21 @@ public class ProductColumnTypes {
 
     public void setNvarchar(String nvarchar) {
         Nvarchar = nvarchar;
+    }
+
+    public String getBinary() {
+        return Binary;
+    }
+
+    public void setBinary(String binary) {
+        Binary = binary;
+    }
+
+    public String getVarbinary() {
+        return Varbinary;
+    }
+
+    public void setVarbinary(String varbinary) {
+        Varbinary = varbinary;
     }
 }

--- a/test/Integration/test-js/AddProductColumnTypes/index.js
+++ b/test/Integration/test-js/AddProductColumnTypes/index.js
@@ -27,7 +27,9 @@ module.exports = async function (context, req) {
         "CharType": "test",
         "Varchar": "test",
         "Nchar": "\u2649",
-        "Nvarchar": "\u2649"
+        "Nvarchar": "\u2649",
+        "Binary": "dGVzdA==",
+        "Varbinary": "dGVzdA=="
     };
 
     context.bindings.product = JSON.stringify(product);

--- a/test/Integration/test-powershell/AddProductColumnTypes/run.ps1
+++ b/test/Integration/test-powershell/AddProductColumnTypes/run.ps1
@@ -33,6 +33,8 @@ $req_query = @{
     Varchar="test";
     Nchar="\u2649";
     Nvarchar="\u2649";
+    Binary="dGVzdA==";
+    Varbinary="dGVzdA==";
 };
 
 # Assign the value we want to pass to the SQL Output binding.

--- a/test/Integration/test-python/AddProductColumnTypes/__init__.py
+++ b/test/Integration/test-python/AddProductColumnTypes/__init__.py
@@ -29,7 +29,9 @@ def main(req: func.HttpRequest, product: func.Out[func.SqlRow]) -> func.HttpResp
         "test",
         "test",
         "\u2649",
-        "\u2649")
+        "\u2649",
+        "dGVzdA==",
+        "dGVzdA==")
     )
     product.set(productColumnTypes)
 

--- a/test/Integration/test-python/Common/productcolumntypes.py
+++ b/test/Integration/test-python/Common/productcolumntypes.py
@@ -6,7 +6,7 @@ import collections
 class ProductColumnTypes(collections.UserDict):
     def __init__(self, productId, bigInt, bit, decimalType, money, numeric, smallInt,
         smallMoney, tinyInt, floatType, real, date, datetime, datetime2, datetimeOffset,
-        smallDatetime, time, charType, varchar, nchar, nvarchar):
+        smallDatetime, time, charType, varchar, nchar, nvarchar, binary, varBinary):
         super().__init__()
         self['ProductId'] = productId
         self['BigInt'] = bigInt
@@ -29,4 +29,6 @@ class ProductColumnTypes(collections.UserDict):
         self['Varchar'] = varchar
         self['Nchar'] = nchar
         self['Nvarchar'] = nvarchar
+        self['Binary'] = binary
+        self['Varbinary'] = varBinary
 


### PR DESCRIPTION
Normally the sql binary type maps to a byte array. But Newtonsoft serializes the byte array as a base64 encoded string when sending it to the language workers. So non-CSharp languages need to map binary types to a string (added a note to the known issues section of the readme).

If we try to use a byte array in a non-CSharp output binding, we get the following error because Newtonsoft expects a string:
`System.Private.CoreLib: Exception while executing function: Functions.AddProductColumnTypes. Microsoft.Azure.WebJobs.Host: Error while handling parameter _binder after function returned:. Newtonsoft.Json: Error reading string. Unexpected token: StartArray. Path 'Binary', line 23, position 13.`

Fixes: https://github.com/Azure/azure-functions-sql-extension/issues/423