### PR TITLE
add traceroute against api.esrp.microsoft.com 

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -217,6 +217,11 @@ steps:
   displayName: 'Stop and Remove SQL Server Image'
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
+- script: |
+    tarcert https://api.esrp.microsoft.com
+  displayName: Tracert EsrpCodeSigning
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
+  
 - task: EsrpCodeSigning@3
   displayName: 'ESRP CodeSigning - Binaries (Extension)'
   inputs:

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -218,7 +218,7 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |
-    traceroute https://api.esrp.microsoft.com
+    traceroute api.esrp.microsoft.com
   displayName: Tracert EsrpCodeSigning
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -218,10 +218,10 @@ steps:
   condition: and(succeeded(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |
-    tarcert https://api.esrp.microsoft.com
+    traceroute https://api.esrp.microsoft.com
   displayName: Tracert EsrpCodeSigning
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
-  
+
 - task: EsrpCodeSigning@3
   displayName: 'ESRP CodeSigning - Binaries (Extension)'
   inputs:


### PR DESCRIPTION
As suggested in the [ICM](https://portal.microsofticm.com/imp/v3/incidents/incident/447617542/summary), added the tracert step for the mac build. 
Following up with the on-call engineer on the Icm if this is a required step and sending this PR for temporarily unblocking the build.
