### PR TITLE
Treat warnings as errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,7 +19,6 @@ dotnet_diagnostic.CS1573.severity = none
 dotnet_diagnostic.CS1572.severity = none
 dotnet_diagnostic.CS1570.severity = none
 dotnet_diagnostic.CS1574.severity = none
-dotnet_diagnostic.CS1584.severity = error
 
 #### Core EditorConfig Options ####
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,5 +26,6 @@
     <PackageProjectUrl>https://github.com/Azure/azure-functions-sql-extension</PackageProjectUrl>
     <PackageIcon>pkgicon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Seizing this moment when we have no build warnings to treat warnings as errors to prevent many classes of problems from reoccurring.

(If there are new classes of warnings that we collectively decide to add new entries to .editorconfig to unblock)