### PR TITLE
Revert back to Pylint 2.x

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -131,6 +131,7 @@ steps:
 
 - script: |
     pip3 install pylint_runner
+    pip3 install 'pylint<3.0'
     pip3 install pylintfileheader
     pylint_runner
   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -130,7 +130,7 @@ steps:
     architecture: 'x64'
 
 - script: |
-    pip3 install pylint
+    pip3 install "pylint<3.0"
     pip3 install pylintfileheader
     pylint --recursive=yes .
   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -130,10 +130,9 @@ steps:
     architecture: 'x64'
 
 - script: |
-    pip3 install pylint_runner
-    pip3 install 'pylint<3.0'
+    pip3 install pylint
     pip3 install pylintfileheader
-    pylint_runner
+    pylint --recursive=yes .
   workingDirectory: $(Build.SourcesDirectory)/samples/samples-python
   displayName: Lint samples-python
 


### PR DESCRIPTION
Reverting back to pylint 2.x.

3.x introduced a bunch of breaking changes: https://github.com/pylint-dev/pylint/releases/tag/v3.0.0

The two packages that we were dependent on here (pylint_runner and pylintfileheader) are not compatible with pylint 3.x due to these changes.

I've managed to work around needing to use pylint_runner by passing in `"yes"` for the `recursive` parameter, but pylintfileheader (which, as its name suggests, looks to ensure that file headers exist) does not have similiar functionality baked into pylint itself. Filed bug in pylintfileheader repo here: https://github.com/HaaLeo/pylint-file-header/issues/6

For now, to unblock builds, reverting back to pylint 2.x.