### PR TITLE
Increase build timeout from 90 to 120 minutes

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -37,7 +37,7 @@ stages:
     workspace:
       clean: all
 
-    timeoutInMinutes: '90'
+    timeoutInMinutes: '120'
 
     steps:
     - template: 'template-steps-build-test.yml'

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -58,7 +58,7 @@ stages:
     workspace:
       clean: all
 
-    timeoutInMinutes: '90'
+    timeoutInMinutes: '120'
 
     steps:
       - template: 'template-steps-build-test.yml'
@@ -78,7 +78,7 @@ stages:
     workspace:
       clean: all
 
-    timeoutInMinutes: '90'
+    timeoutInMinutes: '120'
 
     steps:
       - template: 'template-steps-build-test.yml'


### PR DESCRIPTION
Temporarily increasing the timeout to 120 minutes to unblock builds while I work on decreasing our test run times.