### PR TITLE
Revert codeql candence back to default 72 hours

### DIFF
--- a/builds/azure-pipelines/build-release.yml
+++ b/builds/azure-pipelines/build-release.yml
@@ -33,7 +33,6 @@ variables:
   Codeql.Enabled: true
   Codeql.TSAEnabled: true
   Codeql.PublishDatabaseLog: true
-  Codeql.Cadence: 0
 
 
 stages:


### PR DESCRIPTION
CodeQL is working as expected in the [latest build](https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/results?buildId=219089&view=logs&j=ad533c73-7a95-5e12-cf66-f0b3921575e3&t=130ce56f-989a-52c8-ef59-05418a7b1f11) for all languages except PowerShell and TSQL.
According to the [docs](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/codeql-semmle#supported-languages), support for these languages are in alpha/beta. I plan on going to CodeQL office hours next week and will leave the [github issue](https://github.com/Azure/azure-functions-sql-extension/issues/973) open for now to track.