### PR TITLE
Fix up performance tests & enable schedule

### DIFF
--- a/builds/azure-pipelines/performance.yml
+++ b/builds/azure-pipelines/performance.yml
@@ -2,7 +2,13 @@ trigger: none
 
 pr: none
 
-schedules: [ ]
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Mon-Fri at Midnight
+    branches:
+      include:
+        - release/trigger
+    always: true
 
 variables:
   configuration: 'Release'

--- a/performance/Microsoft.Azure.WebJobs.Extensions.Sql.Performance.csproj
+++ b/performance/Microsoft.Azure.WebJobs.Extensions.Sql.Performance.csproj
@@ -17,6 +17,11 @@
 
   <Target Name="CopySamples" AfterTargets="Build">
     <ItemGroup>
+        <_DatabaseItems Include="..\samples\Database\**\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_DatabaseItems)" DestinationFolder="$(OutDir)\Database\%(RecursiveDir)" />
+    <Message Text="Copied SQL Scripts to $(OutDir)\Database" Importance="high" />
+    <ItemGroup>
       <_CSharpCopyItems Include="..\samples\samples-csharp\bin\$(Configuration)\$(TargetFramework)\**\*.*" />
     </ItemGroup>
     <Copy SourceFiles="@(_CSharpCopyItems)" DestinationFolder="$(OutDir)\SqlExtensionSamples\CSharp\%(RecursiveDir)" />
@@ -30,6 +35,11 @@
       <Link>SqlExtensionSamples\%(RecursiveDir)\%(Filename)%(Extension)</Link>
       <Visible>True</Visible>
     </None>
+    <None Include="$(OutDir)\Database\**\*">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>Database\%(RecursiveDir)\%(Filename)%(Extension)</Link>
+        <Visible>True</Visible>
+      </None>
   </ItemGroup>
 
 </Project>

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,16 +1,31 @@
 # Running Performance Tests
 
 ## Pre-requisites
+
 The performance tests are based on the IntegrationTestBase class. Follow the instructions to set up the pre-requisites for integration tests [here](../test/README.md#running-integration-tests).
 
 ## Run
+
 The performance tests use BenchmarkDotNet to benchmark performance for input and output bindings.
 
 Run the tests from the terminal.
-```
+
+### Run all tests
+
+```bash
 cd performance
 dotnet run -c Release
 ```
 
+### Run subset of tests
+
+You can also pass in an argument to the test runner to run only a subset of tests. Each argument corresponds to a category of tests (each contained in a single class). See [SqlBindingBenchmark](./SqlBindingBenchmarks.cs) for the full list of arguments.
+
+```bash
+cd performance
+dotnet run -c Release input
+```
+
 ## Results
+
 The test results will be generated in the BenchmarkDotNet.Artifacts folder.


### PR DESCRIPTION
Going to start working on setting up the performance test runs to actually start comparing to a baseline - but the first step is to fix the project so it runs and then enable the pipeline to run on a schedule so we can catch any issues that crop up. 