### PR TITLE
add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
+  - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
adding dependabot.yml for enabling Dependabot.

There is a ignore attribute that we can use to explicitly [ignore](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-4) certain package updates (ignoring the major version updates for following semver). I haven't included them in this PR since we still have to approve to merge it in. I'll update the yml depending on if there are too many that we encounter.