### PR TITLE
Fix test task timeout in build pipeline

### DIFF
--- a/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
@@ -90,17 +90,25 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                     }
                     catch (Exception ex)
                     {
-                        throw new InvalidOperationException($"Exception deserializing JSON content. Error={ex.Message} Json=\"{json}\"", ex);
+                        taskCompletion.SetException(new InvalidOperationException($"Exception deserializing JSON content. Error={ex.Message} Json=\"{json}\"", ex));
+                        return;
                     }
-                    foreach (SqlChange<Product> change in changes)
+                    try
                     {
-                        Assert.Equal(operation, change.Operation); // Expected change operation
-                        Product product = change.Item;
-                        Assert.NotNull(product); // Product deserialized correctly
-                        Assert.Contains(product.ProductId, expectedIds); // We haven't seen this product ID yet, and it's one we expected to see
-                        expectedIds.Remove(product.ProductId);
-                        Assert.Equal(getName(product.ProductId), product.Name); // The product has the expected name
-                        Assert.Equal(getCost(product.ProductId), product.Cost); // The product has the expected cost
+                        foreach (SqlChange<Product> change in changes)
+                        {
+                            Assert.Equal(operation, change.Operation); // Expected change operation
+                            Product product = change.Item;
+                            Assert.NotNull(product); // Product deserialized correctly
+                            Assert.Contains(product.ProductId, expectedIds); // We haven't seen this product ID yet, and it's one we expected to see
+                            expectedIds.Remove(product.ProductId);
+                            Assert.Equal(getName(product.ProductId), product.Name); // The product has the expected name
+                            Assert.Equal(getCost(product.ProductId), product.Cost); // The product has the expected cost
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        taskCompletion.SetException(ex);
                     }
                     if (expectedIds.Count == 0)
                     {


### PR DESCRIPTION
Exceptions thrown in [MonitorOutputData handler](https://github.com/Azure/azure-functions-sql-extension/blob/46ebda53bf4441906ffe60ee667b02af470c5100/test/Integration/SqlTriggerBindingIntegrationTestBase.cs#L77) was causing the test host to crash and the pipeline test task to timeout.

It is recommended to not throw exceptions inside handlers. Updated the handler to use TaskCompletionSource.SetException and I verified locally that exceptions get propagated up correctly.
```
  Failed Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlTriggerBindingIntegrationTests.MultiOperationTriggerTest(lang: PowerShell) [11 s]
  Error Message:
   Assert.Equal() Failure: Strings differ
           ↓ (pos 0)
Expected: "0"
Actual:   "1"
           ↑ (pos 0)
  Stack Trace:
     at Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlTriggerBindingIntegrationTestBase.<>c__DisplayClass5_0.<WaitForProductChanges>g__MonitorOutputData|0(Object sender, DataReceivedEventArgs e) in /Users/lucyzhang/GitProjects/azure-functions-sql-extension/test/Integration/SqlTriggerBindingIntegrationTestBase.cs:line 107
--- End of stack trace from previous location ---
   at Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common.TestUtils.TimeoutAfter[TResult](Task`1 task, TimeSpan timeout, String message) in /Users/lucyzhang/GitProjects/azure-functions-sql-extension/test/Common/TestUtils.cs:line 314
   at Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlTriggerBindingIntegrationTestBase.WaitForProductChanges(Int32 firstId, Int32 lastId, SqlChangeOperation operation, Func`1 actions, Func`2 getName, Func`2 getCost, Int32 timeoutMs, String messagePrefix) in /Users/lucyzhang/GitProjects/azure-functions-sql-extension/test/Integration/SqlTriggerBindingIntegrationTestBase.cs:line 131
   at Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlTriggerBindingIntegrationTests.MultiOperationTriggerTest(SupportedLanguages lang) in /Users/lucyzhang/GitProjects/azure-functions-sql-extension/test/Integration/SqlTriggerBindingIntegrationTests.cs:line 219
```
