### PR TITLE
Add docs & logging information for Leases table info

### DIFF
--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         transaction.Commit();
                     }
 
-                    this._logger.LogInformation($"Starting SQL trigger listener for table: '{this._userTable.FullName}', function ID: '{this._userFunctionId}'.");
+                    this._logger.LogInformation($"Starting SQL trigger listener for table: '{this._userTable.FullName}' (object ID: {userTableId}), function ID: {this._userFunctionId}");
 
                     this._changeMonitor = new SqlTableChangeMonitor<T>(
                         this._connectionString,
@@ -155,7 +155,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         this._telemetryProps);
 
                     this._listenerState = ListenerStarted;
-                    this._logger.LogInformation($"Started SQL trigger listener for table: '{this._userTable.FullName}', function ID: '{this._userFunctionId}'.");
+                    this._logger.LogInformation($"Started SQL trigger listener for table: '{this._userTable.FullName}' (object ID: {userTableId}), function ID: {this._userFunctionId}");
+                    this._logger.LogInformation($"SQL trigger Leases table: {leasesTableName}");
 
                     var measures = new Dictionary<TelemetryMeasureName, double>
                     {


### PR DESCRIPTION
To help customers debug their functions and fix any problems that occur adding docs for how to query for "ignored" rows in the Leases table (rows that failed to be processed 5 times in a row) and how to reset them so they start getting processed again.

Also added log message on startup saying what the leases table name is since that's not easily able to be found.