### PR TITLE
clean up the logger delegates in tests

### DIFF
--- a/test-outofproc/MultiFunctionTrigger.cs
+++ b/test-outofproc/MultiFunctionTrigger.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using DotnetIsolatedTests.Common;
 using Microsoft.Extensions.Logging;
@@ -16,7 +15,6 @@ namespace DotnetIsolatedTests
     /// </summary>
     public static class MultiFunctionTrigger
     {
-        private static readonly Action<ILogger, string, Exception> _loggerMessage = LoggerMessage.Define<string>(LogLevel.Information, eventId: new EventId(0, "INFO"), formatString: "{Message}");
 
         [Function(nameof(MultiFunctionTrigger1))]
         public static void MultiFunctionTrigger1(
@@ -24,7 +22,8 @@ namespace DotnetIsolatedTests
             IReadOnlyList<SqlChange<Product>> products,
             FunctionContext context)
         {
-            _loggerMessage(context.GetLogger("ProductsTriggerWithValidation"), "Trigger1 Changes: " + Utils.JsonSerializeObject(products), null);
+            ILogger logger = context.GetLogger("MultiFunctionTrigger1");
+            logger.LogInformation("Trigger1 Changes: " + Utils.JsonSerializeObject(products), null);
         }
 
         [Function(nameof(MultiFunctionTrigger2))]
@@ -33,7 +32,8 @@ namespace DotnetIsolatedTests
             IReadOnlyList<SqlChange<Product>> products,
             FunctionContext context)
         {
-            _loggerMessage(context.GetLogger("ProductsTriggerWithValidation"), "Trigger2 Changes: " + Utils.JsonSerializeObject(products), null);
+            ILogger logger = context.GetLogger("MultiFunctionTrigger1");
+            logger.LogInformation("Trigger2 Changes: " + Utils.JsonSerializeObject(products), null);
         }
     }
 }

--- a/test-outofproc/ProductsTriggerWithValidation.cs
+++ b/test-outofproc/ProductsTriggerWithValidation.cs
@@ -12,8 +12,6 @@ namespace DotnetIsolatedTests
 {
     public static class ProductsTriggerWithValidation
     {
-        private static readonly Action<ILogger, string, Exception> _loggerMessage = LoggerMessage.Define<string>(LogLevel.Information, eventId: new EventId(0, "INFO"), formatString: "{Message}");
-
         /// <summary>
         /// Simple trigger function with additional logic to allow for verifying that the expected number
         /// of changes was received in each batch.
@@ -24,13 +22,14 @@ namespace DotnetIsolatedTests
             IReadOnlyList<SqlChange<Product>> changes,
             FunctionContext context)
         {
+            ILogger logger = context.GetLogger("ProductsTriggerWithValidation");
             string expectedMaxBatchSize = Environment.GetEnvironmentVariable("TEST_EXPECTED_MAX_BATCH_SIZE");
             if (!string.IsNullOrEmpty(expectedMaxBatchSize) && int.Parse(expectedMaxBatchSize, null) != changes.Count)
             {
                 throw new InvalidOperationException($"Invalid max batch size, got {changes.Count} changes but expected {expectedMaxBatchSize}");
             }
             // The output is used to inspect the trigger binding parameter in test methods.
-            _loggerMessage(context.GetLogger("ProductsTriggerWithValidation"), "SQL Changes: " + Utils.JsonSerializeObject(changes), null);
+            logger.LogInformation("SQL Changes: " + Utils.JsonSerializeObject(changes), null);
         }
     }
 }

--- a/test-outofproc/TriggerWithException.cs
+++ b/test-outofproc/TriggerWithException.cs
@@ -23,8 +23,9 @@ namespace DotnetIsolatedTests
         public static void Run(
             [SqlTrigger("[dbo].[Products]", "SqlConnectionString")]
             IReadOnlyList<SqlChange<Product>> changes,
-            ILogger logger)
+            FunctionContext context)
         {
+            ILogger logger = context.GetLogger("TriggerWithException");
             if (!threwException)
             {
                 threwException = true;


### PR DESCRIPTION
Removed the logger delegates in OOP trigger test classes.