### PR TITLE
Fix the casting error and EngineEdition error

### DIFF
--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -311,8 +311,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         if (await reader.ReadAsync(cancellationToken))
                         {
-                            int engineEdition = reader.GetByte(0);
-                            var serverProperties = new ServerProperties() { Edition = reader.GetString(1) };
+                            int engineEdition = (int)reader.GetValue(0);
+                            var serverProperties = new ServerProperties() { Edition = reader.GetValue(1).ToString() };
                             // Mapping information from
                             // https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver16
                             switch (engineEdition)

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 try
                 {
-                    string serverPropertiesQuery = $"SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('EngineEdition')";
+                    string serverPropertiesQuery = $"SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('Edition')";
 
                     logger.LogDebugWithThreadId($"BEGIN GetServerTelemetryProperties Query={serverPropertiesQuery}");
                     using (var selectServerEditionCommand = new SqlCommand(serverPropertiesQuery, connection))
@@ -311,8 +311,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         if (await reader.ReadAsync(cancellationToken))
                         {
-                            int engineEdition = (int)reader.GetValue(0);
-                            var serverProperties = new ServerProperties() { Edition = reader.GetValue(1).ToString() };
+                            int engineEdition = reader.GetInt32(0);
+                            var serverProperties = new ServerProperties() { Edition = reader.GetString(1) };
                             // Mapping information from
                             // https://learn.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?view=sql-server-ver16
                             switch (engineEdition)


### PR DESCRIPTION
1. EngineEdtion value is Int32, was trying to read it as Byte from the reader, fixed that.
2. Was getting the same EngineEdition property twice instead of Edition, updated it correctly.
Fixes #683 