### PR TITLE
add baselines json

### DIFF
--- a/performance/PerformanceBaselines.json
+++ b/performance/PerformanceBaselines.json
@@ -1,0 +1,79 @@
+{
+    "PerformanceRuntime": {
+        "InputBinding": {
+            "TestName": "GetProductsTest",
+            "RunTimeAverage": 2.081
+        },
+        "OutputBinding": {
+            "TestName": "AddProductsArrayTest",
+            "RunTimeAverage": 2.055
+        },
+        "TriggerBinding": [
+            {
+                "Count": 100,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 1.02
+            },
+            {
+                "Count": 1000,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 10.4
+            }
+        ],
+        "TriggerBinding_BatchOverride": [
+            {
+                "MaxBatchSize": 100,
+                "Numbatches": 1,
+                "TestName": "ProductsTrigger",
+                "RunTimeAverage": 1.022
+            },
+            {
+                "MaxBatchSize": 100,
+                "Numbatches": 5,
+                "TestName": "ProductsTrigger",
+                "RunTimeAverage": 5.206
+            },
+            {
+                "MaxBatchSize": 1000,
+                "Numbatches": 1,
+                "TestName": "ProductsTrigger",
+                "RunTimeAverage": 1.071
+            },
+            {
+                "MaxBatchSize": 1000,
+                "Numbatches": 5,
+                "TestName": "ProductsTrigger",
+                "RunTimeAverage": 5.719
+            }
+        ],
+        "TriggerBinding_Parallelization": [
+            {
+                "HostCount": 2,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 1.8
+            },
+            {
+                "HostCount": 5,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 0.8
+            }
+        ],
+        "TriggerBinding_PollingIntervalOverride": [
+            {
+                "PollingIntervalMs": 100,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 0.326
+            },
+            {
+                "PollingIntervalMs": 500,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 1.1254
+            },
+            {
+                "PollingIntervalMs": 2000,
+                "TestName": "ProductsTriggerTest",
+                "RunTimeAverage": 4.0976
+            }
+        ]
+    }
+}

--- a/performance/PerformanceBaselines.json
+++ b/performance/PerformanceBaselines.json
@@ -2,22 +2,22 @@
     "PerformanceRuntime": {
         "InputBinding": {
             "TestName": "GetProductsTest",
-            "RunTimeAverage": 2.081
+            "RunTimeAverageSec": 2.081
         },
         "OutputBinding": {
             "TestName": "AddProductsArrayTest",
-            "RunTimeAverage": 2.055
+            "RunTimeAverageSec": 2.055
         },
         "TriggerBinding": [
             {
                 "Count": 100,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 1.02
+                "RunTimeAverageSec": 1.02
             },
             {
                 "Count": 1000,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 10.4
+                "RunTimeAverageSec": 10.4
             }
         ],
         "TriggerBinding_BatchOverride": [
@@ -25,54 +25,54 @@
                 "MaxBatchSize": 100,
                 "Numbatches": 1,
                 "TestName": "ProductsTrigger",
-                "RunTimeAverage": 1.022
+                "RunTimeAverageSec": 1.022
             },
             {
                 "MaxBatchSize": 100,
                 "Numbatches": 5,
                 "TestName": "ProductsTrigger",
-                "RunTimeAverage": 5.206
+                "RunTimeAverageSec": 5.206
             },
             {
                 "MaxBatchSize": 1000,
                 "Numbatches": 1,
                 "TestName": "ProductsTrigger",
-                "RunTimeAverage": 1.071
+                "RunTimeAverageSec": 1.071
             },
             {
                 "MaxBatchSize": 1000,
                 "Numbatches": 5,
                 "TestName": "ProductsTrigger",
-                "RunTimeAverage": 5.719
+                "RunTimeAverageSec": 5.719
             }
         ],
         "TriggerBinding_Parallelization": [
             {
                 "HostCount": 2,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 1.8
+                "RunTimeAverageSec": 1.8
             },
             {
                 "HostCount": 5,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 0.8
+                "RunTimeAverageSec": 0.8
             }
         ],
         "TriggerBinding_PollingIntervalOverride": [
             {
                 "PollingIntervalMs": 100,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 0.326
+                "RunTimeAverageSec": 0.326
             },
             {
                 "PollingIntervalMs": 500,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 1.1254
+                "RunTimeAverageSec": 1.1254
             },
             {
                 "PollingIntervalMs": 2000,
                 "TestName": "ProductsTriggerTest",
-                "RunTimeAverage": 4.0976
+                "RunTimeAverageSec": 4.0976
             }
         ]
     }


### PR DESCRIPTION
Will add instructions to the on-call wiki for the on-call person to keep tabs on the perf run times. 