### PR TITLE
Make attribute properties readonly + cleanup

### DIFF
--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
 using Microsoft.Azure.Functions.Worker.Extensions.Abstractions;
 
 namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
@@ -13,10 +14,14 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// </summary>
         /// <param name="commandTextOrProcedureName">Either a SQL query or stored procedure that will be run in the target database.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        public SqlInputAttribute(string commandTextOrProcedureName, string connectionStringSetting)
+        /// <param name="commandType">Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
+        /// <param name="parameters">Optional - Specifies the parameters that will be used to execute the SQL query or stored procedure. See <see cref="Parameters"/> for more details.</param>
+        public SqlInputAttribute(string commandTextOrProcedureName, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
         {
             this.CommandTextOrProcedureName = commandTextOrProcedureName ?? throw new ArgumentNullException(nameof(commandTextOrProcedureName));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
+            this.CommandType = commandType;
+            this.Parameters = parameters;
         }
 
         /// <summary>
@@ -40,7 +45,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter.
         /// Defaults to <see cref="CommandType.Text"/>.
         /// </summary>
-        public System.Data.CommandType CommandType { get; set; } = System.Data.CommandType.Text;
+        public CommandType CommandType { get; }
 
         /// <summary>
         /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandTextOrProcedureName"/>.
@@ -51,6 +56,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// as in "@param1=,@param2=param2"
         /// Note that neither the parameter name nor the parameter value can have ',' or '='
         /// </summary>
-        public string Parameters { get; set; }
+        public string Parameters { get; }
     }
 }

--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -12,17 +12,24 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// <summary>
         /// Creates an instance of the <see cref="SqlInputAttribute"/>, which takes a SQL query or stored procedure to run and returns the output to the function.
         /// </summary>
-        /// <param name="commandTextOrProcedureName">Either a SQL query or stored procedure that will be run in the target database.</param>
+        /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
         /// <param name="commandType">Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
         /// <param name="parameters">Optional - Specifies the parameters that will be used to execute the SQL query or stored procedure. See <see cref="Parameters"/> for more details.</param>
