### PR TITLE
Fix trigger connection not being retried when connection is closed

### DIFF
--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Checks whether an exception is a fatal SqlException. It is deteremined to be fatal
+        /// Checks whether an exception is a fatal SqlException. It is determined to be fatal
         /// if the Class value of the Exception is 20 or higher, see
         /// https://learn.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlexception#remarks
         /// for details
@@ -248,6 +248,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             // Most SqlExceptions wrap the original error from the native driver, so make sure to check both
             return (e as SqlException)?.Class >= 20 || (e.InnerException as SqlException)?.Class >= 20;
+        }
+
+        /// <summary>
+        /// Checks whether the connection state is currently Broken or Closed
+        /// </summary>
+        /// <param name="conn">The connection to check</param>
+        /// <returns>True if the connection is broken or closed, false otherwise</returns>
+        internal static bool IsBrokenOrClosed(this SqlConnection conn)
+        {
+            return conn.State == ConnectionState.Broken || conn.State == ConnectionState.Closed;
         }
 
         /// <summary>
@@ -266,7 +276,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             string connectionName,
             CancellationToken token)
         {
-            if (forceReconnect || conn.State.HasFlag(ConnectionState.Broken | ConnectionState.Closed))
+            if (forceReconnect || conn.IsBrokenOrClosed())
             {
                 logger.LogWarning($"{connectionName} is broken, attempting to reconnect...");
                 logger.LogDebugWithThreadId($"BEGIN RetryOpen{connectionName}");

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -304,8 +304,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                                 await this.ReleaseLeasesAsync(connection, token);
                             }
                         }
-                        catch (Exception e) when (e.IsFatalSqlException())
+                        catch (Exception e) when (e.IsFatalSqlException() || connection.IsBrokenOrClosed())
                         {
+                            // Retry connection if there was a fatal SQL exception or something else caused the connection to be closed
+                            // since that indicates some other issue occurred (such as dropped network) and may be able to be recovered
                             this._logger.LogError($"Fatal SQL Client exception processing changes. Will attempt to reestablish connection in {this._pollingIntervalInMs}ms. Exception = {e.Message}");
                             forceReconnect = true;
                         }
@@ -435,9 +437,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
                 this._logger.LogError($"Failed to check for changes in table '{this._userTable.FullName}' due to exception: {e.GetType()}. Exception message: {e.Message}");
                 TelemetryInstance.TrackException(TelemetryErrorName.GetChanges, e, this._telemetryProps);
-                if (e.IsFatalSqlException())
+                if (e.IsFatalSqlException() || connection.IsBrokenOrClosed())
                 {
-                    // If we get a fatal SQL Client exception here let it bubble up so we can try to re-establish the connection
+                    // If we get a fatal SQL Client exception or the connection is broken let it bubble up so we can try to re-establish the connection
                     throw;
                 }
             }
@@ -546,8 +548,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         {
                             await this.RenewLeasesAsync(connection, token);
                         }
-                        catch (Exception e) when (e.IsFatalSqlException())
+                        catch (Exception e) when (e.IsFatalSqlException() || connection.IsBrokenOrClosed())
                         {
+                            // Retry connection if there was a fatal SQL exception or something else caused the connection to be closed
+                            // since that indicates some other issue occurred (such as dropped network) and may be able to be recovered
                             forceReconnect = true;
                         }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-functions-sql-extension/issues/723

Turns out that the "Connection is closed" exception is just an InvalidOperationException so the checks I added weren't catching that. So to fix it also checking the actual connection state, since if that's closed/broken then we know something happened and can hopefully recover from it. 

While I was doing this I realized the "is broken or closed" check I had previously wasn't even working...HasFlags checks if ALL the flag bits are set that you give it (so a connection would have to be both closed AND broken to be true). And using HasFlags for Closed isn't even correct since its value is 0 so will always return true. I don't know why this is a flags enum to begin with but just checking the State directly is what we actually want to be doing here. (I didn't notice this because the connection retry was being forced if a fatal SQL exception occurred, which was the thing being fixed with the original logic)