### PR TITLE
Test logging improvements

### DIFF
--- a/test/Common/LogTestNameAttribute.cs
+++ b/test/Common/LogTestNameAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
+{
+    internal class LogTestNameAttribute : BeforeAfterTestAttribute
+    {
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            Console.WriteLine($"Starting test {methodUnderTest.Name}");
+        }
+
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Console.WriteLine($"Completed test {methodUnderTest.Name}");
+        }
+    }
+}

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// </summary>
         /// <param name="connection">The connection.  This must be opened.</param>
         /// <param name="commandText">The scalar T-SQL command.</param>
+        /// <param name="logger">The method to call for logging output</param>
         /// <param name="catchException">Optional exception handling.  Pass back 'true' to handle the
         /// exception, 'false' to throw. If Null is passed in then all exceptions are thrown.</param>
         /// <param name="message">Optional message to write when this query is executed. Defaults to writing the query commandText</param>
@@ -48,6 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         public static int ExecuteNonQuery(
             IDbConnection connection,
             string commandText,
+            Action<string> logger,
             Predicate<Exception> catchException = null,
             string message = null)
         {
@@ -69,7 +71,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                     cmd.CommandText = commandText;
                     cmd.CommandType = CommandType.Text;
                     cmd.CommandTimeout = 60; // Increase from default 30s to prevent timeouts while connecting to Azure SQL DB
-                    Console.WriteLine(message);
+                    logger.Invoke(message);
                     return cmd.ExecuteNonQuery();
                 }
                 catch (Exception ex)
@@ -89,12 +91,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// </summary>
         /// <param name="connection">The connection.  This must be opened.</param>
         /// <param name="commandText">The scalar T-SQL command.</param>
+        /// <param name="logger">The method to call for logging output</param>
         /// <param name="catchException">Optional exception handling.  Pass back 'true' to handle the
         /// exception, 'false' to throw. If Null is passed in then all exceptions are thrown.</param>
         /// <returns>The scalar result</returns>
         public static object ExecuteScalar(
             IDbConnection connection,
             string commandText,
+            Action<string> logger,
             Predicate<Exception> catchException = null)
         {
             if (connection == null)
@@ -112,7 +116,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                 {
                     cmd.CommandText = commandText;
                     cmd.CommandType = CommandType.Text;
-                    Console.WriteLine($"Executing scalar {commandText}");
+                    logger.Invoke($"Executing scalar {commandText}");
                     return cmd.ExecuteScalar();
                 }
                 catch (Exception ex)
@@ -132,10 +136,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
         /// Retries the specified action, waiting for the specified duration in between each attempt
         /// </summary>
         /// <param name="action">The action to run</param>
+        /// <param name="logger">The method to call for logging output</param>
         /// <param name="retryCount">The max number of retries to attempt</param>
         /// <param name="waitDurationMs">The duration in milliseconds between each attempt</param>
         /// <exception cref="AggregateException">Aggregate of all exceptions thrown if all retries failed</exception>
-        public static void Retry(Action action, int retryCount = 3, int waitDurationMs = 10000)
+        public static void Retry(Action action, Action<string> logger, int retryCount = 3, int waitDurationMs = 10000)
         {
             var exceptions = new List<Exception>();
             while (true)
@@ -153,7 +158,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                     {
                         throw new AggregateException($"Action failed all retries", exceptions);
                     }
-                    Console.WriteLine($"Error running action, retrying after {waitDurationMs}ms. {retryCount} retries left. {ex}");
+                    logger.Invoke($"Error running action, retrying after {waitDurationMs}ms. {retryCount} retries left. {ex}");
                     Thread.Sleep(waitDurationMs);
                 }
             }

--- a/test/Integration/IntegrationTestBase.cs
+++ b/test/Integration/IntegrationTestBase.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             {
                 using var masterConnection = new SqlConnection(this.MasterConnectionString);
                 masterConnection.Open();
-                TestUtils.ExecuteNonQuery(masterConnection, $"CREATE DATABASE [{this.DatabaseName}]");
-            });
+                TestUtils.ExecuteNonQuery(masterConnection, $"CREATE DATABASE [{this.DatabaseName}]", this.LogOutput);
+            }, this.LogOutput);
 
             // Setup connection
             connectionStringBuilder.InitialCatalog = this.DatabaseName;
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             return funcPath;
         }
 
