### PR TITLE
Fix nuget packaging during build

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -46,4 +46,4 @@ stages:
         configuration: '$(configuration)'
         nugetVersion: '99.99.99-test'
         binariesVersion: '99.99.99'
-        oopWorkerSupportedExtensionVersion: '99.99.99'
+        oopWorkerSupportedExtensionVersion: '99.99.99-test'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -91,7 +91,7 @@ steps:
   inputs:
     command: build
     projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
+    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }} -v:diag
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -167,7 +167,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~Integration'
+    arguments: --configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~Integration --no-build
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - task: DotNetCoreCLI@2
@@ -183,7 +183,7 @@ steps:
     projects: '${{ parameters.solution }}'
     # Skip any non .NET In-Proc integration tests. Otherwise, the following error will be thrown:
     # System.InvalidOperationException : No data found for Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlOutputBindingIntegrationTests.NoPropertiesThrows
-    arguments: '--configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~NoPropertiesThrows --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings'
+    arguments: --configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~NoPropertiesThrows --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
@@ -197,7 +197,7 @@ steps:
     command: test
     projects: '${{ parameters.solution }}'
     # Skip any CSharp only integration tests
-    arguments: '--configuration ${{ parameters.configuration }} --filter "FullyQualifiedName~Integration & FullyQualifiedName!~AddProductsCollectorTest"'
+    arguments: --configuration ${{ parameters.configuration }} --filter "FullyQualifiedName~Integration & FullyQualifiedName!~AddProductsCollectorTest" --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
@@ -209,7 +209,7 @@ steps:
   inputs:
     command: test
     projects: '${{ parameters.solution }}'
-    arguments: '--configuration ${{ parameters.configuration }}'
+    arguments: --configuration ${{ parameters.configuration }} --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -86,21 +86,12 @@ steps:
     workingDirectory: $(Agent.WorkFolder)
 
   # Build and generate (unsigned) packages & assemblies to use for testing
-  # We build the extension project first since the auto-generated WorkerExtension project will try to restore
-  # depdencies before the extension project has finished building and fail if it can't find the nuget package
-- task: DotNetCoreCLI@2
-  displayName: .NET Build for Test (Extension DLL)
-  inputs:
-    command: build
-    projects: $(Build.SourcesDirectory)/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
-
 - task: DotNetCoreCLI@2
   displayName: .NET Build for Test (Solution)
   inputs:
     command: build
     projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
+    arguments: --configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=true -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -86,12 +86,21 @@ steps:
     workingDirectory: $(Agent.WorkFolder)
 
   # Build and generate (unsigned) packages & assemblies to use for testing
+  # We build the extension project first since the auto-generated WorkerExtension project will try to restore
+  # depdencies before the extension project has finished building and fail if it can't find the nuget package
 - task: DotNetCoreCLI@2
-  displayName: .NET Build for Test
+  displayName: .NET Build for Test (Extension DLL)
+  inputs:
+    command: build
+    projects: $(Build.SourcesDirectory)/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
+
+- task: DotNetCoreCLI@2
+  displayName: .NET Build for Test (Solution)
   inputs:
     command: build
     projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }} -v:diag
+    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -87,7 +87,7 @@ steps:
 
   # Build and generate (unsigned) packages & assemblies to use for testing
 - task: DotNetCoreCLI@2
-  displayName: .NET Build for Test (Solution)
+  displayName: .NET Build for Test
   inputs:
     command: build
     projects: ${{ parameters.solution }}

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -85,22 +85,6 @@ steps:
     arguments: add source -n afsqlext.local $(Build.SourcesDirectory)/local-packages
     workingDirectory: $(Agent.WorkFolder)
 
-  # Build and generate (unsigned) packages & assemblies to use for testing
-- task: DotNetCoreCLI@2
-  displayName: .NET Build for Test
-  inputs:
-    command: build
-    projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=true -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
-
-- task: CopyFiles@2
-  displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
-  inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
-    contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
-    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
-    overWrite: true
-
   # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
 - task: CopyFiles@2
   displayName: 'Copy local Sql package to local-packages folder'
@@ -157,6 +141,22 @@ steps:
     # update-snapshot forces a check for updated library dependencies
     options: --batch-mode --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
     checkStyleRunAnalysis: true
+
+  # Build and generate (unsigned) packages & assemblies to use for testing
+- task: DotNetCoreCLI@2
+  displayName: .NET Build for Test
+  inputs:
+    command: build
+    projects: ${{ parameters.solution }}
+    arguments: --configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=true -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
+
+- task: CopyFiles@2
+  displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
+  inputs:
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
+    contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
+    targetFolder: $(azureFunctionsExtensionBundlePath)/bin
+    overWrite: true
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Mac (unit tests only)'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -85,14 +85,13 @@ steps:
     arguments: add source -n afsqlext.local $(Build.SourcesDirectory)/local-packages
     workingDirectory: $(Agent.WorkFolder)
 