-        public SqlInputAttribute(string commandTextOrProcedureName, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
+        public SqlInputAttribute(string commandText, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
         {
-            this.CommandTextOrProcedureName = commandTextOrProcedureName ?? throw new ArgumentNullException(nameof(commandTextOrProcedureName));
+            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
             this.CommandType = commandType;
             this.Parameters = parameters;
         }
+
+        /// <summary>
+        /// Creates an instance of the <see cref="SqlInputAttribute"/>, which takes a SQL query or stored procedure to run and returns the output to the function.
+        /// </summary>
+        /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
+        /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
+        public SqlInputAttribute(string commandText, string connectionStringSetting) : this(commandText, connectionStringSetting, CommandType.Text, null) { }
 
         /// <summary>
         /// The name of the app setting where the SQL connection string is stored
@@ -38,17 +45,17 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// <summary>
         /// Either a SQL query or stored procedure that will be run in the target database.
         /// </summary>
-        public string CommandTextOrProcedureName { get; }
+        public string CommandText { get; }
 
         /// <summary>
-        /// Specifies whether <see cref="CommandTextOrProcedureName"/> refers to a stored procedure or SQL query string.
+        /// Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string.
         /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter.
         /// Defaults to <see cref="CommandType.Text"/>.
         /// </summary>
         public CommandType CommandType { get; }
 
         /// <summary>
-        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandTextOrProcedureName"/>.
+        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandText"/>.
         /// Must follow the format "@param1=param1,@param2=param2". For example, if your SQL query looks like
         /// "select * from Products where cost = @Cost and name = @Name", then Parameters must have the form "@Cost=100,@Name={Name}"
         /// If the value of a parameter should be null, use "null", as in @param1=null,@param2=param2".

--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// </summary>
         /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        /// <param name="commandType">Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
+        /// <param name="commandType">Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
         /// <param name="parameters">Optional - Specifies the parameters that will be used to execute the SQL query or stored procedure. See <see cref="Parameters"/> for more details.</param>
         public SqlInputAttribute(string commandText, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
         {

--- a/Worker.Extensions.Sql/src/SqlInputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlInputAttribute.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// <summary>
         /// Creates an instance of the <see cref="SqlInputAttribute"/>, which takes a SQL query or stored procedure to run and returns the output to the function.
         /// </summary>
-        /// <param name="commandText">Either a SQL query or stored procedure that will be run in the target database.</param>
+        /// <param name="commandTextOrProcedureName">Either a SQL query or stored procedure that will be run in the target database.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        public SqlInputAttribute(string commandText, string connectionStringSetting)
+        public SqlInputAttribute(string commandTextOrProcedureName, string connectionStringSetting)
         {
-            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+            this.CommandTextOrProcedureName = commandTextOrProcedureName ?? throw new ArgumentNullException(nameof(commandTextOrProcedureName));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
@@ -28,21 +28,22 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// create a ConnectionStringSetting with a name like SqlServerAuthentication. The value of the SqlServerAuthentication app setting
         /// would look like "Data Source=test.database.windows.net;Database=TestDB;User ID={userid};Password={password}".
         /// </summary>
-        public string ConnectionStringSetting { get; set; }
+        public string ConnectionStringSetting { get; }
 
         /// <summary>
         /// Either a SQL query or stored procedure that will be run in the target database.
         /// </summary>
-        public string CommandText { get; set; }
+        public string CommandTextOrProcedureName { get; }
 
         /// <summary>
-        /// Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string.
-        /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter
+        /// Specifies whether <see cref="CommandTextOrProcedureName"/> refers to a stored procedure or SQL query string.
+        /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter.
+        /// Defaults to <see cref="CommandType.Text"/>.
         /// </summary>
         public System.Data.CommandType CommandType { get; set; } = System.Data.CommandType.Text;
 
         /// <summary>
-        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandText"/>.
+        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandTextOrProcedureName"/>.
         /// Must follow the format "@param1=param1,@param2=param2". For example, if your SQL query looks like
         /// "select * from Products where cost = @Cost and name = @Name", then Parameters must have the form "@Cost=100,@Name={Name}"
         /// If the value of a parameter should be null, use "null", as in @param1=null,@param2=param2".

--- a/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// <summary>
         /// Creates an instance of the <see cref="SqlOutputAttribute"/>, which takes a list of rows and upserts them into the target table.
         /// </summary>
-        /// <param name="tableName">The table name to upsert the values to.</param>
+        /// <param name="commandText">The table name to upsert the values to.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        public SqlOutputAttribute(string tableName, string connectionStringSetting)
+        public SqlOutputAttribute(string commandText, string connectionStringSetting)
         {
-            this.TableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
+            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
@@ -33,6 +33,6 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// <summary>
         /// The table name to upsert the values to.
         /// </summary>
-        public string TableName { get; }
+        public string CommandText { get; }
     }
 }

--- a/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
+++ b/Worker.Extensions.Sql/src/SqlOutputAttribute.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// <summary>
         /// Creates an instance of the <see cref="SqlOutputAttribute"/>, which takes a list of rows and upserts them into the target table.
         /// </summary>
-        /// <param name="commandText">The table name to upsert the values to.</param>
+        /// <param name="tableName">The table name to upsert the values to.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        public SqlOutputAttribute(string commandText, string connectionStringSetting)
+        public SqlOutputAttribute(string tableName, string connectionStringSetting)
         {
-            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+            this.TableName = tableName ?? throw new ArgumentNullException(nameof(tableName));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
@@ -28,16 +28,11 @@ namespace Microsoft.Azure.Functions.Worker.Extensions.Sql
         /// create a ConnectionStringSetting with a name like SqlServerAuthentication. The value of the SqlServerAuthentication app setting
         /// would look like "Data Source=test.database.windows.net;Database=TestDB;User ID={userid};Password={password}".
         /// </summary>
-        public string ConnectionStringSetting { get; set; }
+        public string ConnectionStringSetting { get; }
 
         /// <summary>
         /// The table name to upsert the values to.
         /// </summary>
-        public string CommandText { get; set; }
-
-        /// <summary>
-        /// Specifies <see cref="CommandText"/> as Text.
-        /// </summary>
-        public System.Data.CommandType CommandType { get; } = System.Data.CommandType.Text;
+        public string TableName { get; }
     }
 }

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -83,8 +83,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "employees")] HttpRequest req,
         ILogger log,
         [Sql("select * from Employees",
-        "SqlConnectionString"
-        CommandType = System.Data.CommandType.Text)]
+        "SqlConnectionString")]
         IEnumerable<Employee> employee)
     {
         return new OkObjectResult(employee);
@@ -130,8 +129,7 @@ The input binding executes the `select * from Products where Cost = @Cost` query
       HttpRequest req,
       [Sql("select * from Products where Cost = @Cost",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost}")]
+          parameters: "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -169,8 +167,7 @@ In this case, the parameter value of the `@Name` parameter is an empty string.
       HttpRequest req,
       [Sql("select * from Products where Cost = @Cost and Name = @Name",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost},@Name=")]
+          parameters: "@Cost={cost},@Name=")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -188,8 +185,7 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       HttpRequest req,
       [Sql("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.Text,
-          Parameters = "@Name={name}")]
+          parameters: "@Name={name}")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -207,8 +203,8 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       HttpRequest req,
       [Sql("SelectProductsCost",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.StoredProcedure,
-          Parameters = "@Cost={cost}")]
+          System.Data.CommandType.StoredProcedure,
+          "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return (ActionResult)new OkObjectResult(products);
@@ -225,8 +221,7 @@ public static async Task<IActionResult> Run(
      HttpRequest req,
     [Sql("select * from Products where cost = @Cost",
          "SqlConnectionString",
-         CommandType = System.Data.CommandType.Text,
-         Parameters = "@Cost={cost}")]
+         parameters: "@Cost={cost}")]
      IAsyncEnumerable<Product> products)
 {
     var enumerator = products.GetAsyncEnumerator();

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -55,8 +55,8 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Input bindings takes four arguments:
 
-- **CommandTextOrTarget**: Passed as a constructor argument to the binding attribute. Represents either a query string or the name of a stored procedure based on the value of the CommandType.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **CommandTextOrTarget**: Represents either a query string or the name of a stored procedure based on the value of the CommandType.
+- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 - **CommandType**: Specifies whether CommandTextOrTarget is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Defaults to `CommandType.Text`.
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
 
@@ -243,8 +243,8 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Output bindings takes two arguments:
 
-- **CommandTextOrTarget**: Passed as a constructor argument to the binding attribute. Represents the name of the table into which rows will be upserted.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **CommandTextOrTarget**: Represents the name of the table into which rows will be upserted.
+- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:
 
@@ -403,8 +403,8 @@ See [Trigger Binding Overview](./BindingsOverview.md#trigger-binding) for genera
 
 The SqlAttribute for Trigger bindings takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)
 
-- **TableName**: Passed as a constructor argument to the binding attribute. Represents the name of the table to be monitored for changes.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **TableName**: Represents the name of the table to be monitored for changes.
+- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The trigger binding can bind to type `IReadOnlyList<SqlChange<T>>`:
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -55,9 +55,9 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Input bindings takes four arguments:
 
-- **CommandText**: Passed as a constructor argument to the binding. Represents either a query string or the name of a stored procedure.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
-- **CommandType**: Specifies whether CommandText is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`)
+- **CommandTextOrTarget**: Passed as a constructor argument to the binding attribute. Represents either a query string or the name of a stored procedure based on the value of the CommandType.
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **CommandType**: Specifies whether CommandTextOrTarget is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Defaults to `CommandType.Text`.
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
 
 The following are valid binding types for the result of the query/stored procedure execution:
@@ -248,8 +248,8 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Output bindings takes two arguments:
 
-- **CommandText**: Passed as a constructor argument to the binding. Represents the name of the table into which rows will be upserted.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **CommandTextOrTarget**: Passed as a constructor argument to the binding attribute. Represents the name of the table into which rows will be upserted.
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:
 
@@ -408,8 +408,8 @@ See [Trigger Binding Overview](./BindingsOverview.md#trigger-binding) for genera
 
 The SqlAttribute for Trigger bindings takes two [arguments](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/TriggerBinding/SqlTriggerAttribute.cs)
 
-- **TableName**: Passed as a constructor argument to the binding. Represents the name of the table to be monitored for changes.
-- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **TableName**: Passed as a constructor argument to the binding attribute. Represents the name of the table to be monitored for changes.
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The trigger binding can bind to type `IReadOnlyList<SqlChange<T>>`:
 

--- a/docs/SetupGuide_Dotnet.md
+++ b/docs/SetupGuide_Dotnet.md
@@ -55,9 +55,9 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Input bindings takes four arguments:
 
-- **CommandTextOrTarget**: Represents either a query string or the name of a stored procedure based on the value of the CommandType.
+- **CommandText**: Represents either a query string or the name of a stored procedure based on the value of the CommandType.
 - **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
-- **CommandType**: Specifies whether CommandTextOrTarget is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Defaults to `CommandType.Text`.
+- **CommandType**: Specifies whether CommandText is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Defaults to `CommandType.Text`.
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
 
 The following are valid binding types for the result of the query/stored procedure execution:
@@ -243,7 +243,7 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 
 The [SqlAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/SqlAttribute.cs) for Output bindings takes two arguments:
 
-- **CommandTextOrTarget**: Represents the name of the table into which rows will be upserted.
+- **CommandText**: Represents the name of the table into which rows will be upserted.
 - **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -66,10 +66,10 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 The [SqlInputAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/SqlInputAttribute.cs) takes four arguments:
 
-- **CommandText**: Passed as a constructor argument to the binding. Represents either a query string or the name of a stored procedure.
-- **CommandType**: Specifies whether CommandText is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`)
+- **CommandTextOrProcedureName**: Passed as a constructor argument to the binding attribute. Represents either a query string or the name of a stored procedure.
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **CommandType**: Specifies whether CommandTextOrProcedureName is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Default is `Text`
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
-- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the result of the query/stored procedure execution:
 
