### PR TITLE
Add OOP function app setup

### DIFF
--- a/docs/GeneralSetup.md
+++ b/docs/GeneralSetup.md
@@ -42,15 +42,15 @@ ALTER TABLE ['{table_name}'] ALTER COLUMN ['{primary_key_column_name}'] int NOT 
 ALTER TABLE ['{table_name}'] ADD CONSTRAINT PKey PRIMARY KEY CLUSTERED (['{primary_key_column_name}']);
 ```
 
-## Create a Function App
+## Create a Function Project
 
-Now you will need a Function App to add the binding to. If you have one created already you can skip this step.
+Now you will need a Function Project to add the binding to. If you have one created already you can skip this step.
 
 These steps can be done in the Terminal/CLI or with PowerShell.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for .NET, JavaScript, TypeScript, Python or Java.
+2. Create a function project for .NET, JavaScript, TypeScript, Python or Java.
 
     **.NET**
 
@@ -102,7 +102,7 @@ These steps can be done in the Terminal/CLI or with PowerShell.
     func init --worker-runtime powershell
     ```
 
-3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function project. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     **.NET:** Install the extension.
 
@@ -174,7 +174,7 @@ These steps can be done in the Terminal/CLI or with PowerShell.
 
 ## Configure Function App
 
-Once you have your Function App you need to configure it for use with Azure SQL bindings for Azure Functions.
+Once you have your Function Project you need to configure it for use with Azure SQL bindings for Azure Functions.
 
 1. Ensure you have Azure Storage Emulator running. This is specific to the sample functions in this repository with a non-HTTP trigger. For information on the Azure Storage Emulator, refer to the docs on its use in [functions local development](https://docs.microsoft.com/azure/azure-functions/functions-app-settings#azurewebjobsstorage) and [installation](https://docs.microsoft.com/azure/storage/common/storage-use-emulator#get-the-storage-emulator).
 

--- a/docs/GeneralSetup.md
+++ b/docs/GeneralSetup.md
@@ -172,7 +172,7 @@ These steps can be done in the Terminal/CLI or with PowerShell.
     }
     ```
 
-## Configure Function App
+## Configure Function Project
 
 Once you have your Function Project you need to configure it for use with Azure SQL bindings for Azure Functions.
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -4,7 +4,7 @@
 
 - [Azure SQL bindings for Azure Functions - .NET](#azure-sql-bindings-for-azure-functions---net)
   - [Table of Contents](#table-of-contents)
-  - [Setup Function App](#setup-function-app)
+  - [Setup Function Project](#setup-function-project)
   - [Input Binding](#input-binding)
     - [SqlAttribute for Input Bindings](#sqlattribute-for-input-bindings)
     - [Setup for Input Bindings](#setup-for-input-bindings)
@@ -25,9 +25,9 @@
     - [SqlTriggerAttribute](#sqltriggerattribute)
     - [Setup for Trigger Bindings](#setup-for-trigger-bindings)
 
-## Setup Function App
+## Setup Function Project
 
-These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -73,7 +73,7 @@ The repo contains examples of each of these binding types [here](https://github.
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
+- Open your project that you created in [Create a Function Project](./GeneralSetup.md#create-a-function-project) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> Company.namespace -> anonymous
 - In the file that opens, replace the `public static async Task<IActionResult> Run` block with the below code.

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -39,7 +39,7 @@ These instructions will guide you through creating your Function Project and add
     func init --worker-runtime dotnet
     ```
 
-3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function project. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Install the extension.
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -27,11 +27,11 @@
 
 ## Setup Function Project
 
