### PR TITLE
Backport fix for nuget packaging during build

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -44,6 +44,6 @@ stages:
       parameters:
         solution: '$(solution)'
         configuration: '$(configuration)'
-        nugetVersion: '1.0.0-test'
-        binariesVersion: '1.0.0'
-        supportedVersion: '1.*-*'
+        nugetVersion: '99.99.99-test'
+        binariesVersion: '99.99.99'
+        supportedVersion: '99.99.99'

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -36,7 +36,7 @@
   <Target Name="PackAndCopyNupkg" AfterTargets="Build">
     <!-- Removed the GeneratePackageOnBuild and adding this explicit Pack command to run post build
     and also adding the copy package to local-packages to be available for the worker extension project. -->
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\$(PackageId).csproj&quot; --no-build --include-symbols" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\$(PackageId).csproj&quot; --no-build --include-symbols -p:Version=$(Version)" />
     <ItemGroup>
       <_Packages Include=".\bin\$(Configuration)\*.nupkg" />
     </ItemGroup>
@@ -44,7 +44,7 @@
     <Message Text="Copied sql .nupkg to local-packages" Importance="high" />
   </Target>
   <Target Name="RemoveNugetPackageCache" BeforeTargets="Build">
-    <RemoveDir Directories="$(NugetPackageRoot)\$(PackageId.ToLower())\99.99.99"></RemoveDir>
-    <Message Text="Deleted nuget cache for $(PackageId.ToLower())\99.99.99" Importance="high" />
+    <RemoveDir Directories="$(NugetPackageRoot)\$(PackageId.ToLower())\$(Version)"></RemoveDir>
+    <Message Text="Deleted nuget cache for $(PackageId.ToLower())\$(Version)" Importance="high" />
   </Target>
 </Project>


### PR DESCRIPTION
Fixes two issues: 

* It was hardcoded to 99.99.99 for the package version, but that is going to be different in the pipelines. We should use the actual version instead
* We need to pass the correct version to the dotnet pack call as well, otherwise it'll always use the default 99.99.99 (which then causes failures later as it tries to find the package version from the pipeline, e.g. 1.x/2.x)

See https://github.com/Azure/azure-functions-sql-extension/pull/868#issuecomment-1574172708 for full explanation of why this wasn't caught earlier and what issues it causes. 