### PR TITLE
add timestamp to global state table for lease table cleanup

### DIFF
--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -185,7 +185,8 @@ The Azure SQL Trigger does not currently handle automatically cleaning up any le
 ```sql
 -- Deletes all the lease tables that haven't been accessed in @CleanupAgeDays days (set below)
 -- and removes them from the GlobalState table.
-USE <Insert DATABASE name here>;
+USE [<Insert DATABASE name here>]
+GO
 DECLARE @TableName NVARCHAR(MAX);
 DECLARE @UserFunctionId char(16);
 DECLARE @UserTableId int;
@@ -204,7 +205,7 @@ WHILE @@FETCH_STATUS = 0
 BEGIN
     PRINT N'Dropping table ' + @TableName;
     EXEC ('DROP TABLE IF EXISTS ' + @TableName);
-    PRINT N'Removing row from GlobalState for UserFunctionID = ' + @UserFunctionId + ' and UserTableID = ' + @UserTableId;
+    PRINT 'Removing row from GlobalState for UserFunctionID = ' + RTRIM(CAST(@UserFunctionId AS NVARCHAR(30))) + ' and UserTableID = ' + RTRIM(CAST(@UserTableId AS NVARCHAR(30)));
     DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId
     FETCH NEXT FROM LeaseTable_Cursor INTO @TableName, @UserFunctionId, @UserTableId;
 END;
@@ -224,13 +225,14 @@ This log message is at the `Information` level, so make sure your log level is s
 
 ```sql
 -- Deletes the specified lease table and removes it from GlobalState table.
-USE <Insert DATABASE name here>;
+USE [<Insert DATABASE name here>]
+GO
 DECLARE @TableName NVARCHAR(MAX) = <Insert lease table name here>; -- e.g. '[az_func].[Leases_84d975fca0f7441a_901578250]
 DECLARE @UserFunctionId char(16) = <Insert function ID here>; -- e.g. '84d975fca0f7441a' the first section of the lease table name [Leases_84d975fca0f7441a_901578250].
 DECLARE @UserTableId int = <Insert table ID here>; -- e.g. '901578250' the second section of the lease table name [Leases_84d975fca0f7441a_901578250].
 PRINT N'Dropping table ' + @TableName;
 EXEC ('DROP TABLE IF EXISTS ' + @TableName);
-PRINT N'Removing row from GlobalState for UserFunctionID = ' + @UserFunctionId + ' and UserTableID = ' + @UserTableId;
+PRINT 'Removing row from GlobalState for UserFunctionID = ' + RTRIM(CAST(@UserFunctionId AS NVARCHAR(30))) + ' and UserTableID = ' + RTRIM(CAST(@UserTableId AS NVARCHAR(30)));
 DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId
 ```
 
@@ -238,7 +240,8 @@ DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserT
 
 ```sql
 -- Deletes all the lease tables and clears them from the GlobalState table.
-USE <Insert DATABASE name here>;
+USE [<Insert DATABASE name here>]
+GO
 DECLARE @TableName NVARCHAR(MAX);
 DECLARE @UserFunctionId char(16);
 DECLARE @UserTableId int;
@@ -255,7 +258,7 @@ WHILE @@FETCH_STATUS = 0
 BEGIN
     PRINT N'Dropping table ' + @TableName;
     EXEC ('DROP TABLE IF EXISTS ' + @TableName);
-    PRINT N'Removing row from GlobalState for UserFunctionID = ' + @UserFunctionId + ' and UserTableID = ' + @UserTableId;
+    PRINT 'Removing row from GlobalState for UserFunctionID = ' + RTRIM(CAST(@UserFunctionId AS NVARCHAR(30))) + ' and UserTableID = ' + RTRIM(CAST(@UserTableId AS NVARCHAR(30)));
     DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId
     FETCH NEXT FROM LeaseTable_Cursor INTO @TableName, @UserFunctionId, @UserTableId;
 END;

