### PR TITLE
Align the worker package to Sql package

### DIFF
--- a/Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj
+++ b/Worker.Extensions.Sql/src/Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj
@@ -7,7 +7,7 @@
 		<Product>SQL Binding Worker</Product>
 		<!-- Default Version for dev -->
 		<Version>99.99.99</Version>
-		<SupportedVersion>99.99.99</SupportedVersion>
+		<OOPWorkerSupportedExtensionVersion>99.99.99</OOPWorkerSupportedExtensionVersion>
 		<PackageId>Microsoft.Azure.Functions.Worker.Extensions.Sql</PackageId>
 		<PackageTags>Microsoft Azure WebJobs AzureFunctions Isolated DotnetIsolated SQL AzureSQL Worker</PackageTags>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -34,7 +34,7 @@
 	<ItemGroup>
 		<AssemblyAttribute Include="Microsoft.Azure.Functions.Worker.Extensions.Abstractions.ExtensionInformationAttribute">
 			<_Parameter1>Microsoft.Azure.WebJobs.Extensions.Sql</_Parameter1>
-			<_Parameter2>$(SupportedVersion)</_Parameter2>
+			<_Parameter2>$(OOPWorkerSupportedExtensionVersion)</_Parameter2>
 		</AssemblyAttribute>
 	</ItemGroup>
 </Project>

--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -46,4 +46,4 @@ stages:
         configuration: '$(configuration)'
         nugetVersion: '99.99.99-test'
         binariesVersion: '99.99.99'
-        supportedVersion: '99.99.99'
+        oopWorkerSupportedExtensionVersion: '99.99.99'

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -28,7 +28,7 @@ variables:
   versionPatch: $[counter(variables['versionMajorMinor'], 0)] # This will reset when we bump minor version
   binariesVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
   nugetVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(binariesVersion)'),'True','$(binariesVersion)-preview')] # This will set the preview tag to the version based on the ReleaseType parameter.
-  supportedVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(versionMajor).*'),'True','$(versionMajor).*-*')] # This will set the expression to pull the preview vs full version based on the ReleaseType parameter.
+  supportedVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(versionMajor).$(versionMinor)'),'True','$(versionMajor).$(versionMinor)-preview')] # This will set the expression to pull the preview vs full version based on the ReleaseType parameter.
   LGTM.UploadSnapshot: true
   Semmle.SkipAnalysis: true
 

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -28,7 +28,7 @@ variables:
   versionPatch: $[counter(variables['versionMajorMinor'], 0)] # This will reset when we bump minor version
   binariesVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
   nugetVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(binariesVersion)'),'True','$(binariesVersion)-preview')] # This will set the preview tag to the version based on the ReleaseType parameter.
-  supportedVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(binariesVersion)'),'True','$(binariesVersion)-preview')] # This will set the expression to pull the preview vs full version based on the ReleaseType parameter.
+  oopWorkerSupportedExtensionVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(binariesVersion)'),'True','$(binariesVersion)-preview')] # This will set the expression to pull the preview vs full version based on the ReleaseType parameter.
   LGTM.UploadSnapshot: true
   Semmle.SkipAnalysis: true
 
@@ -67,7 +67,7 @@ stages:
           configuration: '$(configuration)'
           nugetVersion: '$(nugetVersion)'
           binariesVersion: '$(binariesVersion)'
-          supportedVersion: '$(supportedVersion)'
+          oopWorkerSupportedExtensionVersion: '$(oopWorkerSupportedExtensionVersion)'
 
   - job: BuildTestPublishLinux
     displayName: 'Build, Test and Publish on linux'
@@ -87,7 +87,7 @@ stages:
           configuration: '$(configuration)'
           nugetVersion: '$(nugetVersion)'
           binariesVersion: '$(binariesVersion)'
-          supportedVersion: '$(supportedVersion)'
+          oopWorkerSupportedExtensionVersion: '$(oopWorkerSupportedExtensionVersion)'
           testServer: ''
 
       - template: 'template-steps-publish.yml'

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -28,7 +28,7 @@ variables:
   versionPatch: $[counter(variables['versionMajorMinor'], 0)] # This will reset when we bump minor version
   binariesVersion: '$(versionMajor).$(versionMinor).$(versionPatch)'
   nugetVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(binariesVersion)'),'True','$(binariesVersion)-preview')] # This will set the preview tag to the version based on the ReleaseType parameter.
-  supportedVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(versionMajor).$(versionMinor)'),'True','$(versionMajor).$(versionMinor)-preview')] # This will set the expression to pull the preview vs full version based on the ReleaseType parameter.
+  supportedVersion: $[replace(replace('True', eq('${{ parameters.ReleaseType }}', 'full'), '$(binariesVersion)'),'True','$(binariesVersion)-preview')] # This will set the expression to pull the preview vs full version based on the ReleaseType parameter.
   LGTM.UploadSnapshot: true
   Semmle.SkipAnalysis: true
 

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -4,7 +4,7 @@ parameters:
   nugetVersion: ''
   binariesVersion: ''
   testServer: ''
-  supportedVersion: ''
+  oopWorkerSupportedExtensionVersion: ''
 
 steps:
 - task: UseDotNet@2
@@ -92,7 +92,7 @@ steps:
   inputs:
     command: build
     projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:SupportedVersion=${{ parameters.binariesVersion }}
+    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.binariesVersion }}
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
@@ -224,7 +224,7 @@ steps:
   inputs:
     command: build
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }} -p:SupportedVersion=${{ parameters.supportedVersion }}'
+    arguments: '--configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=false -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }}'
 
 # 5.0 isn't supported on Mac yet
 - task: UseDotNet@2


### PR DESCRIPTION
We have given a range for the SQL webjobs package dependency of the Worker and that could cause issues when we have multiple package releases targeting different versions.
Ex scenario: [3.0.343-preview](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Sql/3.0.343-preview)  worker package has dependency on [3.0.343-preview](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Sql/3.0.343-preview) Web Jobs package
Since we gave a range for that dependency, when customer runs the 3.0.343-preview worker package, it can pull the 3.0.399-preview SQL web jobs package which has all the package upgrades and could cause issues.

In order to avoid this, am removing the range and coupling it with the webjobs package version. What this entails is that every time we release the webjobs, we release the corresponding worker package as well. I'll make changes to the Release pipeline to release both the packages every time.
