### PR TITLE
Default release type to full for main

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -4,7 +4,7 @@ parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'ReleaseType'
   displayName: 'Type of release'
   type: string
-  default: preview
+  default: full
   values:
     - full
     - preview


### PR DESCRIPTION
Honestly we could probably remove this - with the separate trigger branch for preview we could just have each branch set the name it wants to use. But it doesn't seem like a huge deal to leave it in for now, although updating it to default to full for the main branch needs to happen for scheduled builds (and to help prevent mistakes when manually queueing)