### PR TITLE
Add release branch to PR build triggers

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -4,6 +4,7 @@ pr:
   branches:
     include:
     - main
+    - release/*
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
Currently PR builds are only set to trigger on main - adding release branches as well for when we need to use those. 