### PR TITLE
Fix the race condition by adding the extension reference to build first.

### DIFF
--- a/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
+++ b/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
@@ -13,9 +13,12 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
-    <!-- We want to build the extension project first since this project references the package produced by building that. But we don't want it as an actual runtime depdendency -->
-		<ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference
+      Include="..\..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
+    <!-- We want to build the extension project first since this project references the package
+    produced by building that. But we don't want it as an actual runtime depdendency -->
+    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
+++ b/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
@@ -13,7 +13,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
+    <ProjectReference Include="..\..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
+    <!-- We want to build the extension project first since this project references the package produced by building that. But we don't want it as an actual runtime depdendency -->
+		<ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -43,11 +43,11 @@
     <ItemGroup>
       <_Packages Include=".\bin\$(Configuration)\*.nupkg" />
     </ItemGroup>
-    <Copy SourceFiles="@(_Packages)" DestinationFolder="../local-packages" />
+    <Copy SourceFiles="@(_Packages)" DestinationFolder="..\local-packages" />
     <Message Text="Copied sql .nupkg to local-packages" Importance="high" />
   </Target>
   <Target Name="RemoveNugetPackageCache" BeforeTargets="Build">
-    <RemoveDir Directories="$(NugetPackageRoot)/$(PackageId.ToLower())/99.99.99"></RemoveDir>
-    <Message Text="Deleted nuget cache for $(PackageId.ToLower())/99.99.99" Importance="high" />
+    <RemoveDir Directories="$(NugetPackageRoot)\$(PackageId.ToLower())\99.99.99"></RemoveDir>
+    <Message Text="Deleted nuget cache for $(PackageId.ToLower())\99.99.99" Importance="high" />
   </Target>
 </Project>

--- a/test-outofproc/test-outofproc.csproj
+++ b/test-outofproc/test-outofproc.csproj
@@ -15,9 +15,12 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
-      <!-- We want to build the extension project first since this project references the package produced by building that. But we don't want it as an actual runtime depdendency -->
-		<ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference
+      Include="..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
+    <!-- We want to build the extension project first since this project references the package
+    produced by building that. But we don't want it as an actual runtime depdendency -->
+    <ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">
@@ -29,6 +32,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
+    <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
   </ItemGroup>
 </Project>

--- a/test-outofproc/test-outofproc.csproj
+++ b/test-outofproc/test-outofproc.csproj
@@ -16,6 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
+      <!-- We want to build the extension project first since this project references the package produced by building that. But we don't want it as an actual runtime depdendency -->
+		<ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Fixes #837.
I observed that the build step fails even before the copy to local-packages step in the pipeline and the `Set up local-packages Nuget source` step prior to the build shows the below result:
C:\hostedtoolcache\windows\dotnet\dotnet.exe nuget add source -n afsqlext.local **D:\a\1\s/local-packages**
Package source with Name: afsqlext.local added successfully.

If the out of proc samples or tests are built first and the sql extension is still not available in local-packages, to avoid this added the sql extension to the project dependencies, so we make sure to have the local-packages available. 

Fixing that in this PR and going to monitor if that stops the "Error NU1301: The local source 'D:\a\1\s\local-packages' doesn't exist."