-  # Do an initial build for use during testing, this will have the OOP "supported version" set to the exact binaries version
-  # so it ensures we use the local version of the package
+  # Build and generate (unsigned) packages & assemblies to use for testing
 - task: DotNetCoreCLI@2
   displayName: .NET Build for Test
   inputs:
     command: build
     projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.binariesVersion }}
+    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
@@ -219,6 +218,7 @@ steps:
   displayName: 'Stop and Remove SQL Server Image'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
+# Build, but don't package since we need to sign the assemblies first
 - task: DotNetCoreCLI@2
   displayName: .NET Build for Release
   inputs:

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -74,26 +74,6 @@ steps:
   displayName: Set logging level
   condition: and(succeeded(), ne(variables['AFSQLEXT_TEST_LOGLEVEL'], ''))
 
-  # The build process for the OOP samples involve generating a temporary csproj in the %TEMP% directory, so it doesn't pick
-  # up the custom nuget.config we have. Set up the local-packages source here so that it can build correctly. Running from
-  # WorkFolder so it applies globally.
-- task: DotNetCoreCLI@2
-  displayName: Set up local-packages Nuget source
-  inputs:
-    command: custom
-    custom: nuget
-    arguments: add source -n afsqlext.local $(Build.SourcesDirectory)/local-packages
-    workingDirectory: $(Agent.WorkFolder)
-
-  # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
-- task: CopyFiles@2
-  displayName: 'Copy local Sql package to local-packages folder'
-  inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
-    contents: '*.nupkg'
-    targetFolder: $(Build.SourcesDirectory)/local-packages
-    overWrite: true
-
 - script: |
     npm install
     npm run lint
@@ -141,6 +121,26 @@ steps:
     # update-snapshot forces a check for updated library dependencies
     options: --batch-mode --define=org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --update-snapshots
     checkStyleRunAnalysis: true
+
+  # The build process for the OOP samples involve generating a temporary csproj in the %TEMP% directory, so it doesn't pick
+  # up the custom nuget.config we have. Set up the local-packages source here so that it can build correctly. Running from
+  # WorkFolder so it applies globally.
+- task: DotNetCoreCLI@2
+  displayName: Set up local-packages Nuget source
+  inputs:
+    command: custom
+    custom: nuget
+    arguments: add source -n afsqlext.local $(Build.SourcesDirectory)/local-packages
+    workingDirectory: $(Agent.WorkFolder)
+
+  # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
+- task: CopyFiles@2
+  displayName: 'Copy local Sql package to local-packages folder'
+  inputs:
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
+    contents: '*.nupkg'
+    targetFolder: $(Build.SourcesDirectory)/local-packages
+    overWrite: true
 
   # Build and generate (unsigned) packages & assemblies to use for testing
 - task: DotNetCoreCLI@2

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -133,6 +133,14 @@ steps:
     arguments: add source -n afsqlext.local $(Build.SourcesDirectory)/local-packages
     workingDirectory: $(Agent.WorkFolder)
 
+  # Build and generate (unsigned) packages & assemblies to use for testing
+- task: DotNetCoreCLI@2
+  displayName: .NET Build for Test
+  inputs:
+    command: build
+    projects: ${{ parameters.solution }}
+    arguments: --configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=true -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
+
   # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
 - task: CopyFiles@2
   displayName: 'Copy local Sql package to local-packages folder'
@@ -141,14 +149,6 @@ steps:
     contents: '*.nupkg'
     targetFolder: $(Build.SourcesDirectory)/local-packages
     overWrite: true
-
-  # Build and generate (unsigned) packages & assemblies to use for testing
-- task: DotNetCoreCLI@2
-  displayName: .NET Build for Test
-  inputs:
-    command: build
-    projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:GeneratePackageOnBuild=true -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }}
 
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'

--- a/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
+++ b/samples/samples-outofproc/Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj
@@ -19,8 +19,10 @@
       Include="..\..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
     <!-- We want to build the extension project first since this project references the package
     produced by building that. But we don't want it as an actual runtime depdendency -->
-    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj"
-      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -33,10 +33,10 @@
     <None Include="..\Images\pkgicon.png" Pack="true" PackagePath="" />
     <None Include="..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
-  <Target Name="PackAndCopyNupkg" AfterTargets="Build">
+  <Target Name="PackAndCopyNupkg" Condition="'$(GeneratePackageOnBuild)' != 'false'" AfterTargets="Build">
     <!-- Removed the GeneratePackageOnBuild and adding this explicit Pack command to run post build
     and also adding the copy package to local-packages to be available for the worker extension project. -->
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\$(PackageId).csproj&quot; --no-build --include-symbols -p:Version=$(Version)" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\$(PackageId).csproj&quot; --no-build --include-symbols -p:Version=$(Version) -p:PackageVersion=$(PackageVersion)" />
     <ItemGroup>
       <_Packages Include=".\bin\$(Configuration)\*.nupkg" />
     </ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -36,7 +36,7 @@
   <Target Name="PackAndCopyNupkg" Condition="'$(GeneratePackageOnBuild)' != 'false'" AfterTargets="Build">
     <!-- Removed the GeneratePackageOnBuild and adding this explicit Pack command to run post build
     and also adding the copy package to local-packages to be available for the worker extension project. -->
