### PR TITLE
Require connection string in attributes

### DIFF
--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -12,9 +12,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// Creates an instance of the <see cref="SqlInputAttribute"/>, which takes a SQL query or stored procedure to run and returns the output to the function.
         /// </summary>
         /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
-        public SqlInputAttribute(string commandText)
+        /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
+        public SqlInputAttribute(string commandText, string connectionStringSetting)
         {
             this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+            this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
         /// <summary>

--- a/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
@@ -12,9 +12,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// Creates an instance of the <see cref="SqlOutputAttribute"/>, which takes a list of rows and upserts them into the target table.
         /// </summary>
         /// <param name="commandText">The table name to upsert the values to.</param>
-        public SqlOutputAttribute(string commandText)
+        /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
+        public SqlOutputAttribute(string commandText, string connectionStringSetting)
         {
             this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+            this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
         /// <summary>

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -55,9 +55,9 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Input bindings takes four arguments:
 
 - **CommandText**: Passed as a constructor argument to the binding. Represents either a query string or the name of a stored procedure.
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 - **CommandType**: Specifies whether CommandText is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`)
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
-- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the result of the query/stored procedure execution:
 
@@ -82,15 +82,15 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "employees")] HttpRequest req,
         ILogger log,
         [Sql("select * from Employees",
-        CommandType = System.Data.CommandType.Text,
-        ConnectionStringSetting = "SqlConnectionString")]
+        "SqlConnectionString"
+        CommandType = System.Data.CommandType.Text)]
         IEnumerable<Employee> employee)
     {
         return new OkObjectResult(employee);
     }
     ```
 
-    *In the above, "select * from Employees" is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [SqlAttribute for Input Bindings](#sqlattribute-for-input-bindings) section*
+    *In the above, "select * from Employees" is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. The next parameter specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [SqlAttribute for Input Bindings](#sqlattribute-for-input-bindings) section*
 
 - Add 'using System.Collections.Generic;' to the namespaces list at the top of the page.
 - Currently, there is an error for the IEnumerable. We'll fix this by creating an Employee class.
@@ -128,9 +128,9 @@ The input binding executes the "select * from Products where Cost = @Cost" query
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
       HttpRequest req,
       [Sql("select * from Products where Cost = @Cost",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost}",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -167,9 +167,9 @@ In this case, the parameter value of the `@Name` parameter is an empty string.
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-nameempty/{cost}")]
       HttpRequest req,
       [Sql("select * from Products where Cost = @Cost and Name = @Name",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost},@Name=",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Cost={cost},@Name=")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -186,9 +186,9 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-namenull/{name}")]
       HttpRequest req,
       [Sql("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.Text,
-          Parameters = "@Name={name}",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Name={name}")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -205,9 +205,9 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-storedprocedure/{cost}")]
       HttpRequest req,
       [Sql("SelectProductsCost",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.StoredProcedure,
-          Parameters = "@Cost={cost}",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -223,9 +223,9 @@ public static async Task<IActionResult> Run(
     [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-async/{cost}")]
      HttpRequest req,
     [Sql("select * from Products where cost = @Cost",
+         "SqlConnectionString",
          CommandType = System.Data.CommandType.Text,
-         Parameters = "@Cost={cost}",
-         ConnectionStringSetting = "SqlConnectionString")]
+         Parameters = "@Cost={cost}")]
      IAsyncEnumerable<Product> products)
 {
     var enumerator = products.GetAsyncEnumerator();
@@ -248,7 +248,7 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Output bindings takes two arguments:
 
 - **CommandText**: Passed as a constructor argument to the binding. Represents the name of the table into which rows will be upserted.
-- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:
 
@@ -271,8 +271,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
     public static IActionResult Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addemployees-array")]
         HttpRequest req, ILogger log,
-        [Sql("dbo.Employees",
-        ConnectionStringSetting = "SqlConnectionString")]
+        [Sql("dbo.Employees", "SqlConnectionString")]
         out Employee[] output)
     {
         output = new Employee[]
@@ -314,7 +313,7 @@ When using an `ICollector`, it is not necessary to instantiate it. The function 
 [FunctionName("AddProductsCollector")]
 public static IActionResult Run(
 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproducts-collector")] HttpRequest req,
-[Sql("Products", ConnectionStringSetting = "SqlConnectionString")] ICollector<Product> products)
+[Sql("Products", "SqlConnectionString")] ICollector<Product> products)
 {
     var newProducts = GetNewProducts(5000);
     foreach (var product in newProducts)
@@ -331,7 +330,7 @@ It is also possible to force an upsert within the function by calling `FlushAsyn
 [FunctionName("AddProductsAsyncCollector")]
 public static async Task<IActionResult> Run(
 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproducts-asynccollector")] HttpRequest req,
-[Sql("Products", ConnectionStringSetting = "SqlConnectionString")] IAsyncCollector<Product> products)
+[Sql("Products", "SqlConnectionString")] IAsyncCollector<Product> products)
 {
     var newProducts = GetNewProducts(5000);
     foreach (var product in newProducts)
@@ -359,7 +358,7 @@ This output binding type requires explicit instantiation within the function bod
 public static IActionResult Run(
 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproducts-array")]
     HttpRequest req,
-[Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out Product[] output)
+[Sql("dbo.Products", "SqlConnectionString")] out Product[] output)
 {
     // Suppose that the ProductId column is the primary key in the Products table, and the
     // table already contains a row with ProductId = 1. In that case, the row will be updated
@@ -388,7 +387,7 @@ When binding to a single row, it is also necessary to prefix the row with `out`
 public static IActionResult Run(
 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct")]
     HttpRequest req,
-[Sql("Products", ConnectionStringSetting = "SqlConnectionString")] out Product product)
+[Sql("Products", "SqlConnectionString")] out Product product)
 {
     product = new Product
     {
@@ -424,7 +423,7 @@ Any time when the changes happen to the "Products" table, the user function will
 ```csharp
 [FunctionName("ProductsTrigger")]
 public static void Run(
-    [SqlTrigger("Products", ConnectionStringSetting = "SqlConnectionString")]
+    [SqlTrigger("Products", "SqlConnectionString")]
     IReadOnlyList<SqlChange<Product>> changes,
     ILogger logger)
 {
@@ -453,7 +452,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
         {
             [FunctionName("EmployeeTrigger")]
             public static void Run(
-                [SqlTrigger("[dbo].[Employees]", ConnectionStringSetting = "SqlConnectionString")]
+                [SqlTrigger("[dbo].[Employees]", "SqlConnectionString")]
                 IReadOnlyList<SqlChange<Employee>> changes,
                 ILogger logger)
             {

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -70,8 +70,8 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "employees")] HttpRequest req,
         ILogger log,
         [SqlInput("select * from Employees",
-        CommandType = System.Data.CommandType.Text,
-        ConnectionStringSetting = "SqlConnectionString")]
+        "SqlConnectionString",
+        CommandType = System.Data.CommandType.Text)]
         IEnumerable<Employee> employees)
     {
         return employees;
@@ -116,9 +116,9 @@ The input binding executes the "select * from Products where Cost = @Cost" query
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
       HttpRequestData req,
       [SqlInput("select * from Products where Cost = @Cost",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost}",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return products;
@@ -155,9 +155,9 @@ In this case, the parameter value of the `@Name` parameter is an empty string.
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-nameempty/{cost}")]
       HttpRequestData req,
       [SqlInput("select * from Products where Cost = @Cost and Name = @Name",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost},@Name=",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Cost={cost},@Name=")]
       IEnumerable<Product> products)
   {
       return products;
@@ -174,9 +174,9 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-namenull/{name}")]
       HttpRequestData req,
       [SqlInput("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.Text,
-          Parameters = "@Name={name}",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Name={name}")]
       IEnumerable<Product> products)
   {
       return products;
@@ -193,9 +193,9 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-storedprocedure/{cost}")]
       HttpRequestData req,
       [SqlInput("SelectProductsCost",
+          "SqlConnectionString",
           CommandType = System.Data.CommandType.StoredProcedure,
-          Parameters = "@Cost={cost}",
-          ConnectionStringSetting = "SqlConnectionString")]
+          Parameters = "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return products;
@@ -212,9 +212,9 @@ public static async Task<List<Product>> Run(
     [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-async/{cost}")]
      HttpRequestData req,
     [SqlInput("select * from Products where cost = @Cost",
+         "SqlConnectionString",
          CommandType = System.Data.CommandType.Text,
-         Parameters = "@Cost={cost}",
-         ConnectionStringSetting = "SqlConnectionString")]
+         Parameters = "@Cost={cost}")]
      IAsyncEnumerable<Product> products)
 {
     var enumerator = products.GetAsyncEnumerator();
@@ -259,7 +259,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
 
     ```csharp
     [Function("AddEmployees")]
-    [SqlOutput("dbo.Employees", ConnectionStringSetting = "SqlConnectionString")]
+    [SqlOutput("dbo.Employees", "SqlConnectionString")]
     public static Employee[] Run(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addemployees-array")]
         HttpRequestData req)
@@ -301,7 +301,7 @@ This output binding type requires the product array to be passed in the request 
 
 ``` csharp
 [Function("AddProductsArray")]
-[SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+[SqlOutput("dbo.Products", "SqlConnectionString")]
 public static async Task<Product[]> Run(
 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproducts-array")]
     HttpRequestData req)
@@ -317,7 +317,7 @@ public static async Task<Product[]> Run(
 
 ```csharp
 [Function("AddProduct")]
-[SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+[SqlOutput("dbo.Products", "SqlConnectionString")]
 public static Task<Product> Run(
 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct")]
     HttpRequestData req)

--- a/samples/samples-csharp/InputBindingSamples/GetProductNamesView.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductNamesView.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproduct-namesview/")]
             HttpRequest req,
             [Sql("SELECT * FROM ProductNames",
-                CommandType = System.Data.CommandType.Text,
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString",
+                CommandType = System.Data.CommandType.Text)]
             IEnumerable<ProductName> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProducts.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProducts.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
             HttpRequest req,
             [Sql("select * from Products where Cost = @Cost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsAsyncEnumerable.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsAsyncEnumerable.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-async/{cost}")]
             HttpRequest req,
             [Sql("select * from Products where cost = @Cost",
+                "SqlConnectionString",
                  CommandType = System.Data.CommandType.Text,
-                 Parameters = "@Cost={cost}",
-                 ConnectionStringSetting = "SqlConnectionString")]
+                 Parameters = "@Cost={cost}")]
              IAsyncEnumerable<Product> products)
         {
             IAsyncEnumerator<Product> enumerator = products.GetAsyncEnumerator();

--- a/samples/samples-csharp/InputBindingSamples/GetProductsNameEmpty.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsNameEmpty.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-nameempty/{cost}")]
             HttpRequest req,
             [Sql("select * from Products where Cost = @Cost and Name = @Name",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost},@Name=",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost},@Name=")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsNameNull.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsNameNull.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-namenull/{name}")]
             HttpRequest req,
             [Sql("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Name={name}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Name={name}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsSqlCommand.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsSqlCommand.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-sqlcommand/{cost}")]
             HttpRequest req,
             [Sql("select * from Products where cost = @Cost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             SqlCommand command)
         {
             string result = string.Empty;

--- a/samples/samples-csharp/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproductsbycost")]
             HttpRequest req,
             [Sql("%Sp_SelectCost%",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost=%ProductCost%",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost=%ProductCost%")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsStoredProcedure.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsStoredProcedure.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-storedprocedure/{cost}")]
             HttpRequest req,
             [Sql("SelectProductsCost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsString.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsString.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-string/{cost}")]
             HttpRequest req,
             [Sql("select * from Products where cost = @Cost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             string products)
         {
             // Products is a JSON representation of the returned rows. For example, if there are two returned rows,

--- a/samples/samples-csharp/InputBindingSamples/GetProductsTopN.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsTopN.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproductstopn/{count}")]
             HttpRequest req,
             [Sql("SELECT TOP(CAST(@Count AS INT)) * FROM Products",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Count={count}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Count={count}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/MultipleBindingsSamples/GetAndAddProducts.cs
+++ b/samples/samples-csharp/MultipleBindingsSamples/GetAndAddProducts.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.MultipleBindingsSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getandaddproducts/{cost}")]
             HttpRequest req,
             [Sql("SELECT * FROM Products",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             IEnumerable<Product> products,
             [Sql("ProductsWithIdentity",
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString")]
             out Product[] productsWithIdentity)
         {
             productsWithIdentity = products.ToArray();

--- a/samples/samples-csharp/OutputBindingSamples/AddProduct.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProduct.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct")]
             [FromBody] Product prod,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out Product product)
+            [Sql("dbo.Products", "SqlConnectionString")] out Product product)
         {
             product = prod;
             return new CreatedResult($"/api/addproduct", product);

--- a/samples/samples-csharp/OutputBindingSamples/AddProductParams.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductParams.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct-params")]
             HttpRequest req,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out Product product)
+            [Sql("dbo.Products", "SqlConnectionString")] out Product product)
         {
             product = new Product
             {

--- a/samples/samples-csharp/OutputBindingSamples/AddProductWithDefaultPK.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductWithDefaultPK.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproductwithdefaultpk")]
             [FromBody] ProductWithDefaultPK product,
-            [Sql("dbo.ProductsWithDefaultPK", ConnectionStringSetting = "SqlConnectionString")] out ProductWithDefaultPK output)
+            [Sql("dbo.ProductsWithDefaultPK", "SqlConnectionString")] out ProductWithDefaultPK output)
         {
             output = product;
             return new CreatedResult($"/api/addproductwithdefaultpk", output);

--- a/samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumn.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumn.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithidentitycolumn")]
             HttpRequest req,
-            [Sql("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")] out ProductWithoutId product)
+            [Sql("dbo.ProductsWithIdentity", "SqlConnectionString")] out ProductWithoutId product)
         {
             product = new ProductWithoutId
             {

--- a/samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumnIncluded.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductWithIdentityColumnIncluded.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithidentitycolumnincluded")]
             HttpRequest req,
-            [Sql("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")] out ProductWithOptionalId product)
+            [Sql("dbo.ProductsWithIdentity", "SqlConnectionString")] out ProductWithOptionalId product)
         {
             product = new ProductWithOptionalId
             {

--- a/samples/samples-csharp/OutputBindingSamples/AddProductWithMultiplePrimaryColumnsAndIdentity.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductWithMultiplePrimaryColumnsAndIdentity.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithmultipleprimarycolumnsandidentity")]
             HttpRequest req,
-            [Sql("dbo.ProductsWithMultiplePrimaryColumnsAndIdentity", ConnectionStringSetting = "SqlConnectionString")] out MultiplePrimaryKeyProductWithoutId product)
+            [Sql("dbo.ProductsWithMultiplePrimaryColumnsAndIdentity", "SqlConnectionString")] out MultiplePrimaryKeyProductWithoutId product)
         {
             product = new MultiplePrimaryKeyProductWithoutId
             {

--- a/samples/samples-csharp/OutputBindingSamples/AddProductsArray.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductsArray.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproducts-array")]
             [FromBody] List<Product> products,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out Product[] output)
+            [Sql("dbo.Products", "SqlConnectionString")] out Product[] output)
         {
             // Upsert the products, which will insert them into the Products table if the primary key (ProductId) for that item doesn't exist. 
             // If it does then update it to have the new name and cost

--- a/samples/samples-csharp/OutputBindingSamples/AddProductsAsyncCollector.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductsAsyncCollector.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproducts-asynccollector")]
             HttpRequest req,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] IAsyncCollector<Product> products)
+            [Sql("dbo.Products", "SqlConnectionString")] IAsyncCollector<Product> products)
         {
             List<Product> newProducts = ProductUtilities.GetNewProducts(5000);
             foreach (Product product in newProducts)

--- a/samples/samples-csharp/OutputBindingSamples/AddProductsCollector.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductsCollector.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproducts-collector")]
             HttpRequest req,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] ICollector<Product> products)
+            [Sql("dbo.Products", "SqlConnectionString")] ICollector<Product> products)
         {
             List<Product> newProducts = ProductUtilities.GetNewProducts(5000);
             foreach (Product product in newProducts)

--- a/samples/samples-csharp/OutputBindingSamples/AddProductsWithIdentityColumnArray.cs
+++ b/samples/samples-csharp/OutputBindingSamples/AddProductsWithIdentityColumnArray.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")]
             HttpRequest req,
-            [Sql("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")] out ProductWithoutId[] products)
+            [Sql("dbo.ProductsWithIdentity", "SqlConnectionString")] out ProductWithoutId[] products)
         {
             products = new[]
             {

--- a/samples/samples-csharp/OutputBindingSamples/QueueTriggerProducts.cs
+++ b/samples/samples-csharp/OutputBindingSamples/QueueTriggerProducts.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         [FunctionName("QueueTriggerProducts")]
         public static void Run(
             [QueueTrigger("testqueue")] string queueMessage, ILogger log,
-            [Sql("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")] ICollector<Product> products)
+            [Sql("[dbo].[Products]", "SqlConnectionString")] ICollector<Product> products)
         {
             int totalUpserts = 100;
             log.LogInformation($"[QueueTrigger]: {DateTime.Now} starting execution {queueMessage}. Rows to generate={totalUpserts}.");

--- a/samples/samples-csharp/OutputBindingSamples/TimerTriggerProducts.cs
+++ b/samples/samples-csharp/OutputBindingSamples/TimerTriggerProducts.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.OutputBindingSamples
         [FunctionName("TimerTriggerProducts")]
         public static void Run(
             [TimerTrigger("*/5 * * * * *")] TimerInfo req, ILogger log,
-            [Sql("Products", ConnectionStringSetting = "SqlConnectionString")] ICollector<Product> products)
+            [Sql("Products", "SqlConnectionString")] ICollector<Product> products)
         {
             int totalUpserts = 1000;
             log.LogInformation($"{DateTime.Now} starting execution #{_executionNumber}. Rows to generate={totalUpserts}.");

--- a/samples/samples-csharp/TriggerBindingSamples/ProductsTrigger.cs
+++ b/samples/samples-csharp/TriggerBindingSamples/ProductsTrigger.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.TriggerBindingSamples
     {
         [FunctionName(nameof(ProductsTrigger))]
         public static void Run(
-            [SqlTrigger("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[Products]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> changes,
             ILogger logger)
         {

--- a/samples/samples-outofproc/InputBindingSamples/GetProductNamesView.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductNamesView.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproduct-namesview/")]
             HttpRequestData req,
             [SqlInput("SELECT * FROM ProductNames",
-                CommandType = System.Data.CommandType.Text,
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString",
+                CommandType = System.Data.CommandType.Text)]
             IEnumerable<ProductName> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProducts.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProducts.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts/{cost}")]
             HttpRequestData req,
             [SqlInput("select * from Products where Cost = @Cost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsAsyncEnumerable.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsAsyncEnumerable.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-async/{cost}")]
             HttpRequestData req,
             [SqlInput("select * from Products where cost = @Cost",
+                "SqlConnectionString",
                  CommandType = System.Data.CommandType.Text,
-                 Parameters = "@Cost={cost}",
-                 ConnectionStringSetting = "SqlConnectionString")]
+                 Parameters = "@Cost={cost}")]
              IAsyncEnumerable<Product> products)
         {
             IAsyncEnumerator<Product> enumerator = products.GetAsyncEnumerator();

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsNameEmpty.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsNameEmpty.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-nameempty/{cost}")]
             HttpRequestData req,
             [SqlInput("select * from Products where Cost = @Cost and Name = @Name",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost},@Name=",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost},@Name=")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsNameNull.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsNameNull.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-namenull/{name}")]
             HttpRequestData req,
             [SqlInput("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Name={name}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Name={name}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproductsbycost")]
             HttpRequestData req,
             [SqlInput("%Sp_SelectCost%",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost=%ProductCost%",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost=%ProductCost%")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsStoredProcedure.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsStoredProcedure.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-storedprocedure/{cost}")]
             HttpRequestData req,
             [SqlInput("SelectProductsCost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsString.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsString.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-string/{cost}")]
             HttpRequestData req,
             [SqlInput("select * from Products where cost = @Cost",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             string products)
         {
             // Products is a JSON representation of the returned rows. For example, if there are two returned rows,

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsTopN.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsTopN.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproductstopn/{count}")]
             HttpRequestData req,
             [SqlInput("SELECT TOP(CAST(@Count AS INT)) * FROM Products",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Count={count}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Count={count}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/MultipleBindingsSamples/GetAndAddProducts.cs
+++ b/samples/samples-outofproc/MultipleBindingsSamples/GetAndAddProducts.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.MultipleBindin
     public static class GetAndAddProducts
     {
         [Function("GetAndAddProducts")]
-        [SqlOutput("ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("ProductsWithIdentity", "SqlConnectionString")]
         public static IEnumerable<Product> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getandaddproducts/{cost}")]
             HttpRequestData req,
             [SqlInput("SELECT * FROM Products",
+                "SqlConnectionString",
                 CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}",
-                ConnectionStringSetting = "SqlConnectionString")]
+                Parameters = "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return products.ToArray();

--- a/samples/samples-outofproc/OutputBindingSamples/AddProduct.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProduct.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
     public static class AddProduct
     {
         [Function("AddProduct")]
-        [SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.Products", "SqlConnectionString")]
         public static async Task<Product> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductParams.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductParams.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
     public static class AddProductParams
     {
         [Function("AddProductParams")]
-        [SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.Products", "SqlConnectionString")]
         public static Product Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct-params")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductWithDefaultPK.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductWithDefaultPK.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
         /// <param name="req">The original request that triggered the function</param>
         /// <returns>The new product object that will be upserted</returns>
         [Function(nameof(AddProductWithDefaultPK))]
-        [SqlOutput("dbo.ProductsWithDefaultPK", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsWithDefaultPK", "SqlConnectionString")]
         public static async Task<ProductWithDefaultPK> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproductwithdefaultpk")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductWithIdentityColumn.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductWithIdentityColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
         /// <param name="req">The original request that triggered the function</param>
         /// <returns>The product object containing the new object that will be upserted</returns>
         [Function(nameof(AddProductWithIdentityColumn))]
-        [SqlOutput("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsWithIdentity", "SqlConnectionString")]
         public static ProductWithoutId Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithidentitycolumn")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductWithIdentityColumnIncluded.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductWithIdentityColumnIncluded.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
         /// <param name="req">The original request that triggered the function</param>
         /// <returns>The new product object that will be upserted</returns>
         [Function(nameof(AddProductWithIdentityColumnIncluded))]
-        [SqlOutput("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsWithIdentity", "SqlConnectionString")]
         public static ProductWithOptionalId Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithidentitycolumnincluded")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductWithMultiplePrimaryColumnsAndIdentity.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductWithMultiplePrimaryColumnsAndIdentity.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
         /// <param name="req">The original request that triggered the function</param>
         /// <returns>The new product object that will be upserted</returns>
         [Function(nameof(AddProductWithMultiplePrimaryColumnsAndIdentity))]
-        [SqlOutput("dbo.ProductsWithMultiplePrimaryColumnsAndIdentity", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsWithMultiplePrimaryColumnsAndIdentity", "SqlConnectionString")]
         public static MultiplePrimaryKeyProductWithoutId Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproductwithmultipleprimarycolumnsandidentity")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductsArray.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductsArray.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
     public static class AddProductsArray
     {
         [Function("AddProductsArray")]
-        [SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.Products", "SqlConnectionString")]
         public static async Task<Product[]> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproducts-array")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/AddProductsWithIdentityColumnArray.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/AddProductsWithIdentityColumnArray.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
         /// <param name="req">The original request that triggered the function</param>
         /// <returns>The new product objects that will be upserted</returns>
         [Function(nameof(AddProductsWithIdentityColumnArray))]
-        [SqlOutput("dbo.ProductsWithIdentity", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsWithIdentity", "SqlConnectionString")]
         public static ProductWithoutId[] Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")]
             HttpRequestData req)

--- a/samples/samples-outofproc/OutputBindingSamples/QueueTriggerProducts.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/QueueTriggerProducts.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
     public static class QueueTriggerProducts
     {
         [Function("QueueTriggerProducts")]
-        [SqlOutput("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("[dbo].[Products]", "SqlConnectionString")]
         public static List<Product> Run([QueueTrigger("testqueue")] string queueMessage)
         {
             int totalUpserts = 100;

--- a/samples/samples-outofproc/OutputBindingSamples/TimerTriggerProducts.cs
+++ b/samples/samples-outofproc/OutputBindingSamples/TimerTriggerProducts.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.OutputBindingS
         /// This timer function runs evyery 5 seconds, each time it upserts 1000 rows of data.
         /// </summary>
         [Function("TimerTriggerProducts")]
-        [SqlOutput("Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("Products", "SqlConnectionString")]
         public static List<Product> Run(
             [TimerTrigger("*/5 * * * * *")] TimerInfo req, FunctionContext context)
         {

--- a/src/SqlAttribute.cs
+++ b/src/SqlAttribute.cs
@@ -19,10 +19,12 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlAttribute/>"/> class.
         /// </summary>
-        /// <param name="commandText">The text of the command</param>
-        public SqlAttribute(string commandText)
+        /// <param name="commandText">For an input binding, either a SQL query or stored procedure that will be run in the target database. For an output binding, the table name to upsert the values to.</param>
+        /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
+        public SqlAttribute(string commandText, string connectionStringSetting)
         {
             this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+            this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
         /// <summary>
@@ -37,8 +39,8 @@ namespace Microsoft.Azure.WebJobs
         public string ConnectionStringSetting { get; set; }
 
         /// <summary>
-        /// For an input binding, either a SQL query or stored procedure that will be run in the database referred to in the ConnectionString.
-        /// For an output binding, the table name.
+        /// For an input binding, either a SQL query or stored procedure that will be run in the target database.
+        /// For an output binding, the table name to upsert the values to.
         /// </summary>
         [AutoResolve]
         public string CommandText { get; }

--- a/src/TriggerBinding/SqlTriggerAttribute.cs
+++ b/src/TriggerBinding/SqlTriggerAttribute.cs
@@ -17,9 +17,11 @@ namespace Microsoft.Azure.WebJobs
         /// Initializes a new instance of the <see cref="SqlTriggerAttribute"/> class, which triggers the function when any changes on the specified table are detected.
         /// </summary>
         /// <param name="tableName">Name of the table to watch for changes.</param>
-        public SqlTriggerAttribute(string tableName)
+        /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
+        public SqlTriggerAttribute(string tableName, string connectionStringSetting)
         {
             this.TableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
         /// <summary>

--- a/test-outofproc/AddProductColumnTypes.cs
+++ b/test-outofproc/AddProductColumnTypes.cs
@@ -19,7 +19,7 @@ namespace DotnetIsolatedTests
         /// SQL server types.
         /// </summary>
         [Function(nameof(AddProductColumnTypes))]
-        [SqlOutput("dbo.ProductsColumnTypes", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsColumnTypes", "SqlConnectionString")]
         public static ProductColumnTypes Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct-columntypes")] HttpRequestData req)
         {

--- a/test-outofproc/AddProductExtraColumns.cs
+++ b/test-outofproc/AddProductExtraColumns.cs
@@ -13,7 +13,7 @@ namespace DotnetIsolatedTests
         // This output binding should throw an Exception because the ProductExtraColumns object has 
         // two properties that do not exist as columns in the SQL table (ExtraInt and ExtraString).
         [Function("AddProductExtraColumns")]
-        [SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.Products", "SqlConnectionString")]
         public static ProductExtraColumns Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct-extracolumns")]
             HttpRequest req)

--- a/test-outofproc/AddProductIncorrectCasing.cs
+++ b/test-outofproc/AddProductIncorrectCasing.cs
@@ -13,7 +13,7 @@ namespace DotnetIsolatedTests
         // This output binding should throw an error since the casing of the POCO field 'ProductID' and
         // table column name 'ProductId' do not match.
         [Function(nameof(AddProductIncorrectCasing))]
-        [SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.Products", "SqlConnectionString")]
         public static ProductIncorrectCasing Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct-incorrectcasing")] HttpRequestData req)
         {

--- a/test-outofproc/AddProductMissingColumns.cs
+++ b/test-outofproc/AddProductMissingColumns.cs
@@ -13,7 +13,7 @@ namespace DotnetIsolatedTests
         // This output binding should successfully add the ProductMissingColumns object
         // to the SQL table.
         [Function("AddProductMissingColumns")]
-        [SqlOutput("dbo.Products", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.Products", "SqlConnectionString")]
         public static ProductMissingColumns Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct-missingcolumns")]
             HttpRequest req)

--- a/test-outofproc/AddProductMissingColumnsException.cs
+++ b/test-outofproc/AddProductMissingColumnsException.cs
@@ -13,7 +13,7 @@ namespace DotnetIsolatedTests
         // This output binding should throw an error since the ProductsCostNotNull table does not
         // allows rows without a Cost value.
         [Function("AddProductMissingColumnsExceptionFunction")]
-        [SqlOutput("dbo.ProductsCostNotNull", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsCostNotNull", "SqlConnectionString")]
         public static ProductMissingColumns Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct-missingcolumnsexception")]
             HttpRequest req)

--- a/test-outofproc/AddProductsNoPartialUpsert.cs
+++ b/test-outofproc/AddProductsNoPartialUpsert.cs
@@ -16,7 +16,7 @@ namespace DotnetIsolatedTests
         // This output binding should throw an error since the ProductsNameNotNull table does not 
         // allows rows without a Name value. No rows should be upserted to the Sql table.
         [Function("AddProductsNoPartialUpsert")]
-        [SqlOutput("dbo.ProductsNameNotNull", ConnectionStringSetting = "SqlConnectionString")]
+        [SqlOutput("dbo.ProductsNameNotNull", "SqlConnectionString")]
         public static List<Product> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproducts-nopartialupsert")]
             HttpRequest req)

--- a/test-outofproc/GetProductColumnTypesSerialization.cs
+++ b/test-outofproc/GetProductColumnTypesSerialization.cs
@@ -20,8 +20,8 @@ namespace DotnetIsolatedTests
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserialization")]
             HttpRequest req,
             [SqlInput("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                CommandType = System.Data.CommandType.Text,
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString",
+                CommandType = System.Data.CommandType.Text)]
             IEnumerable<ProductColumnTypes> products)
         {
             return products;

--- a/test-outofproc/GetProductColumnTypesSerializationAsyncEnumerable.cs
+++ b/test-outofproc/GetProductColumnTypesSerializationAsyncEnumerable.cs
@@ -23,8 +23,8 @@ namespace DotnetIsolatedTests
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserializationasyncenumerable")]
             HttpRequestData req,
             [SqlInput("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                CommandType = System.Data.CommandType.Text,
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString",
+                CommandType = System.Data.CommandType.Text)]
             IAsyncEnumerable<ProductColumnTypes> products)
         {
             // Test different cultures to ensure that serialization/deserialization works correctly for all types.

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
                 // Either use integrated auth or SQL login depending if SA_PASSWORD is set
                 string userId = "SA";
-                string password = Environment.GetEnvironmentVariable("SA_PASSWORD");
+                string password = "Yukon900"; Environment.GetEnvironmentVariable("SA_PASSWORD");
                 if (string.IsNullOrEmpty(password))
                 {
                     connectionStringBuilder.IntegratedSecurity = true;

--- a/test/Integration/test-csharp/AddProductColumnTypes.cs
+++ b/test/Integration/test-csharp/AddProductColumnTypes.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [FunctionName(nameof(AddProductColumnTypes))]
         public static IActionResult Run(
                 [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct-columntypes")] HttpRequest req,
-                [Sql("dbo.ProductsColumnTypes", ConnectionStringSetting = "SqlConnectionString")] out ProductColumnTypes product)
+                [Sql("dbo.ProductsColumnTypes", "SqlConnectionString")] out ProductColumnTypes product)
         {
             product = new ProductColumnTypes()
             {

--- a/test/Integration/test-csharp/AddProductExtraColumns.cs
+++ b/test/Integration/test-csharp/AddProductExtraColumns.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct-extracolumns")]
             HttpRequest req,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out ProductExtraColumns product)
+            [Sql("dbo.Products", "SqlConnectionString")] out ProductExtraColumns product)
         {
             product = new ProductExtraColumns
             {

--- a/test/Integration/test-csharp/AddProductIncorrectCasing.cs
+++ b/test/Integration/test-csharp/AddProductIncorrectCasing.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "addproduct-incorrectcasing")]
             HttpRequest req,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out ProductIncorrectCasing product)
+            [Sql("dbo.Products", "SqlConnectionString")] out ProductIncorrectCasing product)
         {
             product = new ProductIncorrectCasing
             {

--- a/test/Integration/test-csharp/AddProductMissingColumns.cs
+++ b/test/Integration/test-csharp/AddProductMissingColumns.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct-missingcolumns")]
             HttpRequest req,
-            [Sql("dbo.Products", ConnectionStringSetting = "SqlConnectionString")] out ProductMissingColumns product)
+            [Sql("dbo.Products", "SqlConnectionString")] out ProductMissingColumns product)
         {
             product = new ProductMissingColumns
             {

--- a/test/Integration/test-csharp/AddProductMissingColumnsException.cs
+++ b/test/Integration/test-csharp/AddProductMissingColumnsException.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproduct-missingcolumnsexception")]
             HttpRequest req,
-            [Sql("dbo.ProductsCostNotNull", ConnectionStringSetting = "SqlConnectionString")] out ProductMissingColumns product)
+            [Sql("dbo.ProductsCostNotNull", "SqlConnectionString")] out ProductMissingColumns product)
         {
             product = new ProductMissingColumns
             {

--- a/test/Integration/test-csharp/AddProductsNoPartialUpsert.cs
+++ b/test/Integration/test-csharp/AddProductsNoPartialUpsert.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         public static IActionResult Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "addproducts-nopartialupsert")]
             HttpRequest req,
-            [Sql("dbo.ProductsNameNotNull", ConnectionStringSetting = "SqlConnectionString")] ICollector<Product> products)
+            [Sql("dbo.ProductsNameNotNull", "SqlConnectionString")] ICollector<Product> products)
         {
             List<Product> newProducts = ProductUtilities.GetNewProducts(UpsertBatchSize);
             foreach (Product product in newProducts)

--- a/test/Integration/test-csharp/GetProductColumnTypesSerialization.cs
+++ b/test/Integration/test-csharp/GetProductColumnTypesSerialization.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserialization")]
             HttpRequest req,
             [Sql("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                CommandType = System.Data.CommandType.Text,
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString",
+                CommandType = System.Data.CommandType.Text)]
             IEnumerable<ProductColumnTypes> products,
             ILogger log)
         {

--- a/test/Integration/test-csharp/GetProductColumnTypesSerializationAsyncEnumerable.cs
+++ b/test/Integration/test-csharp/GetProductColumnTypesSerializationAsyncEnumerable.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserializationasyncenumerable")]
             HttpRequest req,
             [Sql("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                CommandType = System.Data.CommandType.Text,
-                ConnectionStringSetting = "SqlConnectionString")]
+                "SqlConnectionString",
+                CommandType = System.Data.CommandType.Text)]
             IAsyncEnumerable<ProductColumnTypes> products,
             ILogger log)
         {

--- a/test/Integration/test-csharp/MultiFunctionTrigger.cs
+++ b/test/Integration/test-csharp/MultiFunctionTrigger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
     {
         [FunctionName(nameof(MultiFunctionTrigger1))]
         public static void MultiFunctionTrigger1(
-            [SqlTrigger("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[Products]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> products,
             ILogger logger)
         {
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         [FunctionName(nameof(MultiFunctionTrigger2))]
         public static void MultiFunctionTrigger2(
-            [SqlTrigger("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[Products]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> products,
             ILogger logger)
         {

--- a/test/Integration/test-csharp/PrimaryKeyNotPresentTrigger.cs
+++ b/test/Integration/test-csharp/PrimaryKeyNotPresentTrigger.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [FunctionName(nameof(PrimaryKeyNotPresentTrigger))]
         public static void Run(
-            [SqlTrigger("[dbo].[ProductsWithoutPrimaryKey]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[ProductsWithoutPrimaryKey]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> products)
         {
             throw new NotImplementedException("Associated test case should fail before the function is invoked.");

--- a/test/Integration/test-csharp/ProductsTriggerWithValidation.cs
+++ b/test/Integration/test-csharp/ProductsTriggerWithValidation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [FunctionName(nameof(ProductsTriggerWithValidation))]
         public static void Run(
-            [SqlTrigger("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[Products]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> changes,
             ILogger logger)
         {

--- a/test/Integration/test-csharp/ReservedPrimaryKeyColumnNamesTrigger.cs
+++ b/test/Integration/test-csharp/ReservedPrimaryKeyColumnNamesTrigger.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [FunctionName(nameof(ReservedPrimaryKeyColumnNamesTrigger))]
         public static void Run(
-            [SqlTrigger("[dbo].[ProductsWithReservedPrimaryKeyColumnNames]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[ProductsWithReservedPrimaryKeyColumnNames]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> products)
         {
             throw new NotImplementedException("Associated test case should fail before the function is invoked.");

--- a/test/Integration/test-csharp/TableNotPresentTrigger.cs
+++ b/test/Integration/test-csharp/TableNotPresentTrigger.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [FunctionName(nameof(TableNotPresentTrigger))]
         public static void Run(
-            [SqlTrigger("[dbo].[TableNotPresent]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[TableNotPresent]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> products)
         {
             throw new NotImplementedException("Associated test case should fail before the function is invoked.");

--- a/test/Integration/test-csharp/TriggerWithException.cs
+++ b/test/Integration/test-csharp/TriggerWithException.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [FunctionName(nameof(TriggerWithException))]
         public static void Run(
-            [SqlTrigger("[dbo].[Products]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[Products]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> changes,
             ILogger logger)
         {

--- a/test/Integration/test-csharp/UnsupportedColumnTypesTrigger.cs
+++ b/test/Integration/test-csharp/UnsupportedColumnTypesTrigger.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [FunctionName(nameof(UnsupportedColumnTypesTrigger))]
         public static void Run(
-            [SqlTrigger("[dbo].[ProductsWithUnsupportedColumnTypes]", ConnectionStringSetting = "SqlConnectionString")]
+            [SqlTrigger("[dbo].[ProductsWithUnsupportedColumnTypes]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> products)
         {
             throw new NotImplementedException("Associated test case should fail before the function is invoked.");

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -38,7 +38,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public void TestNullCommandText()
         {
-            Assert.Throws<ArgumentNullException>(() => new SqlAttribute(null));
+            Assert.Throws<ArgumentNullException>(() => new SqlAttribute(null, "SqlConnectionString"));
+        }
+
+        [Fact]
+        public void TestNullConnectionStringSetting()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SqlAttribute("SELECT * FROM dbo.Products", null));
         }
 
         [Fact]
@@ -65,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         public void TestNullArgumentsSqlAsyncEnumerableConstructor()
         {
             Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(connection, null));
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(null, new SqlAttribute("")));
+            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(null, new SqlAttribute("", "SqlConnectionString")));
         }
 
         /// <summary>
@@ -75,19 +81,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public void TestInvalidOperationSqlAsyncEnumerableConstructor()
         {
-            Assert.Throws<InvalidOperationException>(() => new SqlAsyncEnumerable<string>(connection, new SqlAttribute("")));
+            Assert.Throws<InvalidOperationException>(() => new SqlAsyncEnumerable<string>(connection, new SqlAttribute("", "SqlConnectionString")));
         }
 
         [Fact]
         public void TestInvalidArgumentsBuildConnection()
         {
-            var attribute = new SqlAttribute("");
+            var attribute = new SqlAttribute("", "");
             Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, config.Object));
 
-            attribute = new SqlAttribute("")
-            {
-                ConnectionStringSetting = "ConnectionStringSetting"
-            };
+            attribute = new SqlAttribute("", "ConnectionStringSetting");
             Assert.Throws<ArgumentNullException>(() => SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, null));
         }
 
@@ -95,7 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         public void TestInvalidCommandType()
         {
             // Specify an invalid type
-            var attribute = new SqlAttribute("")
+            var attribute = new SqlAttribute("", "SqlConnectionString")
             {
                 CommandType = System.Data.CommandType.TableDirect
             };
@@ -106,7 +109,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         public void TestDefaultCommandType()
         {
             string query = "select * from Products";
-            var attribute = new SqlAttribute(query);
+            var attribute = new SqlAttribute(query, "SqlConnectionString");
             SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, null);
             // CommandType should default to Text
             Assert.Equal(System.Data.CommandType.Text, command.CommandType);
@@ -118,7 +121,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         public void TestValidCommandType()
         {
             string query = "select * from Products";
-            var attribute = new SqlAttribute(query)
+            var attribute = new SqlAttribute(query, "SqlConnectionString")
             {
                 CommandType = System.Data.CommandType.Text
             };
@@ -127,7 +130,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             Assert.Equal(query, command.CommandText);
 
             string procedure = "StoredProcedure";
-            attribute = new SqlAttribute(procedure)
+            attribute = new SqlAttribute(procedure, "SqlConnectionString")
             {
                 CommandType = System.Data.CommandType.StoredProcedure
             };
@@ -231,7 +234,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public async void TestWellformedDeserialization()
         {
-            var arg = new SqlAttribute(string.Empty);
+            var arg = new SqlAttribute(string.Empty, "SqlConnectionString");
             var converter = new Mock<SqlGenericsConverter<TestData>>(config.Object, logger.Object);
             string json = "[{ \"ID\":1,\"Name\":\"Broom\",\"Cost\":32.5,\"Timestamp\":\"2019-11-22T06:32:15\"},{ \"ID\":2,\"Name\":\"Brush\",\"Cost\":12.3," +
                 "\"Timestamp\":\"2017-01-27T03:13:11\"},{ \"ID\":3,\"Name\":\"Comb\",\"Cost\":100.12,\"Timestamp\":\"1997-05-03T10:11:56\"}]";
@@ -268,7 +271,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public async void TestMalformedDeserialization()
         {
-            var arg = new SqlAttribute(string.Empty);
+            var arg = new SqlAttribute(string.Empty, "SqlConnectionString");
             var converter = new Mock<SqlGenericsConverter<TestData>>(config.Object, logger.Object);
 
             // SQL data is missing a field

--- a/test/Unit/SqlOutputBindingTests.cs
+++ b/test/Unit/SqlOutputBindingTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public void TestNullCollectorConstructorArguments()
         {
-            var arg = new SqlAttribute(string.Empty);
+            var arg = new SqlAttribute(string.Empty, "SqlConnectionString");
             Assert.Throws<ArgumentNullException>(() => new SqlAsyncCollector<string>(config.Object, null, logger.Object));
             Assert.Throws<ArgumentNullException>(() => new SqlAsyncCollector<string>(null, arg, logger.Object));
         }

--- a/test/Unit/TriggerBinding/SqlTriggerBindingProviderTests.cs
+++ b/test/Unit/TriggerBinding/SqlTriggerBindingProviderTests.cs
@@ -96,8 +96,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
 
         private static void UserFunctionWithoutAttribute<T>(T _) { }
 
-        private static void UserFunctionWithoutConnectionString<T>([SqlTrigger("testTableName")] T _) { }
+        private static void UserFunctionWithoutConnectionString<T>([SqlTrigger("testTableName", null)] T _) { }
 
-        private static void UserFunctionWithAttribute<T>([SqlTrigger("testTableName", ConnectionStringSetting = "testConnectionStringSetting")] T _) { }
+        private static void UserFunctionWithAttribute<T>([SqlTrigger("testTableName", "testConnectionStringSetting")] T _) { }
     }
 }

--- a/test/Unit/TriggerBinding/SqlTriggerBindingProviderTests.cs
+++ b/test/Unit/TriggerBinding/SqlTriggerBindingProviderTests.cs
@@ -39,10 +39,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         {
             Type parameterType = typeof(IReadOnlyList<SqlChange<object>>);
             Task testCode() { return CreateTriggerBindingAsync(parameterType, nameof(UserFunctionWithoutConnectionString)); }
-            ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(testCode);
+            ArgumentException exception = await Assert.ThrowsAsync<ArgumentNullException>(testCode);
 
             Assert.Equal(
-                "Must specify ConnectionStringSetting, which should refer to the name of an app setting that contains a SQL connection string",
+                "Value cannot be null. (Parameter 'connectionStringSetting')",
                 exception.Message);
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [InlineData(typeof(IReadOnlyList<IReadOnlyList<object>>))]
         public async Task TryCreateAsync_InvalidTriggerParameterType_ThrowsException(Type parameterType)
         {
-            Task testCode() { return CreateTriggerBindingAsync(parameterType, nameof(UserFunctionWithoutConnectionString)); }
+            Task testCode() { return CreateTriggerBindingAsync(parameterType, nameof(UserFunctionWithAttribute)); }
             InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(testCode);
 
             Assert.Equal(


### PR DESCRIPTION
Closes https://github.com/Azure/azure-functions-sql-extension/issues/31

ConnectionStringSetting is now a required parameter for the C# attributes.

I considered a major version bump for this as well since it's a breaking change - but since this is still in preview and this change is something that won't cause runtime issues (like the SqlClient update) I think sticking with 1.* will be best for the time being (especially given how slow the AF updates for bundles/templates are)