### PR TITLE
add SqlClientListener for diagnostic logging 

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -27,7 +27,7 @@ Needs Connection Logs:
   comment: |
     We need more info to debug your particular issue. If you could attach your SQL Client logs to the issue, it would help us fix the issue much faster.
 
-    1. Set the AzureFunctions_SqlBindings_VerboseLogging to `true` in your `*.settings.json` file.
+    1. Set the AzureFunctions_SqlBindings_VerboseLogging to `true` in your `*.settings.json` file or your Function App settings.
 
     ```json
     {
@@ -41,14 +41,14 @@ Needs Connection Logs:
     }
     ```
 
-    2. Set the default logging level to `Debug` and enable logging to a file. To do this ensure the following entries are in your `host.json`. ([instructions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring?tabs=v2#configure-log-levels))
+    2. Set the default logging level to `Trace` and enable logging to a file. To do this ensure the following entries are in your `host.json`. ([instructions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring?tabs=v2#configure-log-levels))
 
     ```json
     {
       "logging": {
         "fileLoggingMode": "always",
         "logLevel": {
-          "default": "Debug"
+          "default": "Trace"
         }
       }
     }

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -2,6 +2,7 @@
 Needs Logs:
   comment: |
     We need more info to debug your particular issue. If you could attach your logs to the issue, it would help us fix the issue much faster.
+    Note that these instructions are for local development only.
 
     1. Set the default logging level to `Debug` and enable logging to a file. To do this ensure the following entries are in your `host.json`. ([instructions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring?tabs=v2#configure-log-levels))
 
@@ -26,8 +27,9 @@ Needs Logs:
 Needs Connection Logs:
   comment: |
     We need more info to debug your particular issue. If you could attach your SQL Client logs to the issue, it would help us fix the issue much faster.
+    Note that these instructions are for local development only.
 
-    1. Set the AzureFunctions_SqlBindings_VerboseLogging to `true` in your `*.settings.json` file or your Function App settings.
+    1. Set the AzureFunctions_SqlBindings_VerboseLogging to `true` in your `*.settings.json` file.
 
     ```json
     {

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -21,3 +21,41 @@ Needs Logs:
     3. Get the log file and attach it to this issue. By default this will be in `%TMP%/LogFiles/Application/Functions/Host`.
 
     **NOTE** Debug logging will include information such as Database and table names, if you do not wish to include this information you can either redact it from the logs before attaching or let us know and we will provide a way to send logs directly to us.
+
+#actions for Needs Connection Logs
+Needs Connection Logs:
+  comment: |
+    We need more info to debug your particular issue. If you could attach your SQL Client logs to the issue, it would help us fix the issue much faster.
+
+    1. Set the AzureFunctions_SqlBindings_VerboseLogging to `true` in your `*.settings.json` file.
+
+    ```json
+    {
+    "IsEncrypted": false,
+    "Values": {
+      "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+      "FUNCTIONS_WORKER_RUNTIME": "<dotnet>",
+      "SqlConnectionString": "<Your Connection string>",
+      "AzureFunctions_SqlBindings_VerboseLogging": "true",
+    }
+    }
+    ```
+
+    2. Set the default logging level to `Debug` and enable logging to a file. To do this ensure the following entries are in your `host.json`. ([instructions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring?tabs=v2#configure-log-levels))
+
+    ```json
+    {
+      "logging": {
+        "fileLoggingMode": "always",
+        "logLevel": {
+          "default": "Debug"
+        }
+      }
+    }
+    ```
+
+    3. Restart your function and reproduce your issue
+
+    4. Get the log file and attach it to this issue. By default this will be in `%TMP%/LogFiles/Application/Functions/Host`.
+
+    **NOTE** Debug logging will include information such as Database and table names, if you do not wish to include this information you can either redact it from the logs before attaching or let us know and we will provide a way to send logs directly to us.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   - [Known/By Design Issues](#knownby-design-issues)
     - [Output Bindings](#output-bindings)
   - [Telemetry](#telemetry)
+  - [Troubleshooting](#troubleshooting)
   - [Privacy Statement](#privacy-statement)
   - [Trademarks](#trademarks)
 
@@ -70,6 +71,10 @@ Below is a list of common issues that users may run into when using the SQL Bind
 ## Telemetry
 
 This extension collects usage data in order to help us improve your experience. The data is anonymous and doesn't include any personal information. You can opt-out of telemetry by setting the `AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT` environment variable or the `AzureFunctionsSqlBindingsTelemetryOptOut` app setting (in your `*.settings.json` file) to '1', 'true' or 'yes';
+
+## Troubleshooting
+
+For troubleshooting SQL Client issues, You can enable verbose logging by setting the `AzureFunctions_SqlBindings_VerboseLogging` app setting (in your `*.settings.json` file) to '1', 'true' or 'yes';
 
 ## Privacy Statement
 

--- a/src/SqlBindingConfigProvider.cs
+++ b/src/SqlBindingConfigProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly IConfiguration _configuration;
         private readonly ILoggerFactory _loggerFactory;
         private SqlClientListener sqlClientListener;
-        public const string VerboseLogging = "VerboseLogging";
+        public const string VerboseLoggingSettingName = "AzureFunctions_SqlBindings_VerboseLogging";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlBindingConfigProvider"/> class.
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             TelemetryInstance.Initialize(this._configuration, logger);
             // Only enable SQL Client logging when VerboseLogging is set in the config to avoid extra overhead when the
             // detailed logging it provides isn't needed
-            if (this.sqlClientListener == null && Utils.GetConfigSettingAsBool(VerboseLogging, this._configuration))
+            if (this.sqlClientListener == null && Utils.GetConfigSettingAsBool(VerboseLoggingSettingName, this._configuration))
             {
                 this.sqlClientListener = new SqlClientListener();
             }

--- a/src/SqlBindingConfigProvider.cs
+++ b/src/SqlBindingConfigProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly IConfiguration _configuration;
         private readonly ILoggerFactory _loggerFactory;
         private SqlClientListener sqlClientListener;
+        public const string VerboseLogging = "VerboseLogging";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlBindingConfigProvider"/> class.
@@ -57,7 +58,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             TelemetryInstance.Initialize(this._configuration, logger);
             // Only enable SQL Client logging when VerboseLogging is set in the config to avoid extra overhead when the
             // detailed logging it provides isn't needed
-            if (this.sqlClientListener == null && Utils.GetConfigSettingAsBool("VerboseLogging", this._configuration))
+            if (this.sqlClientListener == null && Utils.GetConfigSettingAsBool(VerboseLogging, this._configuration))
             {
                 this.sqlClientListener = new SqlClientListener();
             }

--- a/src/SqlBindingConfigProvider.cs
+++ b/src/SqlBindingConfigProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             // detailed logging it provides isn't needed
             if (this.sqlClientListener == null && Utils.GetConfigSettingAsBool(VerboseLoggingSettingName, this._configuration))
             {
-                this.sqlClientListener = new SqlClientListener();
+                this.sqlClientListener = new SqlClientListener(logger);
             }
             LogDependentAssemblyVersions(logger);
 #pragma warning disable CS0618 // Fine to use this for our stuff

--- a/src/SqlClientEventListener.cs
+++ b/src/SqlClientEventListener.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Diagnostics.Tracing;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
+using System;
+
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql
+{
+
+    /// <summary>
+    /// This listener class will listen for events from the SqlClientEventSource class
+    /// and forward them to the logger.
+    /// </summary>
+    public class SqlClientListener : EventListener
+    {
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            // Only enable events from SqlClientEventSource.
+            if (string.CompareOrdinal(eventSource.Name, "Microsoft.Data.SqlClient.EventSource") == 0)
+            {
+                // Use EventKeyWord 2 to capture basic application flow events.
+                // See https://docs.microsoft.com/sql/connect/ado-net/enable-eventsource-tracing for all available keywords.
+                this.EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)2);
+            }
+        }
+
+        /// <summary>
+        /// This callback runs whenever an event is written by SqlClientEventSource.
+        /// Event data is accessed through the EventWrittenEventArgs parameter.
+        /// </summary>
+        /// <param name="eventData">The data for the event</param>
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            try
+            {
+                if (eventData.Payload == null)
+                {
+                    return;
+                }
+                object[] values = new object[eventData.Payload.Count];
+                string[] keys = new string[eventData.PayloadNames.Count];
+
+                eventData.PayloadNames.CopyTo(keys, 0);
+                eventData.Payload.CopyTo(values, 0);
+                var payloadDictionary = keys.Select((k, i) => new { k, v = values[i].ToString() })
+                  .ToDictionary(x => x.k, x => x.v);
+                foreach (object payload in eventData.Payload)
+                {
+                    if (payload != null)
+                    {
+                        TelemetryInstance.TrackSQLClientEvent(eventData.EventName, payloadDictionary);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                TelemetryInstance.TrackException(Telemetry.TelemetryErrorName.SqlClientListenerOnEventWritten, e);
+            }
+        }
+    }
+}

--- a/src/SqlClientEventListener.cs
+++ b/src/SqlClientEventListener.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Diagnostics.Tracing;
 using System;
 using Microsoft.Extensions.Logging;

--- a/src/SqlClientEventListener.cs
+++ b/src/SqlClientEventListener.cs
@@ -46,24 +46,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     return;
                 }
-                object[] values = new object[eventData.Payload.Count];
-                string[] keys = new string[eventData.PayloadNames.Count];
 
-                eventData.PayloadNames.CopyTo(keys, 0);
-                eventData.Payload.CopyTo(values, 0);
-                var payloadDictionary = keys.Select((k, i) => new { k, v = values[i].ToString() })
-                  .ToDictionary(x => x.k, x => x.v);
                 foreach (object payload in eventData.Payload)
                 {
                     if (payload != null)
                     {
-                        this._logger.LogTrace($"Sending event {eventData.EventName}. Properties: {Utils.JsonSerializeObject(payloadDictionary)}");
+                        this._logger.LogTrace($"EventID {eventData.EventId}. Payload: {payload}");
                     }
                 }
             }
             catch (Exception ex)
             {
-                this._logger.LogError($"Error sending event {eventData.EventName}. Message={ex.Message}");
+                this._logger.LogError($"Error logging SqlClient event {eventData.EventName}. Message={ex.Message}");
 
             }
         }

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -122,6 +122,26 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
             }
         }
 
+        public void TrackSQLClientEvent(string eventName, IDictionary<string, string> properties = null)
+        {
+            try
+            {
+                if (!this._initialized || !this.Enabled || this._client is null)
+                {
+                    return;
+                }
+                this._logger.LogTrace($"Sending event {eventName}");
+
+                this._client.TrackEvent($"{EventsNamespace}/{eventName}", properties, null);
+                this._client.Flush();
+            }
+            catch (Exception ex)
+            {
+                // We don't want errors sending telemetry to break the app, so just log and move on
+                this._logger.LogError($"Error sending event {eventName}. Message={ex.Message}");
+            }
+        }
+
         public void TrackException(TelemetryErrorName errorName, Exception exception, IDictionary<TelemetryPropertyName, string> properties = null,
             IDictionary<TelemetryMeasureName, double> measurements = null)
         {
@@ -438,6 +458,8 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         Upsert,
         UpsertRollback,
         GetServerTelemetryProperties,
+        SqlClientListenerOnEventWritten,
+
     }
 
     internal class ServerProperties

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -130,10 +130,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
                 {
                     return;
                 }
-                this._logger.LogTrace($"Sending event {eventName}");
-
-                this._client.TrackEvent($"{EventsNamespace}/{eventName}", properties, null);
-                this._client.Flush();
+                this._logger.LogTrace($"Sending event {eventName}. Properties: {Utils.JsonSerializeObject(properties)}");
             }
             catch (Exception ex)
             {

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -122,23 +122,6 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
             }
         }
 
-        public void TrackSQLClientEvent(string eventName, IDictionary<string, string> properties = null)
-        {
-            try
-            {
-                if (!this._initialized || !this.Enabled || this._client is null)
-                {
-                    return;
-                }
-                this._logger.LogTrace($"Sending event {eventName}. Properties: {Utils.JsonSerializeObject(properties)}");
-            }
-            catch (Exception ex)
-            {
-                // We don't want errors sending telemetry to break the app, so just log and move on
-                this._logger.LogError($"Error sending event {eventName}. Message={ex.Message}");
-            }
-        }
-
         public void TrackException(TelemetryErrorName errorName, Exception exception, IDictionary<TelemetryPropertyName, string> properties = null,
             IDictionary<TelemetryMeasureName, double> measurements = null)
         {

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -438,8 +438,6 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         Upsert,
         UpsertRollback,
         GetServerTelemetryProperties,
-        SqlClientListenerOnEventWritten,
-
     }
 
     internal class ServerProperties


### PR DESCRIPTION
To enable the sql client logging, user needs to add the VerboseLogging and set it to true in config settings.
(Followed the implementation in sql tools service https://github.com/microsoft/sqltoolsservice/pull/1544)

For #810 