### PR TITLE
Improve connection errors

### DIFF
--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             string connectionString = configuration.GetConnectionStringOrSetting(connectionStringSetting);
             if (string.IsNullOrEmpty(connectionString))
             {
-                string emptyMessage = $"ConnectionStringSetting {connectionStringSetting} must not be empty, it should contain a valid SQL connection string for connection.";
-                throw new ArgumentException(connectionString == null ? $"ConnectionStringSetting {connectionStringSetting} is missing in your local settings, Please add the setting with the SQL connection string" : emptyMessage);
+                throw new ArgumentException(connectionString == null ? $"ConnectionStringSetting `{connectionStringSetting}` is missing in your local settings, Please add the setting with a valid SQL connection string" :
+                $"ConnectionStringSetting `{connectionStringSetting}` must not be empty, it should contain a valid SQL connection string for connection.");
             }
             return connectionString;
         }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -45,7 +45,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
-            return configuration.GetConnectionStringOrSetting(connectionStringSetting);
+            string connectionString = configuration.GetConnectionStringOrSetting(connectionStringSetting);
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                string emptyMessage = $"ConnectionStringSetting {connectionStringSetting} must not be empty, it should contain a valid SQL connection string for connection.";
+                throw new ArgumentException(connectionString == null ? $"ConnectionStringSetting {connectionStringSetting} is missing in your local settings, Please add the setting with the SQL connection string" : emptyMessage);
+            }
+            return connectionString;
         }
 
         /// <summary>

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -48,8 +48,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             string connectionString = configuration.GetConnectionStringOrSetting(connectionStringSetting);
             if (string.IsNullOrEmpty(connectionString))
             {
-                throw new ArgumentException(connectionString == null ? $"ConnectionStringSetting `{connectionStringSetting}` is missing in your local settings, Please add the setting with a valid SQL connection string" :
-                $"ConnectionStringSetting `{connectionStringSetting}` is empty in your local settings, Please update the setting with a valid SQL connection string for connection.");
+                throw new ArgumentException(connectionString == null ? $"ConnectionStringSetting '{connectionStringSetting}' is missing in your function app settings, please add the setting with a valid SQL connection string." :
+                $"ConnectionStringSetting '{connectionStringSetting}' is empty in your function app settings, please update the setting with a valid SQL connection string.");
             }
             return connectionString;
         }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             if (string.IsNullOrEmpty(connectionString))
             {
                 throw new ArgumentException(connectionString == null ? $"ConnectionStringSetting `{connectionStringSetting}` is missing in your local settings, Please add the setting with a valid SQL connection string" :
-                $"ConnectionStringSetting `{connectionStringSetting}` must not be empty, it should contain a valid SQL connection string for connection.");
+                $"ConnectionStringSetting `{connectionStringSetting}` is empty in your local settings, Please update the setting with a valid SQL connection string for connection.");
             }
             return connectionString;
         }


### PR DESCRIPTION
We throw the same generic error when 1. connection string setting is missing in the local.settings.json file
2. connection string is present but empty. => System.Private.CoreLib: One or more errors occurred. (The ConnectionString property has not been initialized.). Microsoft.Data.SqlClient: The ConnectionString property has not been initialized.

Updated the errors thrown so user can better address them.