### PR TITLE
Add .editorconfig to samples-csharpscript folder

### DIFF
--- a/samples/samples-csharpscript/.editorconfig
+++ b/samples/samples-csharpscript/.editorconfig
@@ -1,0 +1,5 @@
+# See https://github.com/dotnet/roslyn-analyzers/blob/main/.editorconfig for an example on different settings and how they're used
+
+[*.csx]
+
+dotnet_diagnostic.CS0659.severity = silent # overrides Object.Equals but does not override Object.GetHashCode() - not necessary for our samples


### PR DESCRIPTION
Following pattern that we previously established in https://github.com/Azure/azure-functions-sql-extension/blob/chlafren/csxeditconfig/samples/samples-csharp/.editorconfig#L5