### PR TITLE
vBump release/trigger 1.* -> 3.*

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -22,7 +22,7 @@ schedules:
 variables:
   solution: '**/*.sln'
   configuration: 'Release'
-  versionMajor: 1
+  versionMajor: 3
   versionMinor: 0
   versionMajorMinor: '$(versionMajor).$(versionMinor)'  # This variable is only used for the counter so we reset properly when either major or minor is bumped
   versionPatch: $[counter(variables['versionMajorMinor'], 0)] # This will reset when we bump minor version


### PR DESCRIPTION
Getting ahead of main branch so that this will always be higher than GA'd version