### PR TITLE
GetLeaseLockedRows for debug logging

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -390,6 +390,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         GetColumnDefinitionsDurationMs,
         GetPrimaryKeysDurationMs,
         GetUnprocessedChangesDurationMs,
+        GetLockedRowCountDurationMs,
         InsertGlobalStateTableRowDurationMs,
         MaxBatchSize,
         MaxChangesPerWorker,
@@ -437,6 +438,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         Upsert,
         UpsertRollback,
         GetServerTelemetryProperties,
+        GetLeaseLockedRowCount,
     }
 
     internal class ServerProperties

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                             getChangesDurationMs = commandSw.ElapsedMilliseconds;
                         }
                         // Log the number of rows
-                        //this._logger.LogDebug($"Executed GetChanges in GetTableChanges. Total changes: {rows.Count} Locked rows: {rows.FindAll(x => from n in x where (n.Value.isLeaseLocked = 1 select n.Value)}");
+                        this._logger.LogDebug($"Executed GetChanges in GetTableChanges. Total changes: {rows.Count} Locked rows: {rows.FindAll(dict => dict.ContainsKey("IsLeaseLocked") && (int)dict["IsLeaseLocked"] == 1).Count}");
 
                         // If changes were found, acquire leases on them.
                         if (rows.Count > 0)

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -814,7 +814,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Returns the query to get for number of changes(rows) on the user's table that are actively locked by other leases.
+        /// Returns the number of changes(rows) on the user's table that are actively locked by other leases.
         /// </summary>
         /// <param name="connection">The connection to add to the SqlCommand</param>
         /// <param name="transaction">The transaction to add to the SqlCommand</param>

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -816,8 +816,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <summary>
         /// Returns the query to get for number of changes(rows) on the user's table that are actively locked by other leases.
         /// </summary>
-        /// <param name="connection">The connection to add to the returned SqlCommand</param>
-        /// <param name="transaction">The transaction to add to the returned SqlCommand</param>
+        /// <param name="connection">The connection to add to the SqlCommand</param>
+        /// <param name="transaction">The transaction to add to the SqlCommand</param>
         /// <returns>The number of rows locked by leases</returns>
         private async Task<int> GetLeaseLockedRowCount(SqlConnection connection, SqlTransaction transaction)
         {
@@ -846,10 +846,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 SELECT COUNT(*)
                 FROM CHANGETABLE(CHANGES {this._userTable.BracketQuotedFullName}, @last_sync_version) AS c
                 LEFT OUTER JOIN {this._leasesTableName} AS l ON {leasesTableJoinCondition}
-                LEFT OUTER JOIN {this._userTable.BracketQuotedFullName} AS u ON {userTableJoinCondition}
-                WHERE
-                    l.{LeasesTableLeaseExpirationTimeColumnName} IS NOT NULL AND
-                        l.{LeasesTableLeaseExpirationTimeColumnName} > SYSDATETIME()";
+                WHERE l.{LeasesTableLeaseExpirationTimeColumnName} IS NOT NULL AND l.{LeasesTableLeaseExpirationTimeColumnName} > SYSDATETIME()";
 
             using (var getLeaseLockedRowCountCommand = new SqlCommand(getLeaseLockedrowCountQuery, connection, transaction))
             {

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -857,6 +857,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 this._logger.LogError($"Failed to query count of lease locked changes for table '{this._userTable.FullName}' due to exception: {ex.GetType()}. Exception message: {ex.Message}");
                 TelemetryInstance.TrackException(TelemetryErrorName.GetLeaseLockedRowCount, ex, null, new Dictionary<TelemetryMeasureName, double>() { { TelemetryMeasureName.GetLockedRowCountDurationMs, getLockedRowCountDurationMs } });
+                // This is currently only used for debugging, so return a -1 instead of throwing since it isn't necessary to get the value
                 leaseLockedRowsCount = -1;
             }
             return leaseLockedRowsCount;

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -300,7 +300,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                             {
                                 while (await reader.ReadAsync(token))
                                 {
-                                    if ((bool)reader["IsLeaseLocked"])
+                                    if ((int)reader["IsLeaseLocked"] == 1)
                                     {
                                         leaseLockedRowCount++;
                                     }
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                             getChangesDurationMs = commandSw.ElapsedMilliseconds;
                         }
                         // Log the number of rows
-                        this._logger.LogDebug($"Executed GetChangesCommand in GetTableChangesAsync. Total changes: {rows.Count + leaseLockedRowCount} Locked rows: {leaseLockedRowCount}");
+                        this._logger.LogDebug($"Executed GetChangesCommand in GetTableChangesAsync. {rows.Count + leaseLockedRowCount} available changed rows ({leaseLockedRowCount} found with lease locks).");
 
                         // If changes were found, acquire leases on them.
                         if (rows.Count > 0)

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -829,7 +829,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             // Get the count of changes from CHANGETABLE that meet the following criteria:
             // * Not Null LeaseExpirationTime AND
             // * LeaseExpirationTime > Current Time
-            //
             string getLeaseLockedrowCountQuery = $@"
                 {AppLockStatements}
 

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -821,7 +821,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <returns>The number of rows locked by leases</returns>
         private async Task<int> GetLeaseLockedRowCount(SqlConnection connection, SqlTransaction transaction)
         {
-            string userTableJoinCondition = string.Join(" AND ", this._primaryKeyColumns.Select(col => $"c.{col.name.AsBracketQuotedString()} = u.{col.name.AsBracketQuotedString()}"));
             string leasesTableJoinCondition = string.Join(" AND ", this._primaryKeyColumns.Select(col => $"c.{col.name.AsBracketQuotedString()} = l.{col.name.AsBracketQuotedString()}"));
             int leaseLockedRows = 0;
             long getLockedRowCountDurationMs = 0L;

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -814,11 +814,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Builds the query to check for changes on the user's table (<see cref="RunChangeConsumptionLoopAsync()"/>).
+        /// Returns the query to get for number of changes(rows) on the user's table that are actively locked by other leases.
         /// </summary>
         /// <param name="connection">The connection to add to the returned SqlCommand</param>
         /// <param name="transaction">The transaction to add to the returned SqlCommand</param>
-        /// <returns>The SqlCommand populated with the query and appropriate parameters</returns>
+        /// <returns>The number of rows locked by leases</returns>
         private async Task<int> GetLeaseLockedRowCount(SqlConnection connection, SqlTransaction transaction)
         {
             string userTableJoinCondition = string.Join(" AND ", this._primaryKeyColumns.Select(col => $"c.{col.name.AsBracketQuotedString()} = u.{col.name.AsBracketQuotedString()}"));
@@ -858,7 +858,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 getLockedRowCountDurationMs = commandSw.ElapsedMilliseconds;
             }
             return leaseLockedRows;
-
         }
 
         /// <summary>


### PR DESCRIPTION
Added IsLeaseLocked for #437 

Can improve it to add a check for only getting all the rows when log level is debug, will look into that but for now adding this in the normal flow.