### PR TITLE
Add "Need Logs" Github label action

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -18,5 +18,5 @@ Needs Logs:
 2. Restart your function and reproduce your issue
 3. Get the log file and attach it to this issue. By default this will be in `%TMP%/LogFiles/Application/Functions/Host`.
 
-**NOTE** Debug logging will include information such as Database and table names, if you do not with to include this information you can either redact it from the logs before attaching or let us know and we will provide a way to send logs directly to us.
+**NOTE** Debug logging will include information such as Database and table names, if you do not wish to include this information you can either redact it from the logs before attaching or let us know and we will provide a way to send logs directly to us.
 "

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,22 @@
+# actions for Needs Logs label
+Needs Logs:
+  comment: "We need more info to debug your particular issue. If you could attach your logs to the issue, it would help us fix the issue much faster.
+
+1. Set the default logging level to `Debug` and enable logging to a file. To do this ensure the following entries are in your `host.json`. ([instructions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring?tabs=v2#configure-log-levels))
+
+```json
+{
+  "logging": {
+      "fileLoggingMode": "debugOnly",
+      "logLevel": {
+        "default": "Debug"
+      }
+  }
+}
+```
+
+2. Restart your function and reproduce your issue
+3. Get the log file and attach it to this issue. By default this will be in `%TMP%/LogFiles/Application/Functions/Host`.
+
+**NOTE** Debug logging will include information such as Database and table names, if you do not with to include this information you can either redact it from the logs before attaching or let us know and we will provide a way to send logs directly to us.
+"

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -7,7 +7,7 @@ Needs Logs:
 ```json
 {
   "logging": {
-      "fileLoggingMode": "debugOnly",
+      "fileLoggingMode": "always",
       "logLevel": {
         "default": "Debug"
       }

--- a/.github/workflows/on-label.yml
+++ b/.github/workflows/on-label.yml
@@ -1,0 +1,15 @@
+name: On Label
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  processLabelAction:
+    name: Process Label Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Process Label Action
+        uses: hramos/label-actions@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Will provide instructions for getting logs when the "Needs Logs" label is added

It doesn't seem like the AF docs provide any really helpful instructions for getting the log file unfortunately - see https://github.com/MicrosoftDocs/azure-docs/issues/59008 for details. Can someone with a Mac verify if the path given makes sense there as well?