### PR TITLE
Clarify exception retries section

### DIFF
--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -24,7 +24,7 @@
     - [Retry support for Trigger Bindings](#retry-support-for-trigger-bindings)
       - [Startup retries](#startup-retries)
       - [Broken connection retries](#broken-connection-retries)
-      - [Function exception retries](#function-exception-retries)
+      - [Function or binding exception retries](#function-or-binding-exception-retries)
       - [Lease Tables clean up](#lease-tables-clean-up)
     - [Setup Guides](#setup-guides-2)
   - [Troubleshooting](#troubleshooting)
@@ -176,9 +176,9 @@ If the function successfully starts but then an error causes the connection to b
 
 Note that these retries are outside the built in idle connection retry logic that SqlClient has which can be configured with the [ConnectRetryCount](https://learn.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnectionstringbuilder.connectretrycount) and [ConnectRetryInterval](https://learn.microsoft.com/dotnet/api/system.data.sqlclient.sqlconnectionstringbuilder.connectretryinterval) connection string options. The built-in idle connection retries will be attempted first and if those fail to reconnect then the trigger binding will attempt to re-establish the connection itself.
 
-#### Function exception retries
+#### Function or binding exception retries
 
-If an exception occurs in the user function when processing changes then the batch of rows currently being processed will be retried again in 60 seconds. Other changes will be processed as normal during this time, but the rows in the batch that caused the exception will be ignored until the timeout period has elapsed.
+If an exception occurs in the binding or while executing the user function when processing changes then the batch of rows currently being processed will be retried again in 60 seconds. Other changes will be processed as normal during this time, but the rows in the batch that caused the exception will be ignored until the timeout period has elapsed.
 
 If the function execution fails 5 times in a row for a given row then that row is completely ignored for all future changes. Because the rows in a batch are not deterministic, rows in a failed batch may end up in different batches in subsequent invocations. This means that not all rows in the failed batch will necessarily be ignored. If other rows in the batch were the ones causing the exception, the "good" rows may end up in a different batch that doesn't fail in future invocations.
 

--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -178,7 +178,7 @@ Note that these retries are outside the built in idle connection retry logic tha
 
 #### Function or binding exception retries
 
-If an exception occurs in the binding or while executing the user function when processing changes then the batch of rows currently being processed will be retried again in 60 seconds. Other changes will be processed as normal during this time, but the rows in the batch that caused the exception will be ignored until the timeout period has elapsed.
+If an exception occurs in the binding (such as deadlocks or timeouts) or while executing the user function when processing changes then the batch of rows currently being processed will be retried again in 60 seconds. Other changes will be processed as normal during this time, but the rows in the batch that caused the exception will be ignored until the timeout period has elapsed.
 
 If the function execution fails 5 times in a row for a given row then that row is completely ignored for all future changes. Because the rows in a batch are not deterministic, rows in a failed batch may end up in different batches in subsequent invocations. This means that not all rows in the failed batch will necessarily be ignored. If other rows in the batch were the ones causing the exception, the "good" rows may end up in a different batch that doesn't fail in future invocations.
 


### PR DESCRIPTION
Clarifying that the 60sec delay also applies to exceptions that occur in the binding code itself, such as deadlocks causing the a query to fail. If that happens we clear the rows currently being processed and don't try again until 60sec has elapsed.