-These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function project you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for .NET:
+2. Create a function project for .NET:
 
     ```bash
     mkdir MyApp

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -85,7 +85,7 @@ The repo contains examples of each of these binding types [here](https://github.
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your project that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
+- Open your project that you created in [Create a Function Project](./GeneralSetup.md#create-a-function-project) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> Company.namespace -> anonymous
 - In the file that opens, replace the `public static async Task<IActionResult> Run` block with the below code.

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -38,11 +38,11 @@ Please refer to the functions documentation [here](https://learn.microsoft.com/a
 
 ## Setup Function Project
 
-These instructions will guide you through creating your Function Project and adding the SQL binding worker extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding worker extension. This only needs to be done once for every function project you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for .NET:
+2. Create a function project for .NET Isolated:
 
     ```bash
     mkdir MyApp
@@ -52,7 +52,7 @@ These instructions will guide you through creating your Function Project and add
 
 3. Enable SQL bindings isolated worker on the function app. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
 
-    Add the SQL binding woker extension package to the project.
+    Add the SQL binding worker extension package to the project.
 
     ```powershell
     dotnet add package Microsoft.Azure.Functions.Worker.Extensions.Sql --prerelease

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -50,7 +50,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime dotnet-isolated
     ```
 
-3. Enable SQL bindings isolated worker on the function app. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide).
+3. Enable SQL bindings isolated worker on the function app. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
 
     Install the extension.
 

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -35,6 +35,28 @@ Please refer to the functions documentation [here](https://learn.microsoft.com/a
 - There's also no direct support for types inherited from underlying service SDKs, such as SqlCommand. Instead, bindings rely on strings, arrays, and serializable types, such as plain old class objects (POCOs).
 - For HTTP triggers, you must use HttpRequestData and HttpResponseData to access the request and response data. This is because you don't have access to the original HTTP request and response objects when running out-of-process.
 
+## Setup Function App
+
+These instructions will guide you through creating your Function App and adding the SQL binding worker. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+
+1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
+
+2. Create a function app for .NET:
+
+    ```bash
+    mkdir MyApp
+    cd MyApp
+    func init --worker-runtime dotnet-isolated
+    ```
+
+3. Enable SQL bindings isolated worker on the function app. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide).
+
+    Install the extension.
+
+    ```powershell
+    dotnet add package Microsoft.Azure.Functions.Worker.Extensions.Sql --prerelease
+    ```
+
 ## Input Binding
 
 See [Input Binding Overview](./BindingsOverview.md#input-binding) for general information about the Azure SQL Input binding.

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -6,7 +6,7 @@
   - [Table of Contents](#table-of-contents)
   - [Binding Model](#binding-model)
   - [Key differences with .NET (Isolated Process)](#key-differences-with-net-isolated-process)
-  - [Setup Function App](#setup-function-app)
+  - [Setup Function Project](#setup-function-project)
   - [Input Binding](#input-binding)
     - [SqlInputAttribute for Input Bindings](#sqlinputattribute-for-input-bindings)
     - [Setup for Input Bindings](#setup-for-input-bindings)
@@ -36,9 +36,9 @@ Please refer to the functions documentation [here](https://learn.microsoft.com/a
 - There's also no direct support for types inherited from underlying service SDKs, such as SqlCommand. Instead, bindings rely on strings, arrays, and serializable types, such as plain old class objects (POCOs).
 - For HTTP triggers, you must use HttpRequestData and HttpResponseData to access the request and response data. This is because you don't have access to the original HTTP request and response objects when running out-of-process.
 
-## Setup Function App
+## Setup Function Project
 
-These instructions will guide you through creating your Function App and adding the SQL binding worker. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding worker extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
@@ -52,7 +52,7 @@ These instructions will guide you through creating your Function App and adding 
 
 3. Enable SQL bindings isolated worker on the function app. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
 
-    Install the extension.
+    Add the SQL binding woker extension package to the project.
 
     ```powershell
     dotnet add package Microsoft.Azure.Functions.Worker.Extensions.Sql --prerelease

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -6,6 +6,7 @@
   - [Table of Contents](#table-of-contents)
   - [Binding Model](#binding-model)
   - [Key differences with .NET (Isolated Process)](#key-differences-with-net-isolated-process)
+  - [Setup Function App](#setup-function-app)
   - [Input Binding](#input-binding)
     - [SqlInputAttribute for Input Bindings](#sqlinputattribute-for-input-bindings)
     - [Setup for Input Bindings](#setup-for-input-bindings)

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -50,7 +50,7 @@ These instructions will guide you through creating your Function Project and add
     func init --worker-runtime dotnet-isolated
     ```
 
-3. Enable SQL bindings isolated worker on the function app. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
+3. Enable SQL bindings isolated worker on the function project. More information can be found in the [Guide for running C# Azure Functions in an isolated worker process](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
 
     Add the SQL binding worker extension package to the project.
 
@@ -85,7 +85,7 @@ The repo contains examples of each of these binding types [here](https://github.
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
+- Open your project that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> Company.namespace -> anonymous
 - In the file that opens, replace the `public static async Task<IActionResult> Run` block with the below code.

--- a/docs/SetupGuide_Java.md
+++ b/docs/SetupGuide_Java.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 - [Azure SQL bindings for Azure Functions - Java](#azure-sql-bindings-for-azure-functions---java)
   - [Table of Contents](#table-of-contents)
-  - [Setup Function App](#setup-function-app)
+  - [Setup Function Project](#setup-function-project)
   - [Input Binding](#input-binding)
     - [SQLInput Attribute](#sqlinput-attribute)
     - [Setup for Input Bindings](#setup-for-input-bindings)
@@ -21,9 +21,9 @@
   - [Trigger Binding](#trigger-binding)
   - [Known Issues](#known-issues)
 
-## Setup Function App
+## Setup Function Project
 
-These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function project you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
@@ -35,7 +35,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime java
     ```
 
-3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function project. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
 
@@ -78,7 +78,7 @@ When you're developing locally, add your application settings in the local.setti
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your app that you created in [Setup Function App](#setup-function-app) in VS Code
+- Open your app that you created in [Setup Function Project](#setup-function-project) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a package name) -> (Provide a function name) -> anonymous
 - In the file that opens, replace the `public HttpResponseMessage run` block with the below code.

--- a/docs/SetupGuide_Java.md
+++ b/docs/SetupGuide_Java.md
@@ -27,7 +27,7 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for Java:
+2. Create a Function Project for Java:
 
     ```bash
     mkdir MyApp

--- a/docs/SetupGuide_Javascript.md
+++ b/docs/SetupGuide_Javascript.md
@@ -29,7 +29,7 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for Javascript:
+2. Create a Function Project for Javascript:
 
     ```bash
     mkdir MyApp
@@ -70,7 +70,7 @@ The following table explains the binding configuration properties that you set i
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
+- Open your project that you created in [Create a Function Project](./GeneralSetup.md#create-a-function-project) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> anonymous
 - In the file that opens (`index.js`), replace the `module.exports = async function (context, req)` block with the below code.

--- a/docs/SetupGuide_Javascript.md
+++ b/docs/SetupGuide_Javascript.md
@@ -4,7 +4,7 @@
 
 - [Azure SQL bindings for Azure Functions - Javascript](#azure-sql-bindings-for-azure-functions---javascript)
   - [Table of Contents](#table-of-contents)
-  - [Setup Function App](#setup-function-app)
+  - [Setup Function Project](#setup-function-project)
   - [Input Binding](#input-binding)
     - [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings)
     - [Setup for Input Bindings](#setup-for-input-bindings)
@@ -23,9 +23,9 @@
       - [Single Row](#single-row)
   - [Trigger Binding](#trigger-binding)
 
-## Setup Function App
+## Setup Function Project
 
-These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function project you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
@@ -37,7 +37,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime node --language javascript
     ```
 
-3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function project. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
 

--- a/docs/SetupGuide_PowerShell.md
+++ b/docs/SetupGuide_PowerShell.md
@@ -4,7 +4,7 @@
 
 - [Azure SQL bindings for Azure Functions - PowerShell](#azure-sql-bindings-for-azure-functions---powershell)
   - [Table of Contents](#table-of-contents)
-  - [Setup Function App](#setup-function-app)
+  - [Setup Function Project](#setup-function-project)
   - [Input Binding](#input-binding)
     - [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings)
     - [Setup for Input Bindings](#setup-for-input-bindings)
@@ -22,9 +22,9 @@
       - [Single Row](#single-row)
   - [Trigger Binding](#trigger-binding)
 
-## Setup Function App
+## Setup Function Project
 
-These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function project you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
@@ -36,7 +36,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime powershell
     ```
 
-3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function project. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
 

--- a/docs/SetupGuide_PowerShell.md
+++ b/docs/SetupGuide_PowerShell.md
@@ -28,7 +28,7 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for PowerShell:
+2. Create a Function Project for PowerShell:
 
     ```bash
     mkdir MyApp
@@ -69,7 +69,7 @@ The following table explains the binding configuration properties that you set i
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
+- Open your project that you created in [Create a Function Project](./GeneralSetup.md#create-a-function-project) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> anonymous
 - In the file that opens (`run.ps1`), replace the code within the file the below code.

--- a/docs/SetupGuide_Python.md
+++ b/docs/SetupGuide_Python.md
@@ -4,7 +4,7 @@
 
 - [Azure SQL bindings for Azure Functions - Python](#azure-sql-bindings-for-azure-functions---python)
   - [Table of Contents](#table-of-contents)
-  - [Setup Function App](#setup-function-app)
+  - [Setup Function Project](#setup-function-project)
   - [Input Binding](#input-binding)
     - [function.json Properties for Input Bindings](#functionjson-properties-for-input-bindings)
     - [Setup for Input Bindings](#setup-for-input-bindings)
@@ -23,9 +23,9 @@
       - [Single Row](#single-row)
   - [Trigger Binding](#trigger-binding)
 
-## Setup Function App
+## Setup Function Project
 
-These instructions will guide you through creating your Function App and adding the SQL binding extension. This only needs to be done once for every function app you create. If you have one created already you can skip this step.
+These instructions will guide you through creating your Function Project and adding the SQL binding extension. This only needs to be done once for every function project you create. If you have one created already you can skip this step.
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
@@ -38,7 +38,7 @@ These instructions will guide you through creating your Function App and adding 
     func init --worker-runtime python
     ```
 
-3. Enable SQL bindings on the function app. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
+3. Enable SQL bindings on the function project. More information can be found in the [Azure SQL bindings for Azure Functions docs](https://aka.ms/sqlbindings).
 
     Update the `host.json` file to the preview extension bundle.
 

--- a/docs/SetupGuide_Python.md
+++ b/docs/SetupGuide_Python.md
@@ -29,7 +29,7 @@ These instructions will guide you through creating your Function App and adding 
 
 1. Install [Azure Functions Core Tools](https://docs.microsoft.com/azure/azure-functions/functions-run-local)
 
-2. Create a function app for Python:
+2. Create a Function Project for Python:
     *See [#250](https://github.com/Azure/azure-functions-sql-extension/issues/250) before starting.*
 
     ```bash
@@ -69,7 +69,7 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 Note: This tutorial requires that a SQL database is setup as shown in [Create a SQL Server](./GeneralSetup.md#create-a-sql-server).
 
-- Open your app that you created in [Create a Function App](./GeneralSetup.md#create-a-function-app) in VS Code
+- Open your project that you created in [Create a Function Project](./GeneralSetup.md#create-a-function-project) in VS Code
 - Press 'F1' and search for 'Azure Functions: Create Function'
 - Choose HttpTrigger -> (Provide a function name) -> anonymous
 - In the file that opens (`__init__.py`), replace the generated function with the following


### PR DESCRIPTION
Updated all the docs to replace "function app" to "function project" and added "setup function project" section to OOP doc.