### PR TITLE
invalid operator used to compare with NULL values in get primary keys query

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         ccu.{ColumnName},
                         c.is_identity,
                         case
-                            when isc.COLUMN_DEFAULT = NULL then 'false'
+                            when isc.COLUMN_DEFAULT IS NULL then 'false'
                             else 'true'
                         end as {HasDefault}
                     FROM


### PR DESCRIPTION
Problem: should not use assignment '=' operator comparing with NULL 
Fix: best to use 'IS NULL' here to get expected value of 'has_default'

Impact Area:  **I have no idea on impact area of this change**. So, I am leaving this on your team's responsibility to make sure, if this change fixes any existing problems in your knowledge.

NOTE to reviewers: The reason of change that I found the existing query as inappropriate. So, **please consider this change after proper testing**.