--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -175,16 +175,16 @@ UPDATE [Products].[az_func].[Leases_<FunctionId>_<TableId>] SET _az_func_Attempt
 Before clean up, please see [Leases table](./TriggerBinding.md#az_funcleases_) documentation for understanding how they are created and used.
 
 Why clean up?
-1. You renamed your function/class/method name and a new lease table is created making the old one obsolete for clean up.
-2. You have created multiple trigger functions that are obsolete which have associated tables that require cleaning up.
-3. You want to reset your environment and start afresh.
-There are many a reason that require cleaning to maintain our databases and since we currently don't handle that within the extension, below are some scripts that guide you through cleaning the leases table without them filling up the database.
+1. You renamed your function/class/method name, which causes a new lease table to be created and the old one to be obsolete.
+2. You created a trigger function that you no longer need and wish to clean up its associated data.
+3. You want to reset your environment.
+The Azure SQL Trigger does not currently handle cleaning up any leftover objects, and so to assist you with that we have provided the below scripts to help guide you through doing that.
 
-- Deletes all the lease tables that haven't been accessed in N days:
+- Delete all the lease tables that haven't been accessed in `@CleanupAgeDays` days:
 
 ```sql
--- Deletes all the lease tables that haven't been accesses in ? days(represented by @CleanupAgeDays variable and needs to defined before running the query).
--- And removes them from the GlobalState table.
+-- Deletes all the lease tables that haven't been accessed in @CleanupAgeDays days (set below)
+-- and removes them from the GlobalState table.
 USE <Insert DATABASE name here>;
 DECLARE @TableName NVARCHAR(MAX);
 DECLARE @UserFunctionId char(16);
@@ -212,9 +212,9 @@ CLOSE LeaseTable_Cursor;
 DEALLOCATE LeaseTable_Cursor;
 ```
 
-- Clean up a specific lease table concerning a specific function:
+- Clean up a specific lease table:
 
-To find the name of the leases table associated with your function, look in the log output for a line such as this which is emitted when the trigger is started.
+To find the name of the lease table associated with your function, look in the log output for a line such as this which is emitted when the trigger is started.
 
 `SQL trigger Leases table: [az_func].[Leases_84d975fca0f7441a_901578250]`
 
@@ -224,8 +224,8 @@ This log message is at the `Information` level, so make sure your log level is s
 -- Deletes the specified lease table and removes it from GlobalState table.
 USE <Insert DATABASE name here>;
 DECLARE @TableName NVARCHAR(MAX) = <Insert lease table name here>; -- e.g. '[az_func].[Leases_84d975fca0f7441a_901578250]
-DECLARE @UserFunctionId char(16) = <Insert function ID here>; -- e.g. '84d975fca0f7441a'
-DECLARE @UserTableId int = <Insert table ID here>; -- e.g. '901578250'
+DECLARE @UserFunctionId char(16) = <Insert function ID here>; -- e.g. '84d975fca0f7441a' the first section of the lease table name [Leases_84d975fca0f7441a_901578250].
+DECLARE @UserTableId int = <Insert table ID here>; -- e.g. '901578250' the second section of the lease table name [Leases_84d975fca0f7441a_901578250].
 
 DROP TABLE IF EXISTS @TableName
 DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId

--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -178,7 +178,7 @@ Why clean up?
 1. You renamed your function/class/method name, which causes a new lease table to be created and the old one to be obsolete.
 2. You created a trigger function that you no longer need and wish to clean up its associated data.
 3. You want to reset your environment.
-The Azure SQL Trigger does not currently handle cleaning up any leftover objects, and so to assist you with that we have provided the below scripts to help guide you through doing that.
+The Azure SQL Trigger does not currently handle automatically cleaning up any leftover objects, and so we have provided the below scripts to help guide you through doing that.
 
 - Delete all the lease tables that haven't been accessed in `@CleanupAgeDays` days:
 
@@ -202,7 +202,9 @@ FETCH NEXT FROM LeaseTable_Cursor INTO @TableName, @UserFunctionId, @UserTableId
 
 WHILE @@FETCH_STATUS = 0
 BEGIN
+    PRINT N'Dropping table ' + @TableName;
     EXEC ('DROP TABLE IF EXISTS ' + @TableName);
+    PRINT N'Removing row from GlobalState for UserFunctionID = ' + @UserFunctionId + ' and UserTableID = ' + @UserTableId;
     DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId
     FETCH NEXT FROM LeaseTable_Cursor INTO @TableName, @UserFunctionId, @UserTableId;
 END;
@@ -226,8 +228,9 @@ USE <Insert DATABASE name here>;
 DECLARE @TableName NVARCHAR(MAX) = <Insert lease table name here>; -- e.g. '[az_func].[Leases_84d975fca0f7441a_901578250]
 DECLARE @UserFunctionId char(16) = <Insert function ID here>; -- e.g. '84d975fca0f7441a' the first section of the lease table name [Leases_84d975fca0f7441a_901578250].
 DECLARE @UserTableId int = <Insert table ID here>; -- e.g. '901578250' the second section of the lease table name [Leases_84d975fca0f7441a_901578250].
-
-DROP TABLE IF EXISTS @TableName
+PRINT N'Dropping table ' + @TableName;
+EXEC ('DROP TABLE IF EXISTS ' + @TableName);
+PRINT N'Removing row from GlobalState for UserFunctionID = ' + @UserFunctionId + ' and UserTableID = ' + @UserTableId;
 DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId
 ```
 
@@ -250,7 +253,9 @@ FETCH NEXT FROM LeaseTable_Cursor INTO @TableName, @UserFunctionId, @UserTableId
 
 WHILE @@FETCH_STATUS = 0
 BEGIN
+    PRINT N'Dropping table ' + @TableName;
     EXEC ('DROP TABLE IF EXISTS ' + @TableName);
+    PRINT N'Removing row from GlobalState for UserFunctionID = ' + @UserFunctionId + ' and UserTableID = ' + @UserTableId;
     DELETE FROM az_func.GlobalState WHERE UserFunctionID = @UserFunctionId and UserTableID = @UserTableId
     FETCH NEXT FROM LeaseTable_Cursor INTO @TableName, @UserFunctionId, @UserTableId;
 END;

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -955,7 +955,7 @@ WHERE l.{LeasesTableChangeVersionColumnName} <= cte.{SysChangeVersionColumnName}
                 IF @unprocessed_changes = 0 AND @current_last_sync_version < {newLastSyncVersion}
                 BEGIN
                     UPDATE {GlobalStateTableName}
-                    SET LastSyncVersion = {newLastSyncVersion}
+                    SET LastSyncVersion = {newLastSyncVersion}, LastAccessTime = GETDATE()
                     WHERE UserFunctionID = '{this._userFunctionId}' AND UserTableID = {this._userTableId};
 
                     DELETE FROM {this._leasesTableName} WHERE {LeasesTableChangeVersionColumnName} <= {newLastSyncVersion};

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -955,7 +955,7 @@ WHERE l.{LeasesTableChangeVersionColumnName} <= cte.{SysChangeVersionColumnName}
                 IF @unprocessed_changes = 0 AND @current_last_sync_version < {newLastSyncVersion}
                 BEGIN
                     UPDATE {GlobalStateTableName}
-                    SET LastSyncVersion = {newLastSyncVersion}, LastAccessTime = GETDATE()
+                    SET LastSyncVersion = {newLastSyncVersion}, LastAccessTime = GETUTCDATE()
                     WHERE UserFunctionID = '{this._userFunctionId}' AND UserTableID = {this._userTableId};
 
                     DELETE FROM {this._leasesTableName} WHERE {LeasesTableChangeVersionColumnName} <= {newLastSyncVersion};

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -323,6 +323,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         LastSyncVersion bigint NOT NULL,
                         PRIMARY KEY (UserFunctionID, UserTableID)
                     );
+                ELSE IF NOT EXISTS(SELECT 1 FROM sys.columns WHERE Name = N'LastAccessTime'
+                    AND Object_ID = Object_ID(N'{GlobalStateTableName}'))
+                        ALTER TABLE {GlobalStateTableName} ADD LastAccessTime Datetime NULL;
             ";
 
             using (var createGlobalStateTableCommand = new SqlCommand(createGlobalStateTableQuery, connection, transaction))

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -321,6 +321,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         UserFunctionID char(16) NOT NULL,
                         UserTableID int NOT NULL,
                         LastSyncVersion bigint NOT NULL,
+                        LastAccessTime Datetime NULL,
                         PRIMARY KEY (UserFunctionID, UserTableID)
                     );
                 ELSE IF NOT EXISTS(SELECT 1 FROM sys.columns WHERE Name = N'LastAccessTime'

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -321,12 +321,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         UserFunctionID char(16) NOT NULL,
                         UserTableID int NOT NULL,
                         LastSyncVersion bigint NOT NULL,
-                        LastAccessTime Datetime NULL,
+                        LastAccessTime Datetime NOT NULL DEFAULT GETUTCDATE(),
                         PRIMARY KEY (UserFunctionID, UserTableID)
                     );
                 ELSE IF NOT EXISTS(SELECT 1 FROM sys.columns WHERE Name = N'LastAccessTime'
                     AND Object_ID = Object_ID(N'{GlobalStateTableName}'))
-                        ALTER TABLE {GlobalStateTableName} ADD LastAccessTime Datetime NULL;
+                        ALTER TABLE {GlobalStateTableName} ADD LastAccessTime Datetime NOT NULL DEFAULT GETUTCDATE();
             ";
 
             using (var createGlobalStateTableCommand = new SqlCommand(createGlobalStateTableQuery, connection, transaction))
@@ -394,7 +394,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     WHERE UserFunctionID = '{this._userFunctionId}' AND UserTableID = {userTableId}
                 )
                     INSERT INTO {GlobalStateTableName}
-                    VALUES ('{this._userFunctionId}', {userTableId}, {(long)minValidVersion});
+                    VALUES ('{this._userFunctionId}', {userTableId}, {(long)minValidVersion}, GETUTCDATE());
             ";
 
             using (var insertRowGlobalStateTableCommand = new SqlCommand(insertRowGlobalStateTableQuery, connection, transaction))


### PR DESCRIPTION
Added LastAccessTime Datetime column to the GlobalState table. For accommodating existing triggers, added the column with default getutcdate() value.

Added the clean up scripts to the BindingsOveriew doc, I could move them over to a more appropriate place if folks have better suggestions.