### PR TITLE
Skip more trigger tests for CSX

### DIFF
--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc, SupportedLanguages.CSharpscript)]
         public async Task PollingIntervalOverrideTriggerTest(SupportedLanguages lang)
         {
             const int firstId = 1;
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc, SupportedLanguages.CSharpscript)]
         public async Task MultiFunctionTriggerTest(SupportedLanguages lang)
         {
             const string Trigger1Changes = "Trigger1 Changes: ";
@@ -472,7 +472,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc, SupportedLanguages.CSharpscript)]
         public void TableNotPresentTriggerTest(SupportedLanguages lang)
         {
             this.StartFunctionHostAndWaitForError(
@@ -487,7 +487,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc, SupportedLanguages.CSharpscript)]
         public void PrimaryKeyNotCreatedTriggerTest(SupportedLanguages lang)
         {
             this.StartFunctionHostAndWaitForError(
@@ -503,7 +503,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc, SupportedLanguages.CSharpscript)]
         public void ReservedPrimaryKeyColumnNamesTriggerTest(SupportedLanguages lang)
         {
             this.StartFunctionHostAndWaitForError(
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [Theory]
         [SqlInlineData()]
-        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc)]
+        [UnsupportedLanguages(SupportedLanguages.Java, SupportedLanguages.OutOfProc, SupportedLanguages.CSharpscript)]
         public void UnsupportedColumnTypesTriggerTest(SupportedLanguages lang)
         {
             this.StartFunctionHostAndWaitForError(


### PR DESCRIPTION
I didn't merge in latest from the trigger branch in my other PR so missed these other tests being enabled - disabling them for CSX until we can investigate and fix those. 