### PR TITLE
Fix HasDefault syntax 

### DIFF
--- a/samples/samples-csharp/Common/Product.cs
+++ b/samples/samples-csharp/Common/Product.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Samples.Common
 {
     public class Product
     {
-        public int ProductId { get; set; }
+        public int? ProductId { get; set; }
 
         public string Name { get; set; }
 

--- a/samples/samples-csx/Common/product.csx
+++ b/samples/samples-csx/Common/product.csx
@@ -3,7 +3,7 @@
 
 public class Product
 {
-    public int ProductId { get; set; }
+    public int? ProductId { get; set; }
 
     public string Name { get; set; }
 

--- a/samples/samples-java/src/main/java/com/function/Common/Product.java
+++ b/samples/samples-java/src/main/java/com/function/Common/Product.java
@@ -7,7 +7,7 @@
 package com.function.Common;
 
 public class Product {
-    private int ProductId;
+    private int? ProductId;
     private String Name;
     private int Cost;
 

--- a/samples/samples-java/src/main/java/com/function/Common/Product.java
+++ b/samples/samples-java/src/main/java/com/function/Common/Product.java
@@ -7,7 +7,7 @@
 package com.function.Common;
 
 public class Product {
-    private int? ProductId;
+    private Integer ProductId;
     private String Name;
     private int Cost;
 

--- a/samples/samples-outofproc/Product.cs
+++ b/samples/samples-outofproc/Product.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.SamplesOutOfProc.Common
 {
     public class Product
     {
-        public int ProductId { get; set; }
+        public int? ProductId { get; set; }
 
         public string Name { get; set; }
 

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         ccu.{ColumnName},
                         c.is_identity,
                         case
-                            when isc.COLUMN_DEFAULT = NULL then 'false'
+                            when isc.COLUMN_DEFAULT IS NULL then 'false'
                             else 'true'
                         end as {HasDefault}
                     FROM

--- a/test-outofproc/Product.cs
+++ b/test-outofproc/Product.cs
@@ -8,7 +8,7 @@ namespace DotnetIsolatedTests.Common
 {
     public class Product
     {
-        public int ProductId { get; set; }
+        public int? ProductId { get; set; }
 
         public string Name { get; set; }
 

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -330,7 +330,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 { "cost", "1" }
             };
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithMultiplePrimaryColumnsAndIdentity"));
-            Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproductwithmultipleprimarycolumnsandidentity", query, TestUtils.GetPort(lang)).Wait());            // Nothing should have been inserted
+            Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproductwithmultipleprimarycolumnsandidentity", query, TestUtils.GetPort(lang)).Wait());
+            // Nothing should have been inserted
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithMultiplePrimaryColumnsAndIdentity"));
         }
 

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             await this.SendOutputPostRequest("addproductwithdefaultpk", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang));
             await this.SendOutputPostRequest("addproductwithdefaultpk", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang));
             Assert.Equal(2, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithDefaultPK"));
-            Assert.Throws<AggregateException>(() => this.SendOutputPostRequest("addproductwithmultipleprimarycolumnsandidentity", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang)).Wait());
+            Assert.Throws<AggregateException>(() => this.SendOutputPostRequest("addproduct", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang)).Wait());
         }
 
         /// <summary>

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -330,8 +330,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 { "cost", "1" }
             };
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithMultiplePrimaryColumnsAndIdentity"));
-            Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproduct", query, TestUtils.GetPort(lang)).Wait());
-            // Nothing should have been inserted
+            Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproductwithmultipleprimarycolumnsandidentity", query, TestUtils.GetPort(lang)).Wait());            // Nothing should have been inserted
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithMultiplePrimaryColumnsAndIdentity"));
         }
 

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -352,6 +352,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             await this.SendOutputPostRequest("addproductwithdefaultpk", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang));
             await this.SendOutputPostRequest("addproductwithdefaultpk", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang));
             Assert.Equal(2, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithDefaultPK"));
+            // Should throw error when there is no default PK and the primary key is missing from the user object.
             Assert.Throws<AggregateException>(() => this.SendOutputPostRequest("addproduct", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang)).Wait());
         }
 

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                 { "cost", "1" }
             };
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithMultiplePrimaryColumnsAndIdentity"));
-            Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproductwithmultipleprimarycolumnsandidentity", query, TestUtils.GetPort(lang)).Wait());
+            Assert.Throws<AggregateException>(() => this.SendOutputGetRequest("addproduct", query, TestUtils.GetPort(lang)).Wait());
             // Nothing should have been inserted
             Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithMultiplePrimaryColumnsAndIdentity"));
         }
@@ -352,6 +352,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             await this.SendOutputPostRequest("addproductwithdefaultpk", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang));
             await this.SendOutputPostRequest("addproductwithdefaultpk", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang));
             Assert.Equal(2, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithDefaultPK"));
+            Assert.Throws<AggregateException>(() => this.SendOutputPostRequest("addproductwithmultipleprimarycolumnsandidentity", Utils.JsonSerializeObject(product), TestUtils.GetPort(lang)).Wait());
         }
 
         /// <summary>

--- a/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
@@ -100,10 +100,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
                             Assert.Equal(operation, change.Operation); // Expected change operation
                             Product product = change.Item;
                             Assert.NotNull(product); // Product deserialized correctly
-                            Assert.Contains(product.ProductId, expectedIds); // We haven't seen this product ID yet, and it's one we expected to see
-                            expectedIds.Remove(product.ProductId);
-                            Assert.Equal(getName(product.ProductId), product.Name); // The product has the expected name
-                            Assert.Equal(getCost(product.ProductId), product.Cost); // The product has the expected cost
+                            Assert.Contains(product.ProductId.Value, expectedIds); // We haven't seen this product ID yet, and it's one we expected to see
+                            expectedIds.Remove(product.ProductId.Value);
+                            Assert.Equal(getName(product.ProductId.Value), product.Name); // The product has the expected name
+                            Assert.Equal(getCost(product.ProductId.Value), product.Cost); // The product has the expected cost
                         }
                     }
                     catch (Exception ex)

--- a/test/Integration/test-csx/Common/Product.csx
+++ b/test/Integration/test-csx/Common/Product.csx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 public class Product
 {
-    public int ProductId { get; set; }
+    public int? ProductId { get; set; }
 
     public string Name { get; set; }
 


### PR DESCRIPTION
This PR adds the fix from the following: https://github.com/Azure/azure-functions-sql-extension/pull/1033  and also updates the existing test to test that output binding fails when there is no default primary key column and user doesn't provide the primary key. Updated the common Product definition for testing the above scenario.