-    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\$(PackageId).csproj&quot; --no-build --include-symbols -p:Version=$(Version) -p:PackageVersion=$(PackageVersion)" />
+    <Exec Command="dotnet pack &quot;$(MSBuildProjectDirectory)\$(PackageId).csproj&quot; --configuration $(Configuration) --no-build --include-symbols -p:Version=$(Version) -p:PackageVersion=$(PackageVersion)" />
     <ItemGroup>
       <_Packages Include=".\bin\$(Configuration)\*.nupkg" />
     </ItemGroup>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -43,8 +43,8 @@
     <Copy SourceFiles="@(_Packages)" DestinationFolder="..\local-packages" />
     <Message Text="Copied sql .nupkg to local-packages" Importance="high" />
   </Target>
-  <Target Name="RemoveNugetPackageCache" BeforeTargets="Build">
-    <RemoveDir Directories="$(NugetPackageRoot)\$(PackageId.ToLower())\$(Version)"></RemoveDir>
-    <Message Text="Deleted nuget cache for $(PackageId.ToLower())\$(Version)" Importance="high" />
+  <Target Name="RemoveNugetPackageCache" Condition="'$(GeneratePackageOnBuild)' != 'false'" BeforeTargets="Build">
+    <RemoveDir Directories="$(NugetPackageRoot)\$(PackageId.ToLower())\$(PackageVersion)"></RemoveDir>
+    <Message Text="Deleted nuget cache for $(PackageId.ToLower())\$(PackageVersion)" Importance="high" />
   </Target>
 </Project>

--- a/test-outofproc/test-outofproc.csproj
+++ b/test-outofproc/test-outofproc.csproj
@@ -16,12 +16,13 @@
     <PackageReference Include="Grpc.Net.Client" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference
-      Include="..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
+    <ProjectReference Include="..\Worker.Extensions.Sql\src\Microsoft.Azure.Functions.Worker.Extensions.Sql.csproj" />
     <!-- We want to build the extension project first since this project references the package
     produced by building that. But we don't want it as an actual runtime depdendency -->
-    <ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj"
-      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <Private>false</Private>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -21,9 +21,11 @@
     <!-- Build the sample projects so that they get copied over afterwards -->
     <ProjectReference Include="..\samples\samples-outofproc\Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <Private>false</Private>
     </ProjectReference>
     <ProjectReference Include="..\test-outofproc\test-outofproc.csproj">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -18,7 +18,8 @@
     <ProjectReference Include="..\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Build the sample projects so that they get copied over afterwards -->
+    <!-- Build the sample projects so that they get copied over afterwards in the CopySamples target -->
+    <!-- Private is set to false so we don't end up copying over the metadata files (such as local.settings.json) into the output of this project -->
     <ProjectReference Include="..\samples\samples-outofproc\Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         <Private>false</Private>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -13,8 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj" />
     <ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj" />
+    <!-- Tests reference types from this assembly -->
+    <ProjectReference Include="..\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Build the sample projects so that they get copied over afterwards -->
+    <ProjectReference Include="..\samples\samples-outofproc\Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.csproj">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="..\test-outofproc\test-outofproc.csproj">
         <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Sql.Tests.csproj
@@ -15,6 +15,9 @@
   <ItemGroup>
     <ProjectReference Include="..\samples\samples-csharp\Microsoft.Azure.WebJobs.Extensions.Sql.Samples.csproj" />
     <ProjectReference Include="..\src\Microsoft.Azure.WebJobs.Extensions.Sql.csproj" />
+    <ProjectReference Include="..\test-outofproc\test-outofproc.csproj">
+        <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We've been getting these warnings in the pipelines lately : 

`##[warning]/var/folders/3s/vfzpb5r51gs6y328rmlgzm7c0000gn/T/b3fgdwow.a3k/WorkerExtensions.csproj(0,0): Warning NU1603: Microsoft.Azure.Functions.Worker.Extensions depends on Microsoft.Azure.WebJobs.Extensions.Sql (>= 3.0.447-preview) but Microsoft.Azure.WebJobs.Extensions.Sql 3.0.447-preview was not found. An approximate best match of Microsoft.Azure.WebJobs.Extensions.Sql 3.0.447 was resolved.`

Looking into it I found a couple of issues that are fixed in this PR

1. We weren't passing in the nuget version to the dotnet pack target so it was falling back to the binary version (which doesn't have -preview for preview builds)
2. We weren't passing in the configuration to the dotnet pack target so it was generating from the wrong assemblies (this was for the test package only, the release packaging was done correctly)
3. We were generating the nuget package when building for release - even though we don't want to at that point (since we have to sign the binaries before packaging)
4. The dotnet test steps were rebuilding the projects again unnecessarily so I'm making them not build to speed up the pipeline. Doing this then required moving the build step below where we build the samples so that the non .NET samples would be copied over for the tests correctly