### PR TITLE
Add SQLTrigger annotation to java library

### DIFF
--- a/java-library/pom.xml
+++ b/java-library/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.microsoft.azure.functions</groupId>
   <artifactId>azure-functions-java-library-sql</artifactId>
-  <version>0.1.1</version> <!-- Update the dependency version in samples-java/pom.xml and test-java/pom.xml if this version is updated. -->
+  <version>2.0.0-preview</version> <!-- Update the dependency version in samples-java/pom.xml and test-java/pom.xml if this version is updated. -->
   <packaging>jar</packaging>
 
   <parent>

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/CommandType.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/CommandType.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+package com.microsoft.azure.functions.sql.annotation;
+
+/**
+ * The type of commandText.
+ */
+public enum CommandType {
+    /**
+     * The commandText is a SQL query.
+     */
+    Text,
+
+    /**
+     * The commandText is a SQL stored procedure.
+     */
+    StoredProcedure
+}

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
@@ -30,7 +30,7 @@ public @interface SQLInput {
     /**
      * Text or Stored Procedure.
      */
-    String commandType();
+    CommandType commandType();
 
     /**
      * Parameters to the query or stored procedure. This string must follow the format

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLInput.java
@@ -25,12 +25,12 @@ public @interface SQLInput {
     /**
      * Query string or name of stored procedure to be run.
      */
-    String commandText() default "";
+    String commandText();
 
     /**
      * Text or Stored Procedure.
      */
-    String commandType() default "";
+    String commandType();
 
     /**
      * Parameters to the query or stored procedure. This string must follow the format
@@ -42,5 +42,5 @@ public @interface SQLInput {
     /**
      * Setting name for SQL connection string.
      */
-    String connectionStringSetting() default "";
+    String connectionStringSetting();
 }

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLOutput.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLOutput.java
@@ -26,10 +26,10 @@ public @interface SQLOutput {
     /**
      * Name of the table to upsert data to.
      */
-    String commandText() default "";
+    String commandText();
 
     /**
      * Setting name for SQL connection string.
      */
-    String connectionStringSetting() default "";
+    String connectionStringSetting();
 }

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLTrigger.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLTrigger.java
@@ -25,10 +25,10 @@ public @interface SQLTrigger {
     /**
      * Name of the table to watch for changes.
     */
-    String tableName() default "";
+    String tableName();
 
     /**
      * Setting name for SQL connection string.
     */
-    String connectionStringSetting() default "";
+    String connectionStringSetting();
 }

--- a/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLTrigger.java
+++ b/java-library/src/main/java/com/microsoft/azure/functions/sql/annotation/SQLTrigger.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.functions.sql.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.ElementType;
+
+import com.microsoft.azure.functions.annotation.CustomBinding;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+@CustomBinding(direction = "in", name = "", type = "sqlTrigger")
+public @interface SQLTrigger {
+    /**
+     * The variable name used in function.json.
+    */
+    String name();
+
+    /**
+     * Name of the table to watch for changes.
+    */
+    String tableName() default "";
+
+    /**
+     * Setting name for SQL connection string.
+    */
+    String connectionStringSetting() default "";
+}


### PR DESCRIPTION
Updated the azure-functions-java-library-sql version to 2.0.0-preview. Will also be releasing version 1.0.0 (with only input and output annotations) for input/output GA.
