### PR TITLE
Add JObject support for SQL trigger

### DIFF
--- a/samples/samples-js/ProductsTrigger/function.json
+++ b/samples/samples-js/ProductsTrigger/function.json
@@ -1,0 +1,12 @@
+{
+    "bindings": [
+      {
+        "name": "changes",
+        "type": "sqlTrigger",
+        "direction": "in",
+        "tableName": "Products",
+        "connectionStringSetting": "SqlConnectionString"
+      }
+    ],
+    "disabled": false
+  }

--- a/samples/samples-js/ProductsTrigger/index.js
+++ b/samples/samples-js/ProductsTrigger/index.js
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+module.exports = async function (context, changes) {
+    context.log(`SQL Changes: ${JSON.stringify(changes)}`)
+}

--- a/samples/samples-powershell/ProductsTrigger/function.json
+++ b/samples/samples-powershell/ProductsTrigger/function.json
@@ -1,0 +1,12 @@
+{
+    "bindings": [
+      {
+        "name": "changes",
+        "type": "sqlTrigger",
+        "direction": "in",
+        "tableName": "Products",
+        "connectionStringSetting": "SqlConnectionString"
+      }
+    ],
+    "disabled": false
+  }

--- a/samples/samples-powershell/ProductsTrigger/run.ps1
+++ b/samples/samples-powershell/ProductsTrigger/run.ps1
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+using namespace System.Net
+
+param($changes)
+$changesJson = $changes | ConvertTo-Json
+# The output is used to inspect the trigger binding parameter in test methods.
+# Removing new lines for testing purposes.
+$changesJson = $changesJson -replace [Environment]::NewLine,"";
+Write-Host "SQL Changes: $changesJson"

--- a/samples/samples-python/ProductsTrigger/__init__.py
+++ b/samples/samples-python/ProductsTrigger/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import json
+import logging
+
+def main(changes):
+    logging.info("SQL Changes: %s", json.loads(changes))

--- a/samples/samples-python/ProductsTrigger/function.json
+++ b/samples/samples-python/ProductsTrigger/function.json
@@ -1,0 +1,12 @@
+{
+    "bindings": [
+      {
+        "name": "changes",
+        "type": "sqlTrigger",
+        "direction": "in",
+        "tableName": "Products",
+        "connectionStringSetting": "SqlConnectionString"
+      }
+    ],
+    "disabled": false
+  }

--- a/src/TriggerBinding/SqlTriggerValueProvider.cs
+++ b/src/TriggerBinding/SqlTriggerValueProvider.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Host.Bindings;
-
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -15,6 +16,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
     {
         private readonly object _value;
         private readonly string _tableName;
+        private readonly Type _parameterType;
+        private readonly bool _isString;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlTriggerValueProvider"/> class.
@@ -24,21 +27,37 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <param name="tableName">Name of the user table</param>
         public SqlTriggerValueProvider(Type parameterType, object value, string tableName)
         {
-            this.Type = parameterType;
+            this._parameterType = parameterType;
             this._value = value;
             this._tableName = tableName;
+            this._isString = parameterType == typeof(string);
         }
 
         /// <summary>
         /// Gets the trigger argument value.
         /// </summary>
-        public Type Type { get; }
+        public Type Type
+        {
+            get
+            {
+                if (this._isString)
+                {
+                    return typeof(IReadOnlyCollection<JObject>);
+                }
+                return this._parameterType;
+            }
+        }
 
         /// <summary>
         /// Returns value of the trigger argument.
         /// </summary>
         public Task<object> GetValueAsync()
         {
+            if (this._isString)
+            {
+                return Task.FromResult<object>(JArray.FromObject(this._value).ToString(Newtonsoft.Json.Formatting.None));
+            }
+
             return Task.FromResult(this._value);
         }
 

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -29,11 +29,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <summary>
         /// Ensures that the user function gets invoked for each of the insert, update and delete operation.
         /// </summary>
-        [Fact]
-        public async Task SingleOperationTriggerTest()
+        [Theory]
+        [SqlInlineData()]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        public async Task SingleOperationTriggerTest(SupportedLanguages lang)
         {
             this.SetChangeTrackingForTable("Products");
-            this.StartFunctionHost(nameof(ProductsTrigger), SupportedLanguages.CSharp);
+            this.StartFunctionHost(nameof(ProductsTrigger), lang);
 
             int firstId = 1;
             int lastId = 30;


### PR DESCRIPTION
Closes: https://github.com/Azure/azure-functions-sql-extension/issues/352, https://github.com/Azure/azure-functions-sql-extension/issues/353, https://github.com/Azure/azure-functions-sql-extension/issues/354
Added ProductsTrigger sample for JavaScript, PowerShell, and Python.

Created a separate [issue](https://github.com/Azure/azure-functions-sql-extension/issues/721) to track adding tests for all languages.
