### PR TITLE
Don't cache query type

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     TelemetryInstance.TrackEvent(TelemetryEventName.TableInfoCacheMiss, props);
                     // set the columnNames for supporting T as JObject since it doesn't have columns in the member info.
-                    tableInfo = TableInformation.RetrieveTableInformation(connection, fullTableName, this._logger, GetColumnNamesFromItem(rows.First()), this._serverProperties);
+                    tableInfo = TableInformation.RetrieveTableInformation(connection, fullTableName, this._logger, this._serverProperties);
                     var policy = new CacheItemPolicy
                     {
                         // Re-look up the primary key(s) after timeout (default timeout is 10 minutes)
@@ -244,7 +244,26 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
 
                 var table = new SqlObject(fullTableName);
-                string mergeOrInsertQuery = tableInfo.QueryType == QueryType.Insert ? TableInformation.GetInsertQuery(table, bracketedColumnNamesFromItem) :
+
+                IEnumerable<string> objectColumnNames = GetColumnNamesFromItem(rows.First());
+                IEnumerable<string> primaryKeysFromObject = objectColumnNames.Where(f => tableInfo.PrimaryKeys.Any(k => string.Equals(k.Name, f, StringComparison.Ordinal)));
+                IEnumerable<PrimaryKey> missingPrimaryKeysFromItem = tableInfo.PrimaryKeys
+                    .Where(k => !primaryKeysFromObject.Contains(k.Name));
+                bool hasIdentityColumnPrimaryKeys = tableInfo.PrimaryKeys.Any(k => k.IsIdentity);
+                bool hasDefaultColumnPrimaryKeys = tableInfo.PrimaryKeys.Any(k => k.HasDefault);
+                // If none of the primary keys are an identity column or have a default value then we require that all primary keys be present in the POCO so we can
+                // generate the MERGE statement correctly
+                if (!hasIdentityColumnPrimaryKeys && !hasDefaultColumnPrimaryKeys && missingPrimaryKeysFromItem.Any())
+                {
+                    string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromItem)}]";
+                    var ex = new InvalidOperationException(message);
+                    TelemetryInstance.TrackException(TelemetryErrorName.MissingPrimaryKeys, ex, connection.AsConnectionProps(this._serverProperties));
+                    throw ex;
+                }
+                // If any identity columns or columns with default values aren't included in the object then we have to generate a basic insert since the merge statement expects all primary key
+                // columns to exist. (the merge statement can handle nullable columns though if those exist)
+                QueryType queryType = (tableInfo.HasIdentityColumnPrimaryKeys || tableInfo.HasDefaultColumnPrimaryKeys) && missingPrimaryKeysFromItem.Any() ? QueryType.Insert : QueryType.Merge;
+                string mergeOrInsertQuery = queryType == QueryType.Insert ? TableInformation.GetInsertQuery(table, bracketedColumnNamesFromItem) :
                     TableInformation.GetMergeQuery(tableInfo.PrimaryKeys, table, bracketedColumnNamesFromItem);
 
                 var transactionSw = Stopwatch.StartNew();
@@ -415,28 +434,28 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             public IEnumerable<string> ColumnDefinitions => this.Columns.Select(c => $"{c.Key} {c.Value}");
 
             /// <summary>
-            /// Whether to use an insert query or merge query.
-            /// </summary>
-            public QueryType QueryType { get; }
-
-            /// <summary>
             /// Whether at least one of the primary keys on this table is an identity column
             /// </summary>
             public bool HasIdentityColumnPrimaryKeys { get; }
+
+            /// <summary>
+            /// Whether at least one of the primary keys on this table has a default value
+            /// </summary>
+            public bool HasDefaultColumnPrimaryKeys { get; }
+
             /// <summary>
             /// Settings to use when serializing the POCO into SQL.
             /// Only serialize properties and fields that correspond to SQL columns.
             /// </summary>
             public JsonSerializerSettings JsonSerializerSettings { get; }
 
