### PR TITLE
Clean Up Instances of IDE0049

### DIFF
--- a/test-outofproc/Product.cs
+++ b/test-outofproc/Product.cs
@@ -115,9 +115,9 @@ namespace DotnetIsolatedTests.Common
 
         public short TinyInt { get; set; }
 
-        public Double FloatType { get; set; }
+        public double FloatType { get; set; }
 
-        public Single Real { get; set; }
+        public float Real { get; set; }
 
         public DateTime Date { get; set; }
 

--- a/test/Common/ProductColumnTypes.cs
+++ b/test/Common/ProductColumnTypes.cs
@@ -26,9 +26,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
 
         public short TinyInt { get; set; }
 
-        public Double FloatType { get; set; }
+        public double FloatType { get; set; }
 
-        public Single Real { get; set; }
+        public float Real { get; set; }
 
         public DateTime Date { get; set; }
 


### PR DESCRIPTION
Noticed that we were seeing some instances of [IDE0049](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0049) when opening up the project in vscode. Examples:

<img width="556" alt="image" src="https://user-images.githubusercontent.com/40371649/224436121-efa7f0cb-55e3-4b47-b14f-e0adc2c8b76c.png">

https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types#characteristics-of-the-floating-point-types double is an alias for System.Double, float is an alias for System.Single.