### PR TITLE
Enable debug logging for Python and PS samples

### DIFF
--- a/samples/samples-js/host.json
+++ b/samples/samples-js/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Information"
+      "default": "Debug"
     }
   },
   "extensionBundle": {

--- a/samples/samples-powershell/host.json
+++ b/samples/samples-powershell/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Information"
+      "default": "Debug"
     }
   },
   "extensionBundle": {

--- a/samples/samples-python/host.json
+++ b/samples/samples-python/host.json
@@ -8,7 +8,7 @@
       }
     },
     "logLevel": {
-      "default": "Information"
+      "default": "Debug"
     }
   },
   "extensionBundle": {


### PR DESCRIPTION
The SingleOperationTriggerTest has been failing intermittently for Python and PS. Temporarily enabling debug logs to help with investigation. 