### PR TITLE
Remove exception logging on failed user function executions

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -372,6 +372,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         WorkerCount,
         EngineEdition,
         Edition,
+        Succeeded,
     }
 
     /// <summary>
@@ -435,7 +436,6 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         RenewLeasesLoop,
         RenewLeasesRollback,
         StartListener,
-        TriggerFunction,
         Upsert,
         UpsertRollback,
         GetServerTelemetryProperties,


### PR DESCRIPTION
Currently we log the exception every time a user function fails to execute. But that's extremely noisy - since user code can contain whatever they want, and so the number of possible exception types to get is basically infinite.

More importantly, we don't really actually care in nearly all scenarios what the exact exception was - or even that it failed - since it is almost always going to indicate a user error (it may be a host error as well if something goes wrong calling the function, but that is also not a problem with our functionality).

So to simplify things and reduce the amount of noisy stuff we collect I'm removing it and instead just always logging the TriggerFunction event - but with a property added so we can still tell how often we see failures.