@@ -104,7 +104,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
     }
     ```
 
-    *In the above, `select * from Employees` is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [SqlInputAttribute for Input Bindings](#sqlinputattribute-for-input-bindings) section*
+    *In the above sample, `select * from Employees` is the SQL script run by the input binding. The CommandType on the line below specifies whether the first line is a query or a stored procedure. On the next line, the ConnectionStringSetting parameter specifies that the app setting that contains the SQL connection string used to connect to the database is "SqlConnectionString." For more information on this, see the [SqlInputAttribute for Input Bindings](#sqlinputattribute-for-input-bindings) section*
 - Add 'using Microsoft.Azure.Functions.Worker.Extensions.Sql;' for using *SqlInput*, the out of proc sql input binding.
 - Add 'using System.Collections.Generic;' to the namespaces list at the top of the page.
 - Currently, there is an error for the IEnumerable. We'll fix this by creating an Employee class.
@@ -262,8 +262,8 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 
 The [SqlOutputAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/SqlOutputAttribute.cs) takes two arguments:
 
-- **CommandText**: Passed as a constructor argument to the binding. Represents the name of the table into which rows will be upserted.
-- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **TableName**: Passed as a constructor argument to the binding attribute. Represents the name of the table into which rows will be upserted.
+- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:
 

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -66,8 +66,8 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 The [SqlInputAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/SqlInputAttribute.cs) takes four arguments:
 
-- **CommandTextOrProcedureName**: Passed as a constructor argument to the binding attribute. Represents either a query string or the name of a stored procedure.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **CommandTextOrProcedureName**: Represents either a query string or the name of a stored procedure.
+- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 - **CommandType**: Specifies whether CommandTextOrProcedureName is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Default is `Text`
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
 
@@ -257,8 +257,8 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 
 The [SqlOutputAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/SqlOutputAttribute.cs) takes two arguments:
 
-- **TableName**: Passed as a constructor argument to the binding attribute. Represents the name of the table into which rows will be upserted.
-- **ConnectionStringSetting**: Passed as a constructor argument to the binding attribute. Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
+- **TableName**: Represents the name of the table into which rows will be upserted.
+- **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:
 

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -66,9 +66,9 @@ See [Input Binding Overview](./BindingsOverview.md#input-binding) for general in
 
 The [SqlInputAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/SqlInputAttribute.cs) takes four arguments:
 
-- **CommandTextOrProcedureName**: Represents either a query string or the name of a stored procedure.
+- **CommandText**: Represents either a query string or the name of a stored procedure.
 - **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
-- **CommandType**: Specifies whether CommandTextOrProcedureName is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Default is `Text`
+- **CommandType**: Specifies whether CommandText is a query (`System.Data.CommandType.Text`) or a stored procedure (`System.Data.CommandType.StoredProcedure`). Default is `Text`
 - **Parameters**: The parameters to the query/stored procedure. This string must follow the format "@param1=param1,@param2=param2" where @param1 is the name of the parameter and param1 is the parameter value. Each pair of parameter name, parameter value is separated by a comma. Within each pair, the parameter name and value is separated by an equals sign. This means that neither the parameter name nor value can contain "," or "=". To specify a `NULL` parameter value, do "@param1=null,@param2=param2". To specify an empty string as a value, do "@param1=,@param2=param2", i.e. do not put any text after the equals sign of the corresponding parameter name. This argument is auto-resolvable (see Query String examples).
 
 The following are valid binding types for the result of the query/stored procedure execution:
@@ -257,7 +257,7 @@ See [Output Binding Overview](./BindingsOverview.md#output-binding) for general 
 
 The [SqlOutputAttribute](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/SqlOutputAttribute.cs) takes two arguments:
 
-- **TableName**: Represents the name of the table into which rows will be upserted.
+- **CommandText**: Represents the name of the table into which rows will be upserted.
 - **ConnectionStringSetting**: Specifies the name of the app setting that contains the SQL connection string used to connect to a database. The connection string must follow the format specified [here](https://docs.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlconnection.connectionstring?view=sqlclient-dotnet-core-2.0).
 
 The following are valid binding types for the rows to be upserted into the table:

--- a/docs/SetupGuide_DotnetOutOfProc.md
+++ b/docs/SetupGuide_DotnetOutOfProc.md
@@ -96,8 +96,7 @@ Note: This tutorial requires that a SQL database is setup as shown in [Create a 
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "employees")] HttpRequest req,
         ILogger log,
         [SqlInput("select * from Employees",
-        "SqlConnectionString",
-        CommandType = System.Data.CommandType.Text)]
+        "SqlConnectionString")]
         IEnumerable<Employee> employees)
     {
         return employees;
@@ -143,8 +142,7 @@ The input binding executes the `select * from Products where Cost = @Cost` query
       HttpRequestData req,
       [SqlInput("select * from Products where Cost = @Cost",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost}")]
+          parameters: "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return products;
@@ -182,8 +180,7 @@ In this case, the parameter value of the `@Name` parameter is an empty string.
       HttpRequestData req,
       [SqlInput("select * from Products where Cost = @Cost and Name = @Name",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.Text,
-          Parameters = "@Cost={cost},@Name=")]
+          parameters: "@Cost={cost},@Name=")]
       IEnumerable<Product> products)
   {
       return products;
@@ -201,8 +198,7 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       HttpRequestData req,
       [SqlInput("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.Text,
-          Parameters = "@Name={name}")]
+          parameters: "@Name={name}")]
       IEnumerable<Product> products)
   {
       return products;
@@ -220,8 +216,8 @@ If the `{name}` specified in the `getproducts-namenull/{name}` URL is "null", th
       HttpRequestData req,
       [SqlInput("SelectProductsCost",
           "SqlConnectionString",
-          CommandType = System.Data.CommandType.StoredProcedure,
-          Parameters = "@Cost={cost}")]
+          System.Data.CommandType.StoredProcedure,
+          "@Cost={cost}")]
       IEnumerable<Product> products)
   {
       return products;
@@ -239,8 +235,7 @@ public static async Task<List<Product>> Run(
      HttpRequestData req,
     [SqlInput("select * from Products where cost = @Cost",
          "SqlConnectionString",
-         CommandType = System.Data.CommandType.Text,
-         Parameters = "@Cost={cost}")]
+         parameters: "@Cost={cost}")]
      IAsyncEnumerable<Product> products)
 {
     var enumerator = products.GetAsyncEnumerator();

--- a/samples/samples-csharp/InputBindingSamples/GetProductNamesView.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductNamesView.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproduct-namesview/")]
             HttpRequest req,
             [Sql("SELECT * FROM ProductNames",
-                "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text)]
+                "SqlConnectionString")]
             IEnumerable<ProductName> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProducts.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProducts.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("select * from Products where Cost = @Cost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsAsyncEnumerable.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsAsyncEnumerable.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("select * from Products where cost = @Cost",
                 "SqlConnectionString",
-                 CommandType = System.Data.CommandType.Text,
-                 Parameters = "@Cost={cost}")]
+                 parameters: "@Cost={cost}")]
              IAsyncEnumerable<Product> products)
         {
             IAsyncEnumerator<Product> enumerator = products.GetAsyncEnumerator();

--- a/samples/samples-csharp/InputBindingSamples/GetProductsNameEmpty.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsNameEmpty.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("select * from Products where Cost = @Cost and Name = @Name",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost},@Name=")]
+                parameters: "@Cost={cost},@Name=")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsNameNull.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsNameNull.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Name={name}")]
+                parameters: "@Name={name}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsSqlCommand.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsSqlCommand.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("select * from Products where cost = @Cost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             SqlCommand command)
         {
             string result = string.Empty;

--- a/samples/samples-csharp/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("%Sp_SelectCost%",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost=%ProductCost%")]
+                commandType: System.Data.CommandType.StoredProcedure,
+                parameters: "@Cost=%ProductCost%")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsStoredProcedure.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsStoredProcedure.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("SelectProductsCost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost={cost}")]
+                commandType: System.Data.CommandType.StoredProcedure,
+                parameters: "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/InputBindingSamples/GetProductsString.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsString.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("select * from Products where cost = @Cost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             string products)
         {
             // Products is a JSON representation of the returned rows. For example, if there are two returned rows,

--- a/samples/samples-csharp/InputBindingSamples/GetProductsTopN.cs
+++ b/samples/samples-csharp/InputBindingSamples/GetProductsTopN.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             HttpRequest req,
             [Sql("SELECT TOP(CAST(@Count AS INT)) * FROM Products",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Count={count}")]
+                parameters: "@Count={count}")]
             IEnumerable<Product> products)
         {
             return new OkObjectResult(products);

--- a/samples/samples-csharp/MultipleBindingsSamples/GetAndAddProducts.cs
+++ b/samples/samples-csharp/MultipleBindingsSamples/GetAndAddProducts.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.MultipleBindingsSamples
             HttpRequest req,
             [Sql("SELECT * FROM Products",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             IEnumerable<Product> products,
             [Sql("ProductsWithIdentity",
                 "SqlConnectionString")]

--- a/samples/samples-outofproc/InputBindingSamples/GetProductNamesView.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductNamesView.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproduct-namesview/")]
             HttpRequestData req,
             [SqlInput("SELECT * FROM ProductNames",
-                "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text)]
+                "SqlConnectionString")]
             IEnumerable<ProductName> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProducts.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProducts.cs
@@ -19,8 +19,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("select * from Products where Cost = @Cost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsAsyncEnumerable.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsAsyncEnumerable.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("select * from Products where cost = @Cost",
                 "SqlConnectionString",
-                 CommandType = System.Data.CommandType.Text,
-                 Parameters = "@Cost={cost}")]
+                 parameters: "@Cost={cost}")]
              IAsyncEnumerable<Product> products)
         {
             IAsyncEnumerator<Product> enumerator = products.GetAsyncEnumerator();

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsNameEmpty.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsNameEmpty.cs
@@ -18,8 +18,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("select * from Products where Cost = @Cost and Name = @Name",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost},@Name=")]
+                parameters: "@Cost={cost},@Name=")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsNameNull.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsNameNull.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("if @Name is null select * from Products where Name is null else select * from Products where @Name = name",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Name={name}")]
+                parameters: "@Name={name}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsStoreProcedureFromAppSetting.cs
@@ -21,8 +21,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("%Sp_SelectCost%",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost=%ProductCost%")]
+                System.Data.CommandType.StoredProcedure,
+                "@Cost=%ProductCost%")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsStoredProcedure.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsStoredProcedure.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("SelectProductsCost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.StoredProcedure,
-                Parameters = "@Cost={cost}")]
+                System.Data.CommandType.StoredProcedure,
+                "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsString.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsString.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("select * from Products where cost = @Cost",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             string products)
         {
             // Products is a JSON representation of the returned rows. For example, if there are two returned rows,

--- a/samples/samples-outofproc/InputBindingSamples/GetProductsTopN.cs
+++ b/samples/samples-outofproc/InputBindingSamples/GetProductsTopN.cs
@@ -17,8 +17,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.InputBindingSa
             HttpRequestData req,
             [SqlInput("SELECT TOP(CAST(@Count AS INT)) * FROM Products",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Count={count}")]
+                parameters: "@Count={count}")]
             IEnumerable<Product> products)
         {
             return products;

--- a/samples/samples-outofproc/MultipleBindingsSamples/GetAndAddProducts.cs
+++ b/samples/samples-outofproc/MultipleBindingsSamples/GetAndAddProducts.cs
@@ -23,8 +23,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.MultipleBindin
             HttpRequestData req,
             [SqlInput("SELECT * FROM Products",
                 "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text,
-                Parameters = "@Cost={cost}")]
+                parameters: "@Cost={cost}")]
             IEnumerable<Product> products)
         {
             return products.ToArray();

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 this._serverProperties = await GetServerTelemetryProperties(connection, this._logger, CancellationToken.None);
                 Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps(this._serverProperties);
 
-                string fullTableName = attribute.CommandTextOrTarget;
+                string fullTableName = attribute.CommandText;
 
                 // Include the connection string hash as part of the key in case this customer has the same table in two different Sql Servers
                 string cacheKey = $"{connection.ConnectionString.GetHashCode()}-{fullTableName}";

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 this._serverProperties = await GetServerTelemetryProperties(connection, this._logger, CancellationToken.None);
                 Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps(this._serverProperties);
 
-                string fullTableName = attribute.CommandText;
+                string fullTableName = attribute.CommandTextOrTarget;
 
                 // Include the connection string hash as part of the key in case this customer has the same table in two different Sql Servers
                 string cacheKey = $"{connection.ConnectionString.GetHashCode()}-{fullTableName}";

--- a/src/SqlAttribute.cs
+++ b/src/SqlAttribute.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlAttribute/>"/> class.
         /// </summary>
-        /// <param name="commandText">For an input binding, either a SQL query or stored procedure that will be run in the target database. For an output binding, the table name to upsert the values to.</param>
+        /// <param name="commandTextOrTarget">For an input binding, either a SQL query or stored procedure that will be run in the database. For an output binding, the table name to upsert the values to.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        public SqlAttribute(string commandText, string connectionStringSetting)
+        public SqlAttribute(string commandTextOrTarget, string connectionStringSetting)
         {
-            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
+            this.CommandTextOrTarget = commandTextOrTarget ?? throw new ArgumentNullException(nameof(commandTextOrTarget));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
         }
 
@@ -36,23 +36,24 @@ namespace Microsoft.Azure.WebJobs
         /// create a ConnectionStringSetting with a name like SqlServerAuthentication. The value of the SqlServerAuthentication app setting
         /// would look like "Data Source=test.database.windows.net;Database=TestDB;User ID={userid};Password={password}".
         /// </summary>
-        public string ConnectionStringSetting { get; set; }
+        public string ConnectionStringSetting { get; }
 
         /// <summary>
         /// For an input binding, either a SQL query or stored procedure that will be run in the target database.
         /// For an output binding, the table name to upsert the values to.
         /// </summary>
         [AutoResolve]
-        public string CommandText { get; }
+        public string CommandTextOrTarget { get; }
 
         /// <summary>
-        /// Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string.
-        /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter
+        /// Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string.
+        /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter.
+        /// Defaults to <see cref="CommandType.Text"/>
         /// </summary>
         public CommandType CommandType { get; set; } = CommandType.Text;
 
         /// <summary>
-        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandText"/>.
+        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandTextOrTarget"/>.
         /// Must follow the format "@param1=param1,@param2=param2". For example, if your SQL query looks like
         /// "select * from Products where cost = @Cost and name = @Name", then Parameters must have the form "@Cost=100,@Name={Name}"
         /// If the value of a parameter should be null, use "null", as in @param1=null,@param2=param2".

--- a/src/SqlAttribute.cs
+++ b/src/SqlAttribute.cs
@@ -19,17 +19,24 @@ namespace Microsoft.Azure.WebJobs
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlAttribute/>"/> class.
         /// </summary>
-        /// <param name="commandTextOrTarget">For an input binding, either a SQL query or stored procedure that will be run in the database. For an output binding, the table name to upsert the values to.</param>
+        /// <param name="commandText">For an input binding, either a SQL query or stored procedure that will be run in the database. For an output binding, the table name to upsert the values to.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        /// <param name="commandType">Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
+        /// <param name="commandType">Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
         /// <param name="parameters">Optional - Specifies the parameters that will be used to execute the SQL query or stored procedure. See <see cref="Parameters"/> for more details.</param>
-        public SqlAttribute(string commandTextOrTarget, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
+        public SqlAttribute(string commandText, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
         {
-            this.CommandTextOrTarget = commandTextOrTarget ?? throw new ArgumentNullException(nameof(commandTextOrTarget));
+            this.CommandText = commandText ?? throw new ArgumentNullException(nameof(commandText));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
             this.CommandType = commandType;
             this.Parameters = parameters;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqlAttribute/>"/> class with default values for the CommandType and Parameters.
+        /// </summary>
+        /// <param name="commandText">For an input binding, either a SQL query or stored procedure that will be run in the database. For an output binding, the table name to upsert the values to.</param>
+        /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
+        public SqlAttribute(string commandText, string connectionStringSetting) : this(commandText, connectionStringSetting, CommandType.Text, null) { }
 
         /// <summary>
         /// The name of the app setting where the SQL connection string is stored
@@ -47,17 +54,17 @@ namespace Microsoft.Azure.WebJobs
         /// For an output binding, the table name to upsert the values to.
         /// </summary>
         [AutoResolve]
-        public string CommandTextOrTarget { get; }
+        public string CommandText { get; }
 
         /// <summary>
-        /// Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string.
+        /// Specifies whether <see cref="CommandText"/> refers to a stored procedure or SQL query string.
         /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter.
         /// Defaults to <see cref="CommandType.Text"/>
         /// </summary>
         public CommandType CommandType { get; }
 
         /// <summary>
-        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandTextOrTarget"/>.
+        /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandText"/>.
         /// Must follow the format "@param1=param1,@param2=param2". For example, if your SQL query looks like
         /// "select * from Products where cost = @Cost and name = @Name", then Parameters must have the form "@Cost=100,@Name={Name}"
         /// If the value of a parameter should be null, use "null", as in @param1=null,@param2=param2".

--- a/src/SqlAttribute.cs
+++ b/src/SqlAttribute.cs
@@ -21,10 +21,14 @@ namespace Microsoft.Azure.WebJobs
         /// </summary>
         /// <param name="commandTextOrTarget">For an input binding, either a SQL query or stored procedure that will be run in the database. For an output binding, the table name to upsert the values to.</param>
         /// <param name="connectionStringSetting">The name of the app setting where the SQL connection string is stored</param>
-        public SqlAttribute(string commandTextOrTarget, string connectionStringSetting)
+        /// <param name="commandType">Specifies whether <see cref="CommandTextOrTarget"/> refers to a stored procedure or SQL query string. Defaults to <see cref="CommandType.Text"/></param>
+        /// <param name="parameters">Optional - Specifies the parameters that will be used to execute the SQL query or stored procedure. See <see cref="Parameters"/> for more details.</param>
+        public SqlAttribute(string commandTextOrTarget, string connectionStringSetting, CommandType commandType = CommandType.Text, string parameters = null)
         {
             this.CommandTextOrTarget = commandTextOrTarget ?? throw new ArgumentNullException(nameof(commandTextOrTarget));
             this.ConnectionStringSetting = connectionStringSetting ?? throw new ArgumentNullException(nameof(connectionStringSetting));
+            this.CommandType = commandType;
+            this.Parameters = parameters;
         }
 
         /// <summary>
@@ -50,7 +54,7 @@ namespace Microsoft.Azure.WebJobs
         /// Use <see cref="CommandType.StoredProcedure"/> for the former, <see cref="CommandType.Text"/> for the latter.
         /// Defaults to <see cref="CommandType.Text"/>
         /// </summary>
-        public CommandType CommandType { get; set; } = CommandType.Text;
+        public CommandType CommandType { get; }
 
         /// <summary>
         /// Specifies the parameters that will be used to execute the SQL query or stored procedure specified in <see cref="CommandTextOrTarget"/>.
@@ -62,6 +66,6 @@ namespace Microsoft.Azure.WebJobs
         /// Note that neither the parameter name nor the parameter value can have ',' or '='
         /// </summary>
         [AutoResolve]
-        public string Parameters { get; set; }
+        public string Parameters { get; }
     }
 }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             var command = new SqlCommand
             {
                 Connection = connection,
-                CommandText = attribute.CommandText
+                CommandText = attribute.CommandTextOrTarget
             };
             if (attribute.CommandType == CommandType.StoredProcedure)
             {

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             var command = new SqlCommand
             {
                 Connection = connection,
-                CommandText = attribute.CommandTextOrTarget
+                CommandText = attribute.CommandText
             };
             if (attribute.CommandType == CommandType.StoredProcedure)
             {

--- a/src/TriggerBinding/SqlTriggerAttribute.cs
+++ b/src/TriggerBinding/SqlTriggerAttribute.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs
         /// Name of the app setting containing the SQL connection string.
         /// </summary>
         [ConnectionString]
-        public string ConnectionStringSetting { get; set; }
+        public string ConnectionStringSetting { get; }
 
         /// <summary>
         /// Name of the table to watch for changes.

--- a/test-outofproc/GetProductColumnTypesSerialization.cs
+++ b/test-outofproc/GetProductColumnTypesSerialization.cs
@@ -20,8 +20,7 @@ namespace DotnetIsolatedTests
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserialization")]
             HttpRequest req,
             [SqlInput("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text)]
+                "SqlConnectionString")]
             IEnumerable<ProductColumnTypes> products)
         {
             return products;

--- a/test-outofproc/GetProductColumnTypesSerializationAsyncEnumerable.cs
+++ b/test-outofproc/GetProductColumnTypesSerializationAsyncEnumerable.cs
@@ -23,8 +23,7 @@ namespace DotnetIsolatedTests
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserializationasyncenumerable")]
             HttpRequestData req,
             [SqlInput("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text)]
+                "SqlConnectionString")]
             IAsyncEnumerable<ProductColumnTypes> products)
         {
             // Test different cultures to ensure that serialization/deserialization works correctly for all types.

--- a/test/Integration/test-csharp/GetProductColumnTypesSerialization.cs
+++ b/test/Integration/test-csharp/GetProductColumnTypesSerialization.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserialization")]
             HttpRequest req,
             [Sql("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text)]
+                "SqlConnectionString")]
             IEnumerable<ProductColumnTypes> products,
             ILogger log)
         {

--- a/test/Integration/test-csharp/GetProductColumnTypesSerializationAsyncEnumerable.cs
+++ b/test/Integration/test-csharp/GetProductColumnTypesSerializationAsyncEnumerable.cs
@@ -24,8 +24,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.InputBindingSamples
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "getproducts-columntypesserializationasyncenumerable")]
             HttpRequest req,
             [Sql("SELECT * FROM [dbo].[ProductsColumnTypes]",
-                "SqlConnectionString",
-                CommandType = System.Data.CommandType.Text)]
+                "SqlConnectionString")]
             IAsyncEnumerable<ProductColumnTypes> products,
             ILogger log)
         {

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -98,10 +98,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         public void TestInvalidCommandType()
         {
             // Specify an invalid type
-            var attribute = new SqlAttribute("", "SqlConnectionString")
-            {
-                CommandType = System.Data.CommandType.TableDirect
-            };
+            var attribute = new SqlAttribute("", "SqlConnectionString", System.Data.CommandType.TableDirect);
             Assert.Throws<ArgumentException>(() => SqlBindingUtilities.BuildCommand(attribute, null));
         }
 
@@ -121,19 +118,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         public void TestValidCommandType()
         {
             string query = "select * from Products";
-            var attribute = new SqlAttribute(query, "SqlConnectionString")
-            {
-                CommandType = System.Data.CommandType.Text
-            };
+            var attribute = new SqlAttribute(query, "SqlConnectionString", System.Data.CommandType.Text);
             SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, null);
             Assert.Equal(System.Data.CommandType.Text, command.CommandType);
             Assert.Equal(query, command.CommandText);
 
             string procedure = "StoredProcedure";
-            attribute = new SqlAttribute(procedure, "SqlConnectionString")
-            {
-                CommandType = System.Data.CommandType.StoredProcedure
-            };
+            attribute = new SqlAttribute(procedure, "SqlConnectionString", System.Data.CommandType.StoredProcedure);
             command = SqlBindingUtilities.BuildCommand(attribute, null);
             Assert.Equal(System.Data.CommandType.StoredProcedure, command.CommandType);
             Assert.Equal(procedure, command.CommandText);


### PR DESCRIPTION
Continuing cleanup of some stuff I noticed while updating the attributes before. Will help to make it easier to discover the properties we make available and avoid potential weird issues down the line. 

1. Made attribute properties readonly - there's no reason they should be updated outside of the constructor.
1. Move CommandType and Parameters into constructor as needed
1. Update/clarify docs