### PR TITLE
Add codeql language for each stage

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -39,7 +39,9 @@ variables:
 stages:
 - stage: BuildPublish
   displayName: 'Release Build and Publish'
-
+  variables:
+    Codeql.BuildIdentifier: extension
+    Codeql.Language: csharp,java,javascript,powershell,python,tsql
   jobs:
   - job: BuildTest
     displayName: 'Build and Test on '
@@ -101,6 +103,9 @@ stages:
 - stage: BuildJava
   displayName: 'Release Build and Publish Java Library'
   dependsOn: []
+  variables:
+    Codeql.BuildIdentifier: java_library
+    Codeql.Language: java
   jobs:
   - job: BuildJavaLibrary
     displayName: Build Java Library

--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -32,6 +32,8 @@ variables:
   LGTM.UploadSnapshot: true
   Codeql.Enabled: true
   Codeql.TSAEnabled: true
+  Codeql.PublishDatabaseLog: true
+  Codeql.Cadence: 0
 
 
 stages:


### PR DESCRIPTION
This PR addresses https://github.com/Azure/azure-functions-sql-extension/issues/973.

Since our pipeline has two stages, we need to specify the language in each stage separately so that CodeQL will scan only the relevant files. In the case of the java-library build stage, we only build the java-library and we want CodeQL to scan that.
More information:
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-codeql3000-faq#there-are-multiple-pipelines-or-stagesjobs-how-do-we-onboard
