### PR TITLE
add copy task to ensure sql package is available in local-packages folder for tests

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -102,6 +102,14 @@ steps:
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
 
+- task: CopyFiles@2
+  displayName: 'Copy local Sql package to local-packages folder'
+  inputs:
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
+    contents: *
+    targetFolder: $(Build.SourcesDirectory)/local-packages
+    overWrite: true
+
 - script: |
     npm install
     npm run lint

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -102,6 +102,7 @@ steps:
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
 
+  # Copy the Sql nupkg to ensure it's available for tests.
 - task: CopyFiles@2
   displayName: 'Copy local Sql package to local-packages folder'
   inputs:

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -102,12 +102,12 @@ steps:
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
 
-  # Copy the Sql nupkg to ensure it's available for tests.
+  # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
 - task: CopyFiles@2
   displayName: 'Copy local Sql package to local-packages folder'
   inputs:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
-    contents: '*'
+    contents: '*.nupkg'
     targetFolder: $(Build.SourcesDirectory)/local-packages
     overWrite: true
 

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -107,7 +107,7 @@ steps:
   displayName: 'Copy local Sql package to local-packages folder'
   inputs:
     sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
-    contents: *
+    contents: '*'
     targetFolder: $(Build.SourcesDirectory)/local-packages
     overWrite: true
 


### PR DESCRIPTION
Added a copy task to explicitly copy the sql package to local-packages.

Fixes #687 