-        private void LogOutput(string output)
+        protected void LogOutput(string output)
         {
             if (this.TestOutput != null)
             {
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="message">Optional message to write when this query is executed. Defaults to writing the query commandText</param>
         protected void ExecuteNonQuery(string commandText, string message = null)
         {
-            TestUtils.ExecuteNonQuery(this.Connection, commandText, message: message);
+            TestUtils.ExecuteNonQuery(this.Connection, commandText, this.LogOutput, message: message);
         }
 
         /// <summary>
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         protected object ExecuteScalar(string commandText)
         {
-            return TestUtils.ExecuteScalar(this.Connection, commandText);
+            return TestUtils.ExecuteScalar(this.Connection, commandText, this.LogOutput);
         }
 
 
@@ -394,7 +394,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 // Drop the test database
                 using var masterConnection = new SqlConnection(this.MasterConnectionString);
                 masterConnection.Open();
-                TestUtils.ExecuteNonQuery(masterConnection, $"DROP DATABASE IF EXISTS {this.DatabaseName}");
+                TestUtils.ExecuteNonQuery(masterConnection, $"DROP DATABASE IF EXISTS {this.DatabaseName}", this.LogOutput);
             }
             catch (Exception e4)
             {

--- a/test/Integration/MultipleSqlBindingsIntegrationTests.cs
+++ b/test/Integration/MultipleSqlBindingsIntegrationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
     [Collection(IntegrationTestsCollection.Name)]
+    [LogTestName]
     public class MultipleSqlBindingsIntegrationTests : IntegrationTestBase
     {
         public MultipleSqlBindingsIntegrationTests(ITestOutputHelper output) : base(output)

--- a/test/Integration/SqlInputBindingIntegrationTests.cs
+++ b/test/Integration/SqlInputBindingIntegrationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common;
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
     [Collection(IntegrationTestsCollection.Name)]
+    [LogTestName]
     public class SqlInputBindingIntegrationTests : IntegrationTestBase
     {
         public SqlInputBindingIntegrationTests(ITestOutputHelper output) : base(output)

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
     [Collection(IntegrationTestsCollection.Name)]
+    [LogTestName]
     public class SqlOutputBindingIntegrationTests : IntegrationTestBase
     {
         public SqlOutputBindingIntegrationTests(ITestOutputHelper output) : base(output)

--- a/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             await actions();
 
             // Now wait until either we timeout or we've gotten all the expected changes, whichever comes first
-            Console.WriteLine($"[{DateTime.UtcNow:u}] Waiting for {operation} changes ({timeoutMs}ms)");
+            this.LogOutput($"[{DateTime.UtcNow:u}] Waiting for {operation} changes ({timeoutMs}ms)");
             await taskCompletion.Task.TimeoutAfter(TimeSpan.FromMilliseconds(timeoutMs), $"Timed out waiting for {operation} changes.");
 
             // Unhook handler since we're done monitoring these changes so we aren't checking other changes done later

--- a/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
@@ -15,6 +15,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 {
+    [LogTestName]
     public class SqlTriggerBindingIntegrationTestBase : IntegrationTestBase
     {
         public SqlTriggerBindingIntegrationTestBase(ITestOutputHelper output = null) : base(output)


### PR DESCRIPTION
1. Sometimes we'll have tests hang and never complete and currently it's very difficult to find out what test is actually hanging since it doesn't count as a test "failure" in ADO so doesn't show up in the tests tab. To make this easier I'm adding some logging to log the test startup and completion to stdout so it'll show up in the ADO logs for the test job
2. Also moving some of the general logging we do to use ITestOutputHelper so that it goes into the logging for the individual test instead of the stdout for the entire test run. This will help keep that logging cleaner and make it so everything related to a test (setup/teardown) goes into the test log itself to more easily correlate issues

Before job output would look like this : 

![image](https://user-images.githubusercontent.com/28519865/217626554-3454ff16-cb3a-4b79-9f6b-6b76191a6037.png)

After:

![image](https://user-images.githubusercontent.com/28519865/217626699-e4914f0e-5cf8-495d-b764-86e9c43828e9.png)

Notes:

1. The Azurite output still goes there because that's done through an attribute and I didn't see an obvious way to pass the ITestOutputHelper to that as well. Fixing that can be done later as needed. 
2. It doesn't give the parameters for the run so we'll see the same method name show up multiple times (for each language and each parameter). I didn't see an obvious way to get that either so just leaving it like this for now - it'll at least tell us what test is getting stuck which is a good enough start to be able to act on