### PR TITLE
Further clarifications to trigger retry docs

### DIFF
--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -197,9 +197,9 @@ Note that these retries are outside the built in idle connection retry logic tha
 
 #### Function exception retries
 
-If an exception occurs in the user function when processing changes then those rows will be retried again in 60 seconds. Other changes will be processed as normal during this time, but the rows that caused the exception will be ignored until the timeout period has elapsed.
+If an exception occurs in the user function when processing changes then the batch of rows currently being processed will be retried again in 60 seconds. Other changes will be processed as normal during this time, but the rows in the batch that caused the exception will be ignored until the timeout period has elapsed.
 
-If the function execution fails 5 times in a row for a given row then that row is completely ignored for all future changes.
+If the function execution fails 5 times in a row for a given row then that row is completely ignored for all future changes. Because the rows in a batch is not deterministic this means that rows in a batch that failed may end up in different batches in subsequent invocations which may affect whether a given row is ignored if the other rows in the batch are the ones causing the exception since it may end up in a different batch that doesn't fail in future invocations.
 
 You can run this query to see what rows have failed 5 times and are currently ignored, see [Leases table](#az_funcleases_) documentation for how to get the correct Leases table to query for your function.
 


### PR DESCRIPTION
Better clarify that while rows are ignore individually, they are processed as a batch (and thus fail as a batch). 