### PR TITLE
Minor attribute updates

### DIFF
--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
@@ -11,10 +12,10 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// Creates an instance of the <see cref="SqlAttribute"/>, specifying the Sql attributes
         /// the function supports.
         /// </summary>
-        /// <param name="commandText">The text of the command.</param>
+        /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
         public SqlInputAttribute(string commandText)
         {
-            this.CommandText = commandText;
+            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
         }
 
         /// <summary>
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         public string ConnectionStringSetting { get; set; }
 
         /// <summary>
-        /// Either a SQL query or stored procedure that will be run in the database referred to in the ConnectionString.
+        /// Either a SQL query or stored procedure that will be run in the target database.
         /// </summary>
         public string CommandText { get; set; }
 

--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
     public sealed class SqlInputAttribute : InputBindingAttribute
     {
         /// <summary>
-        /// Creates an instance of the <see cref="SqlAttribute"/>, specifying the Sql attributes
-        /// the function supports.
+        /// Creates an instance of the <see cref="SqlInputAttribute"/>, which takes a SQL query or stored procedure to run and returns the output to the function.
         /// </summary>
         /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
         public SqlInputAttribute(string commandText)

--- a/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
@@ -9,8 +9,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
     public class SqlOutputAttribute : OutputBindingAttribute
     {
         /// <summary>
-        /// Creates an instance of the <see cref="SqlAttribute"/>, specifying the Sql attributes
-        /// the function supports.
+        /// Creates an instance of the <see cref="SqlOutputAttribute"/>, which takes a list of rows and upserts them into the target table.
         /// </summary>
         /// <param name="commandText">The table name to upsert the values to.</param>
         public SqlOutputAttribute(string commandText)

--- a/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
@@ -11,10 +12,10 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// Creates an instance of the <see cref="SqlAttribute"/>, specifying the Sql attributes
         /// the function supports.
         /// </summary>
-        /// <param name="commandText">The text of the command.</param>
+        /// <param name="commandText">The table name to upsert the values to.</param>
         public SqlOutputAttribute(string commandText)
         {
-            this.CommandText = commandText;
+            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
         }
 
         /// <summary>

--- a/src/TriggerBinding/SqlTriggerAttribute.cs
+++ b/src/TriggerBinding/SqlTriggerAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlTriggerAttribute"/> class.
         /// </summary>
-        /// <param name="tableName">Name of the user table</param>
+        /// <param name="tableName">Name of the table to watch for changes.</param>
         public SqlTriggerAttribute(string tableName)
         {
             this.TableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs
         public string ConnectionStringSetting { get; set; }
 
         /// <summary>
-        /// Name of the user table.
+        /// Name of the table to watch for changes.
         /// </summary>
         public string TableName { get; }
     }

--- a/src/TriggerBinding/SqlTriggerAttribute.cs
+++ b/src/TriggerBinding/SqlTriggerAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs
     public sealed class SqlTriggerAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SqlTriggerAttribute"/> class.
+        /// Initializes a new instance of the <see cref="SqlTriggerAttribute"/> class, which triggers the function when any changes on the specified table are detected.
         /// </summary>
         /// <param name="tableName">Name of the table to watch for changes.</param>
         public SqlTriggerAttribute(string tableName)


### PR DESCRIPTION
Was looking at something else and noticed : 

1. The out of proc worker isn't throwing on null parameter values like the extension attribute - we should do the same in both for consistency
2. Some of the doc entries could be clarified/improved

I filed https://github.com/Azure/azure-functions-sql-extension/issues/651 to get unit tests added for the out of proc worker - I tried adding a unit test for the null parameter throwing but wasn't able to due to the conflicting libraries used by the two extensions. 