### PR TITLE
Remove use Gson in all java sample functions 

### DIFF
--- a/samples/samples-java/pom.xml
+++ b/samples/samples-java/pom.xml
@@ -31,12 +31,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.10.1</version>

--- a/samples/samples-java/src/main/java/com/function/AddProduct.java
+++ b/samples/samples-java/src/main/java/com/function/AddProduct.java
@@ -15,10 +15,8 @@ import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.function.Common.Product;
+import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -36,11 +34,11 @@ public class AddProduct {
                 name = "product",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
-                OutputBinding<Product> product) throws JsonParseException, JsonMappingException, IOException {
+                OutputBinding<Product> product) throws IOException {
 
         String json = request.getBody().get();
-        ObjectMapper mapper = new ObjectMapper();
-        Product p = mapper.readValue(json, Product.class);
+        Gson gson = new Gson();
+        Product p = gson.fromJson(json, Product.class);
         product.setValue(p);
 
         return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(product).build();

--- a/samples/samples-java/src/main/java/com/function/AddProductReturnValue.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductReturnValue.java
@@ -12,10 +12,8 @@ import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.function.Common.Product;
+import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -32,11 +30,11 @@ public class AddProductReturnValue {
                 methods = {HttpMethod.POST},
                 authLevel = AuthorizationLevel.ANONYMOUS,
                 route = "addproduct-returnvalue")
-                HttpRequestMessage<Optional<String>> request) throws JsonParseException, JsonMappingException, IOException {
+                HttpRequestMessage<Optional<String>> request) throws IOException {
 
         String json = request.getBody().get();
-        ObjectMapper mapper = new ObjectMapper();
-        Product product = mapper.readValue(json, Product.class);
+        Gson gson = new Gson();
+        Product product = gson.fromJson(json, Product.class);
 
         return product;
     }

--- a/samples/samples-java/src/main/java/com/function/AddProductToTwoTables.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductToTwoTables.java
@@ -15,10 +15,8 @@ import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.function.Common.Product;
+import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -45,11 +43,11 @@ public class AddProductToTwoTables {
                 name = "productWithIdentity",
                 commandText = "ProductsWithIdentity",
                 connectionStringSetting = "SqlConnectionString")
