### PR TITLE
Fix label action

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -6,10 +6,10 @@ Needs Logs:
 
 ```json
 {
-  "logging": {
-      "fileLoggingMode": "always",
-      "logLevel": {
-        "default": "Debug"
+  \"logging\": {
+      \"fileLoggingMode\": \"always\",
+      \"logLevel\": {
+        \"default\": \"Debug\"
       }
   }
 }


### PR DESCRIPTION
This should fix the label action not being able to run - had embedded quotes I missed escaping. 