### PR TITLE
Revert node pinning

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -27,11 +27,6 @@ steps:
     result: PoliCheck.xml
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
-# Use 18.15 directly due to https://github.com/Azure/azure-functions-core-tools/issues/3335
-- task: NodeTool@0
-  inputs:
-    versionSpec: '18.15'
-
 - script: npm install -g azure-functions-core-tools
   displayName: 'Install Azure Functions Core Tools'
 

--- a/builds/azure-pipelines/template-steps-performance.yml
+++ b/builds/azure-pipelines/template-steps-performance.yml
@@ -16,11 +16,6 @@ steps:
   inputs:
     useGlobalJson: true
 
-# Use 18.15 directly due to https://github.com/Azure/azure-functions-core-tools/issues/3335
-- task: NodeTool@0
-  inputs:
-    versionSpec: '18.15'
-
 - script: npm install -g azure-functions-core-tools
   displayName: 'Install Azure Functions Core Tools'
 


### PR DESCRIPTION
A new version of the core tools was released with a fix for the issue. I'm leaving the changes I did to always pass in the node modules folder location, since while it's unnecessary for the non-Windows agents it also doesn't hurt and will save us having to change it again if something similar happens again in the future. 

https://github.com/Azure/azure-functions-core-tools/releases/tag/4.0.5095