-                OutputBinding<Product> productWithIdentity) throws JsonParseException, JsonMappingException, IOException {
+                OutputBinding<Product> productWithIdentity) throws IOException {
 
         String json = request.getBody().get();
-        ObjectMapper mapper = new ObjectMapper();
-        Product p = mapper.readValue(json, Product.class);
+        Gson gson = new Gson();
+        Product p = gson.fromJson(json, Product.class);
         product.setValue(p);
         productWithIdentity.setValue(p);
 

--- a/samples/samples-java/src/main/java/com/function/AddProductWithDefaultPK.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductWithDefaultPK.java
@@ -15,10 +15,8 @@ import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.function.Common.ProductWithDefaultPK;
+import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -36,11 +34,11 @@ public class AddProductWithDefaultPK {
                 name = "product",
                 commandText = "dbo.ProductsWithDefaultPK",
                 connectionStringSetting = "SqlConnectionString")
-                OutputBinding<ProductWithDefaultPK> product) throws JsonParseException, JsonMappingException, IOException {
+                OutputBinding<ProductWithDefaultPK> product) throws IOException {
 
         String json = request.getBody().get();
-        ObjectMapper mapper = new ObjectMapper();
-        ProductWithDefaultPK p = mapper.readValue(json, ProductWithDefaultPK.class);
+        Gson gson = new Gson();
+        ProductWithDefaultPK p = gson.fromJson(json, ProductWithDefaultPK.class);
         product.setValue(p);
 
         return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(product).build();

--- a/samples/samples-java/src/main/java/com/function/AddProductsArray.java
+++ b/samples/samples-java/src/main/java/com/function/AddProductsArray.java
@@ -15,10 +15,9 @@ import com.microsoft.azure.functions.annotation.AuthorizationLevel;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import com.microsoft.azure.functions.annotation.HttpTrigger;
 import com.microsoft.azure.functions.sql.annotation.SQLOutput;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.function.Common.Product;
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -36,11 +35,11 @@ public class AddProductsArray {
                 name = "products",
                 commandText = "Products",
                 connectionStringSetting = "SqlConnectionString")
-                OutputBinding<Product[]> products) throws JsonParseException, JsonMappingException, IOException {
+                OutputBinding<Product[]> products) throws IOException {
 
         String json = request.getBody().get();
-        ObjectMapper mapper = new ObjectMapper();
-        Product[] p = mapper.readValue(json, Product[].class);
+        Gson gson = new Gson();
+        Product[] p = gson.fromJson(json, Product[].class);
         products.setValue(p);
 
         return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(products).build();

--- a/samples/samples-java/src/main/java/com/function/Common/Product.java
+++ b/samples/samples-java/src/main/java/com/function/Common/Product.java
@@ -6,14 +6,9 @@
 
 package com.function.Common;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class Product {
-    @JsonProperty("ProductId")
     private int ProductId;
-    @JsonProperty("Name")
     private String Name;
-    @JsonProperty("Cost")
     private int Cost;
 
     public Product() {

--- a/samples/samples-java/src/main/java/com/function/Common/ProductWithDefaultPK.java
+++ b/samples/samples-java/src/main/java/com/function/Common/ProductWithDefaultPK.java
@@ -6,12 +6,8 @@
 
 package com.function.Common;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class ProductWithDefaultPK {
-    @JsonProperty("Name")
     private String Name;
-    @JsonProperty("Cost")
     private int Cost;
 
     public ProductWithDefaultPK() {

--- a/test/Integration/test-java/pom.xml
+++ b/test/Integration/test-java/pom.xml
@@ -31,12 +31,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.13.4.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.10.1</version>

--- a/test/Integration/test-java/src/main/java/com/function/Common/ProductUnsupportedTypes.java
+++ b/test/Integration/test-java/src/main/java/com/function/Common/ProductUnsupportedTypes.java
@@ -6,16 +6,10 @@
 
 package com.function.Common;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public class ProductUnsupportedTypes {
-    @JsonProperty("ProductId")
     private int ProductId;
-    @JsonProperty("TextCol")
     private String TextCol;
-    @JsonProperty("NtextCol")
     private String NtextCol;
-    @JsonProperty("ImageCol")
     private String ImageCol;
 
     public ProductUnsupportedTypes() {

--- a/test/Integration/test-java/src/main/java/com/function/GetProductsColumnTypesSerialization.java
+++ b/test/Integration/test-java/src/main/java/com/function/GetProductsColumnTypesSerialization.java
@@ -59,6 +59,6 @@ public class GetProductsColumnTypesSerialization {
             product.setSmallDatetime(new Timestamp(smallDateTime - offset).toString());
             context.getLogger().log(Level.INFO, gson.toJson(product));
         }
-        return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(mapper.writeValueAsString(products)).build();
+        return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(gson.toJson(products)).build();
     }
 }

--- a/test/Integration/test-java/src/main/java/com/function/GetProductsColumnTypesSerialization.java
+++ b/test/Integration/test-java/src/main/java/com/function/GetProductsColumnTypesSerialization.java
@@ -6,9 +6,9 @@
 
 package com.function;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.function.Common.ProductColumnTypes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.HttpMethod;
 import com.microsoft.azure.functions.HttpRequestMessage;
@@ -42,11 +42,10 @@ public class GetProductsColumnTypesSerialization {
                 commandType = CommandType.Text,
                 connectionStringSetting = "SqlConnectionString")
                 ProductColumnTypes[] products,
-            ExecutionContext context) throws JsonProcessingException, ParseException {
+            ExecutionContext context) throws ParseException {
 
-        ObjectMapper mapper = new ObjectMapper();
+        Gson gson = new GsonBuilder().setDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSXXX").create();
         SimpleDateFormat df = new SimpleDateFormat("yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSXXX");
-        mapper.setDateFormat(df);
         for (ProductColumnTypes product : products) {
             // Convert the datetimes to UTC (Java worker returns the datetimes in local timezone)
             long date = df.parse(product.getDate()).getTime();
@@ -58,7 +57,7 @@ public class GetProductsColumnTypesSerialization {
             product.setDatetime(new Timestamp(datetime - offset).toString());
             product.setDatetime2(new Timestamp(datetime2 - offset).toString());
             product.setSmallDatetime(new Timestamp(smallDateTime - offset).toString());
-            context.getLogger().log(Level.INFO, mapper.writeValueAsString(product));
+            context.getLogger().log(Level.INFO, gson.toJson(product));
         }
         return request.createResponseBuilder(HttpStatus.OK).header("Content-Type", "application/json").body(mapper.writeValueAsString(products)).build();
     }


### PR DESCRIPTION
This PR fixes: https://github.com/Azure/azure-functions-sql-extension/issues/966 and removes the use of Jackson serializer in the java samples/tests.
