### PR TITLE
Remove code block from label action

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -4,7 +4,6 @@ Needs Logs:
 
 1. Set the default logging level to `Debug` and enable logging to a file. To do this ensure the following entries are in your `host.json`. ([instructions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring?tabs=v2#configure-log-levels))
 
-```json
 
 {
 
@@ -21,8 +20,6 @@ Needs Logs:
 	}
 
 }
-
-```
 
 2. Restart your function and reproduce your issue
 


### PR DESCRIPTION
Can't figure out a way to get the multi-line code block syntax correct, so just removing it to see if that works at least