### PR TITLE
Remove pinned python library version in python sample

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -128,6 +128,11 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
   displayName: Lint samples-python
 
+- script: |
+    pip3 install -r requirements.txt
+  workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
+  displayName: Install samples-python dependencies
+
 - task: Maven@3
   displayName: Build Java Samples
   inputs:

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -128,11 +128,6 @@ steps:
   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
   displayName: Lint samples-python
 
-- script: |
-    pip3 install -r requirements.txt
-  workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
-  displayName: Install azure-functions-1.11.3b1
-
 - task: Maven@3
   displayName: Build Java Samples
   inputs:

--- a/docs/GeneralSetup.md
+++ b/docs/GeneralSetup.md
@@ -130,12 +130,6 @@ These steps can be done in the Terminal/CLI or with PowerShell.
     }
     ```
 
-    Add a preview version of the Python functions library to `requirements.txt`.
-
-    ```txt
-    azure-functions==1.11.3b1
-    ```
-
     Add a setting in `local.settings.json` to isolate the worker dependencies.
 
     ```json

--- a/samples/samples-python/requirements.txt
+++ b/samples/samples-python/requirements.txt
@@ -1,3 +1,3 @@
 # Do not include azure-functions-worker as it may conflict with the Azure Functions platform
 
-azure-functions==1.11.3b1
+azure-functions


### PR DESCRIPTION
The pinned version is no longer needed since the latest azure-functions library contains sql. 

Once a new core tools version is out we will be able to remove the "PYTHON_ISOLATE_WORKER_DEPENDENCIES" flag from local.settings.json. Updated this [issue](https://github.com/Azure/azure-functions-sql-extension/issues/495) to track this.