### PR TITLE
Cleanup logging

### DIFF
--- a/src/SqlBindingConfigProvider.cs
+++ b/src/SqlBindingConfigProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             LogDependentAssemblyVersions(logger);
 #pragma warning disable CS0618 // Fine to use this for our stuff
             FluentBindingRule<SqlAttribute> inputOutputRule = context.AddBindingRule<SqlAttribute>();
-            var converter = new SqlConverter(this._configuration, logger);
+            var converter = new SqlConverter(this._configuration);
             inputOutputRule.BindToInput(converter);
             inputOutputRule.BindToInput<string>(typeof(SqlGenericsConverter<string>), this._configuration, logger);
             inputOutputRule.BindToCollector<SQLObjectOpenType>(typeof(SqlAsyncCollectorBuilder<>), this._configuration, logger);

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     string serverPropertiesQuery = $"SELECT SERVERPROPERTY('EngineEdition'), SERVERPROPERTY('Edition')";
 
                     using (var selectServerEditionCommand = new SqlCommand(serverPropertiesQuery, connection))
-                    using (SqlDataReader reader = await selectServerEditionCommand.ExecuteReaderAsync(cancellationToken))
+                    using (SqlDataReader reader = await selectServerEditionCommand.ExecuteReaderAsyncWithLogging(logger, cancellationToken))
                     {
                         if (await reader.ReadAsync(cancellationToken))
                         {

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry;
@@ -23,20 +22,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         internal class SqlConverter : IConverter<SqlAttribute, SqlCommand>
         {
             private readonly IConfiguration _configuration;
-            private readonly ILogger _logger;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="SqlConverter"/> class.
             /// </summary>
             /// <param name="configuration"></param>
-            /// <param name="logger">ILogger used to log information and warnings</param>
             /// <exception cref="ArgumentNullException">
             /// Thrown if the configuration is null
             /// </exception>
-            public SqlConverter(IConfiguration configuration, ILogger logger)
+            public SqlConverter(IConfiguration configuration)
             {
                 this._configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-                this._logger = logger;
                 TelemetryInstance.TrackCreate(CreateType.SqlConverter);
             }
 
@@ -51,14 +47,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             public SqlCommand Convert(SqlAttribute attribute)
             {
                 TelemetryInstance.TrackConvert(ConvertType.SqlCommand);
-                this._logger.LogDebugWithThreadId("BEGIN Convert (SqlCommand)");
-                var sw = Stopwatch.StartNew();
                 try
                 {
-                    SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, SqlBindingUtilities.BuildConnection(
+                    return SqlBindingUtilities.BuildCommand(attribute, SqlBindingUtilities.BuildConnection(
                                        attribute.ConnectionStringSetting, this._configuration));
-                    this._logger.LogDebugWithThreadId($"END Convert (SqlCommand) Duration={sw.ElapsedMilliseconds}ms");
-                    return command;
                 }
                 catch (Exception ex)
                 {
@@ -107,14 +99,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <returns>An IEnumerable containing the rows read from the user's database in the form of the user-defined POCO</returns>
             public async Task<IEnumerable<T>> ConvertAsync(SqlAttribute attribute, CancellationToken cancellationToken)
             {
-                this._logger.LogDebugWithThreadId("BEGIN ConvertAsync (IEnumerable)");
-                var sw = Stopwatch.StartNew();
                 try
                 {
                     string json = await this.BuildItemFromAttributeAsync(attribute, ConvertType.IEnumerable);
-                    IEnumerable<T> result = Utils.JsonDeserializeObject<IEnumerable<T>>(json);
-                    this._logger.LogDebugWithThreadId($"END ConvertAsync (IEnumerable) Duration={sw.ElapsedMilliseconds}ms");
-                    return result;
+                    return Utils.JsonDeserializeObject<IEnumerable<T>>(json);
                 }
                 catch (Exception ex)
                 {
@@ -141,13 +129,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// </returns>
             async Task<string> IAsyncConverter<SqlAttribute, string>.ConvertAsync(SqlAttribute attribute, CancellationToken cancellationToken)
             {
-                this._logger.LogDebugWithThreadId("BEGIN ConvertAsync (Json)");
-                var sw = Stopwatch.StartNew();
                 try
                 {
-                    string result = await this.BuildItemFromAttributeAsync(attribute, ConvertType.Json);
-                    this._logger.LogDebugWithThreadId($"END ConvertAsync (Json) Duration={sw.ElapsedMilliseconds}ms");
-                    return result;
+                    return await this.BuildItemFromAttributeAsync(attribute, ConvertType.Json);
                 }
                 catch (Exception ex)
                 {
@@ -180,9 +164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 using (SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, connection))
                 {
                     adapter.SelectCommand = command;
-                    this._logger.LogDebugWithThreadId("BEGIN OpenBuildItemFromAttributeAsyncConnection");
                     await connection.OpenAsyncWithSqlErrorHandling(CancellationToken.None);
-                    this._logger.LogDebugWithThreadId("END OpenBuildItemFromAttributeAsyncConnection");
                     this._serverProperties = await SqlBindingUtilities.GetServerTelemetryProperties(connection, this._logger, CancellationToken.None);
                     Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps(this._serverProperties);
                     TelemetryInstance.TrackConvert(type, props);

--- a/src/Utils.cs
+++ b/src/Utils.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Text;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -77,16 +76,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 default:
                     return defaultValue;
             }
-        }
-
-        public static void LogDebugWithThreadId(this ILogger logger, string message, params object[] args)
-        {
-            logger.LogDebug($"TID:{Environment.CurrentManagedThreadId} {message}", args);
-        }
-
-        public static void LogInformationWithThreadId(this ILogger logger, string message, params object[] args)
-        {
-            logger.LogInformation($"TID:{Environment.CurrentManagedThreadId} {message}", args);
         }
 
         /// <summary>

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         {
             Assert.Throws<ArgumentNullException>(() => new SqlBindingConfigProvider(null, loggerFactory.Object));
             Assert.Throws<ArgumentNullException>(() => new SqlBindingConfigProvider(config.Object, null));
-            Assert.Throws<ArgumentNullException>(() => new SqlConverter(null, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new SqlConverter(null));
             Assert.Throws<ArgumentNullException>(() => new SqlGenericsConverter<string>(null, logger.Object));
         }
 


### PR DESCRIPTION
Part 1 - will port over to trigger branch and cleanup the rest there after this gets in.

Greatly cleaning up the debug logging we do to avoid spamming the logs with too much verbose logging. In general the idea now is to only do debug logging for one-time or occasional events (such as startup configuration). For everything else we should rely on errors being captured and logged

1. Removed all of the BEGIN/END logs. Those have never really been anything we've used so just straight up removing them and relying on the queries failing due to timeout or other if there's any issues
2. Added SqlCommand.Execute... extension method to log error if a call fails so we can output the query text that caused the error which could still be very valuable to see (we've already had a couple instances of unexpected syntax causing query failures)
3. Removed the ThreadId helper functions, that was primarily added to help keep track of all the BEGIN/END calls (especially for trigger) and so with the removal of those they aren't really necessary anymore

Sample log output when an error occurs:

![image](https://user-images.githubusercontent.com/28519865/231901614-26eb7f75-e1ff-4283-a971-2d5749b7ebf6.png)