-            public TableInformation(List<PrimaryKey> primaryKeys, IEnumerable<PropertyInfo> primaryKeyProperties, IDictionary<string, string> columns, QueryType queryType, bool hasIdentityColumnPrimaryKeys)
+            public TableInformation(List<PrimaryKey> primaryKeys, IEnumerable<PropertyInfo> primaryKeyProperties, IDictionary<string, string> columns, bool hasIdentityColumnPrimaryKeys, bool hasDefaultColumnPrimaryKeys)
             {
                 this.PrimaryKeys = primaryKeys;
                 this.PrimaryKeyProperties = primaryKeyProperties;
                 this.Columns = columns;
-                this.QueryType = queryType;
                 this.HasIdentityColumnPrimaryKeys = hasIdentityColumnPrimaryKeys;
-
+                this.HasDefaultColumnPrimaryKeys = hasDefaultColumnPrimaryKeys;
                 // Convert datetime strings to ISO 8061 format to avoid potential errors on the server when converting into a datetime. This
                 // is the only format that are an international standard.
                 // https://docs.microsoft.com/previous-versions/sql/sql-server-2008-r2/ms180878(v=sql.105)
@@ -546,10 +565,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             /// <param name="sqlConnection">An open connection with which to query SQL against</param>
             /// <param name="fullName">Full name of table, including schema (if exists).</param>
             /// <param name="logger">ILogger used to log any errors or warnings.</param>
-            /// <param name="objectColumnNames">Column names from the object</param>
             /// <param name="serverProperties">EngineEdition and Edition of the target Sql Server.</param>
             /// <returns>TableInformation object containing primary keys, column types, etc.</returns>
-            public static TableInformation RetrieveTableInformation(SqlConnection sqlConnection, string fullName, ILogger logger, IEnumerable<string> objectColumnNames, ServerProperties serverProperties)
+            public static TableInformation RetrieveTableInformation(SqlConnection sqlConnection, string fullName, ILogger logger, ServerProperties serverProperties)
             {
                 Dictionary<TelemetryPropertyName, string> sqlConnProps = sqlConnection.AsConnectionProps(serverProperties);
                 var table = new SqlObject(fullName);
@@ -627,24 +645,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 // Match SQL Primary Key column names to POCO property objects. Ensure none are missing.
                 IEnumerable<PropertyInfo> primaryKeyProperties = typeof(T).GetProperties().Where(f => primaryKeys.Any(k => string.Equals(k.Name, f.Name, StringComparison.Ordinal)));
-                IEnumerable<string> primaryKeysFromObject = objectColumnNames.Where(f => primaryKeys.Any(k => string.Equals(k.Name, f, StringComparison.Ordinal)));
-                IEnumerable<PrimaryKey> missingPrimaryKeysFromItem = primaryKeys
-                    .Where(k => !primaryKeysFromObject.Contains(k.Name));
                 bool hasIdentityColumnPrimaryKeys = primaryKeys.Any(k => k.IsIdentity);
                 bool hasDefaultColumnPrimaryKeys = primaryKeys.Any(k => k.HasDefault);
-                // If none of the primary keys are an identity column or have a default value then we require that all primary keys be present in the POCO so we can
-                // generate the MERGE statement correctly
-                if (!hasIdentityColumnPrimaryKeys && !hasDefaultColumnPrimaryKeys && missingPrimaryKeysFromItem.Any())
-                {
-                    string message = $"All primary keys for SQL table {table} need to be found in '{typeof(T)}.' Missing primary keys: [{string.Join(",", missingPrimaryKeysFromItem)}]";
-                    var ex = new InvalidOperationException(message);
-                    TelemetryInstance.TrackException(TelemetryErrorName.MissingPrimaryKeys, ex, sqlConnProps);
-                    throw ex;
-                }
-
-                // If any identity columns or columns with default values aren't included in the object then we have to generate a basic insert since the merge statement expects all primary key
-                // columns to exist. (the merge statement can handle nullable columns though if those exist)
-                QueryType queryType = (hasIdentityColumnPrimaryKeys || hasDefaultColumnPrimaryKeys) && missingPrimaryKeysFromItem.Any() ? QueryType.Insert : QueryType.Merge;
 
                 tableInfoSw.Stop();
                 var durations = new Dictionary<TelemetryMeasureName, double>()
@@ -652,11 +654,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     { TelemetryMeasureName.GetColumnDefinitionsDurationMs, columnDefinitionsSw.ElapsedMilliseconds },
                     { TelemetryMeasureName.GetPrimaryKeysDurationMs, primaryKeysSw.ElapsedMilliseconds }
                 };
-                sqlConnProps.Add(TelemetryPropertyName.QueryType, queryType.ToString());
-                sqlConnProps.Add(TelemetryPropertyName.HasIdentityColumn, hasIdentityColumnPrimaryKeys.ToString());
+                sqlConnProps.Add(TelemetryPropertyName.HasIdentityColumnPrimaryKeys, hasIdentityColumnPrimaryKeys.ToString());
+                sqlConnProps.Add(TelemetryPropertyName.HasDefaultColumnPrimaryKeys, hasDefaultColumnPrimaryKeys.ToString());
                 TelemetryInstance.TrackDuration(TelemetryEventName.GetTableInfo, tableInfoSw.ElapsedMilliseconds, sqlConnProps, durations);
-                logger.LogDebug($"RetrieveTableInformation DB and Table: {sqlConnection.Database}.{fullName}. Primary keys: [{string.Join(",", primaryKeys.Select(pk => pk.Name))}].\nSQL Column and Definitions:  [{string.Join(",", columnDefinitionsFromSQL)}]\nObject columns: [{string.Join(",", objectColumnNames)}]");
-                return new TableInformation(primaryKeys, primaryKeyProperties, columnDefinitionsFromSQL, queryType, hasIdentityColumnPrimaryKeys);
+                logger.LogDebug($"RetrieveTableInformation DB and Table: {sqlConnection.Database}.{fullName}. Primary keys: [{string.Join(",", primaryKeys.Select(pk => pk.Name))}].\nSQL Column and Definitions:  [{string.Join(",", columnDefinitionsFromSQL)}]");
+                return new TableInformation(primaryKeys, primaryKeyProperties, columnDefinitionsFromSQL, hasIdentityColumnPrimaryKeys, hasDefaultColumnPrimaryKeys);
             }
         }
 

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -358,7 +358,8 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
     {
         ErrorCode,
         ErrorName,
-        HasIdentityColumn,
+        HasIdentityColumnPrimaryKeys,
+        HasDefaultColumnPrimaryKeys,
         HasConfiguredMaxBatchSize,
         HasConfiguredMaxChangesPerWorker,
         HasConfiguredPollingInterval,


### PR DESCRIPTION
Found this when updating the xUnit packages. Previously, the tests ran slow enough that the cached data timed out and so the later tests weren't affected by it. But with the update they all ran together in <10min, which meant that we used the same table info cached for the first test ran (which happened to be AddProductIncorrectCasing.

The issue is this - when we cached the table info we were also caching the query type. But the query type is based off of the incoming object for an output request, which means that since we were caching the info only at the table level (the cache key is connection string + table name) that we'd reuse that query type for ALL queries after that first one within that 10min span. For most cases this probably isn't an issue - we generally prefer to do a merge anyways and only fall back to insert in special circumstances.

But it's a valid scenario that there might be two separate functions which operate differently on the same table - in which case they could easily run into problems where the first one to run causes the other one to start using the wrong query type (like we had here).

In the case that I found this showed up as this error : 

`[3435] [2024-01-17T02:34:50.108Z] System.Private.CoreLib: Exception while executing function: Functions.AddProductsArray. Microsoft.Azure.WebJobs.Host: Error while handling parameter _binder after function returned:. Microsoft.Azure.WebJobs.Extensions.Sql: Unexpected error upserting rows. Core Microsoft SqlClient Data Provider: Violation of PRIMARY KEY constraint 'PK__Products__B40CC6CDD4C38CC3'. Cannot insert duplicate key in object 'dbo.Products'. The duplicate key value is (2).`

Which was because it was trying to do an INSERT instead of a MERGE (where it would have updated the row instead of trying to insert a new one)

This is a follow up to https://github.com/Azure/azure-functions-sql-extension/pull/628 where we did something similar