### PR TITLE
Fix output binding when using column names with slashes

### DIFF
--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -182,7 +182,7 @@ steps:
     projects: '${{ parameters.solution }}'
     # Skip any non .NET In-Proc integration tests. Otherwise, the following error will be thrown:
     # System.InvalidOperationException : No data found for Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlOutputBindingIntegrationTests.NoPropertiesThrows
-    arguments: --configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~NoPropertiesThrows --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
+    arguments: --configuration ${{ parameters.configuration }} --filter "FullyQualifiedName!~NoPropertiesThrows & FullyQualifiedName!~AddProductWithSlashInColumnName" --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -412,6 +412,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             rowData = Utils.JsonSerializeObject(rowsToUpsert, table.JsonSerializerSettings);
             IEnumerable<string> columnNamesFromItem = GetColumnNamesFromItem(rows.First());
             IEnumerable<string> bracketColumnDefinitionsFromItem = columnNamesFromItem.Select(c => $"{c.AsBracketQuotedString()} {table.Columns[c]}");
+            // Escape any forward and backward slashes in the column names of rowData using REPLACE so the OPENJSON can read from those columns.
             newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON(REPLACE(REPLACE({RowDataParameter}, N'\\', N'\\\\'), N'/', N'\\/')) WITH ({string.Join(",", bracketColumnDefinitionsFromItem)}) )";
         }
 

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             rowData = Utils.JsonSerializeObject(rowsToUpsert, table.JsonSerializerSettings);
             IEnumerable<string> columnNamesFromItem = GetColumnNamesFromItem(rows.First());
             IEnumerable<string> bracketColumnDefinitionsFromItem = columnNamesFromItem.Select(c => $"{c.AsBracketQuotedString()} {table.Columns[c]}");
-            newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON({RowDataParameter}) WITH ({string.Join(",", bracketColumnDefinitionsFromItem)}) )";
+            newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON(REPLACE(REPLACE({RowDataParameter}, N'\\', N'\\\\'), N'/', N'\\/')) WITH ({string.Join(",", bracketColumnDefinitionsFromItem)}) )";
         }
 
         public class TableInformation
@@ -633,7 +633,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     throw new InvalidOperationException(message, ex);
                 }
 
-                if (!primaryKeys.Any())
+                if (primaryKeys.Count == 0)
                 {
                     string message = $"Did not retrieve any primary keys for {table}. Cannot generate upsert command without them.";
                     var ex = new InvalidOperationException(message);

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -413,7 +413,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             IEnumerable<string> columnNamesFromItem = GetColumnNamesFromItem(rows.First());
             IEnumerable<string> bracketColumnDefinitionsFromItem = columnNamesFromItem.Select(c => $"{c.AsBracketQuotedString()} {table.Columns[c]}");
             // Escape any forward and backward slashes in the column names of rowData using REPLACE so the OPENJSON can read from those columns.
-            newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON(REPLACE(REPLACE({RowDataParameter}, N'\\', N'\\\\'), N'/', N'\\/')) WITH ({string.Join(",", bracketColumnDefinitionsFromItem)}) )";
+            newDataQuery = $"WITH {CteName} AS ( SELECT * FROM OPENJSON(REPLACE({RowDataParameter}, N'/', N'\\/')) WITH ({string.Join(",", bracketColumnDefinitionsFromItem)}) )";
         }
 
         public class TableInformation

--- a/test/Database/Tables/ProductsWithSlashInColumnNames.sql
+++ b/test/Database/Tables/ProductsWithSlashInColumnNames.sql
@@ -3,5 +3,5 @@ DROP TABLE IF EXISTS [ProductsWithSlashInColumnNames];
 CREATE TABLE [ProductsWithSlashInColumnNames] (
     [ProductId] [int] NOT NULL PRIMARY KEY,
     [Name/Test] [nchar](100) NOT NULL,
-	[Cost/Test] [int] NOT NULL
+    [Cost\Test] [int] NOT NULL
 )

--- a/test/Database/Tables/ProductsWithSlashInColumnNames.sql
+++ b/test/Database/Tables/ProductsWithSlashInColumnNames.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS [ProductsWithSlashInColumnNames];
+
+CREATE TABLE [ProductsWithSlashInColumnNames] (
+    [ProductId] [int] NOT NULL PRIMARY KEY,
+    [Name/Test] [nchar](100) NOT NULL,
+	[Cost/Test] [int] NOT NULL
+)

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -568,6 +568,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             // Check that a product should have been inserted
             Assert.Equal("Test", this.ExecuteScalar("SELECT [Name/Test] FROM dbo.ProductsWithSlashInColumnNames WHERE ProductId = 1"));
             Assert.Equal(1, this.ExecuteScalar("SELECT [Cost\\Test] FROM dbo.ProductsWithSlashInColumnNames WHERE ProductId = 1"));
+
+            var query = new Dictionary<string, object>()
+            {
+                { "ProductId", 2},
+                { "Name/Test", "Test" },
+                { "Cost\\Test", 2 }
+            };
+            await this.SendOutputPostRequest("addproduct-slashcolumns", Utils.JsonSerializeObject(query));
+            // Check that a product should have been inserted
+            Assert.Equal("Test", this.ExecuteScalar("SELECT [Name/Test] FROM dbo.ProductsWithSlashInColumnNames WHERE ProductId = 2"));
+            Assert.Equal(2, this.ExecuteScalar("SELECT [Cost\\Test] FROM dbo.ProductsWithSlashInColumnNames WHERE ProductId = 2"));
         }
     }
 }

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -551,5 +551,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             await this.SendOutputGetRequest("addproductdefaultpkanddifferentcolumnorder", null, TestUtils.GetPort(lang, true));
             Assert.Equal(1, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithDefaultPK"));
         }
+
+        /// <summary>
+        /// Tests that when using a table with column names having slash (/ or \) in them 
+        /// we can insert data using output binding.
+        /// Excluding C#, JAVA and CSX languages since / or \ are reserved characters and are discouraged to use in variable names
+        /// </summary>
+        [Theory]
+        [SqlInlineData()]
+        [UnsupportedLanguages(SupportedLanguages.CSharp, SupportedLanguages.OutOfProc, SupportedLanguages.Java, SupportedLanguages.Csx)]
+        public async Task AddProductWithSlashInColumnName(SupportedLanguages lang)
+        {
+            Assert.Equal(0, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithSlashInColumnNames"));
+            this.StartFunctionHost("AddProductWithSlashInColumnName", lang);
+            await this.SendOutputPostRequest("addproduct-slashcolumns", "");
+            // Check that a product should have been inserted
+            Assert.Equal(1, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithSlashInColumnNames"));
+        }
     }
 }

--- a/test/Integration/SqlOutputBindingIntegrationTests.cs
+++ b/test/Integration/SqlOutputBindingIntegrationTests.cs
@@ -555,7 +555,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <summary>
         /// Tests that when using a table with column names having slash (/ or \) in them 
         /// we can insert data using output binding.
-        /// Excluding C#, JAVA and CSX languages since / or \ are reserved characters and are discouraged to use in variable names
+        /// Excluding C#, JAVA and CSX languages since / or \ are reserved characters and are not allowed to use in variable names
         /// </summary>
         [Theory]
         [SqlInlineData()]
@@ -566,7 +566,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.StartFunctionHost("AddProductWithSlashInColumnName", lang);
             await this.SendOutputPostRequest("addproduct-slashcolumns", "");
             // Check that a product should have been inserted
-            Assert.Equal(1, this.ExecuteScalar("SELECT COUNT(*) FROM dbo.ProductsWithSlashInColumnNames"));
+            Assert.Equal("Test", this.ExecuteScalar("SELECT [Name/Test] FROM dbo.ProductsWithSlashInColumnNames WHERE ProductId = 1"));
+            Assert.Equal(1, this.ExecuteScalar("SELECT [Cost\\Test] FROM dbo.ProductsWithSlashInColumnNames WHERE ProductId = 1"));
         }
     }
 }

--- a/test/Integration/test-js/AddProductWithSlashInColumnName/function.json
+++ b/test/Integration/test-js/AddProductWithSlashInColumnName/function.json
@@ -1,0 +1,27 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "name": "req",
+      "direction": "in",
+      "type": "httpTrigger",
+      "methods": [
+        "post"
+      ],
+      "route": "addproduct-slashcolumns"
+    },
+    {
+      "name": "$return",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "products",
+      "type": "sql",
+      "direction": "out",
+      "commandText": "[dbo].[ProductsWithSlashInColumnNames]",
+      "connectionStringSetting": "SqlConnectionString"
+    }
+  ],
+  "disabled": false
+}

--- a/test/Integration/test-js/AddProductWithSlashInColumnName/index.js
+++ b/test/Integration/test-js/AddProductWithSlashInColumnName/index.js
@@ -3,8 +3,8 @@
 
 // This output binding should successfully add the productMissingColumns object
 // to the SQL table.
-module.exports = async function (context) {
-    const productWithSlashInColumnName = [{
+module.exports = async function (context, req) {
+    const productWithSlashInColumnName = req.body ?? [{
         "ProductId": 1,
         "Name/Test": "Test",
         "Cost\\Test": 1

--- a/test/Integration/test-js/AddProductWithSlashInColumnName/index.js
+++ b/test/Integration/test-js/AddProductWithSlashInColumnName/index.js
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+// This output binding should successfully add the productMissingColumns object
+// to the SQL table.
+module.exports = async function (context) {
+    const productWithSlashInColumnName = [{
+        "ProductId": 1,
+        "Name/Test": "SlashInColumnNameTest",
+        "Cost/Test": 1
+    }];
+
+    context.bindings.products = JSON.stringify(productWithSlashInColumnName);
+
+    return {
+        status: 201,
+        body: productWithSlashInColumnName
+    };
+}

--- a/test/Integration/test-js/AddProductWithSlashInColumnName/index.js
+++ b/test/Integration/test-js/AddProductWithSlashInColumnName/index.js
@@ -6,8 +6,8 @@
 module.exports = async function (context) {
     const productWithSlashInColumnName = [{
         "ProductId": 1,
-        "Name/Test": "SlashInColumnNameTest",
-        "Cost/Test": 1
+        "Name/Test": "Test",
+        "Cost\\Test": 1
     }];
 
     context.bindings.products = JSON.stringify(productWithSlashInColumnName);

--- a/test/Integration/test-powershell/AddProductWithSlashInColumnName/function.json
+++ b/test/Integration/test-powershell/AddProductWithSlashInColumnName/function.json
@@ -1,0 +1,27 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "name": "Request",
+      "direction": "in",
+      "type": "httpTrigger",
+      "methods": [
+        "post"
+      ],
+      "route": "addproduct-slashcolumns"
+    },
+    {
+      "name": "response",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "product",
+      "type": "sql",
+      "direction": "out",
+      "commandText": "[dbo].[ProductsWithSlashInColumnNames]",
+      "connectionStringSetting": "SqlConnectionString"
+    }
+  ],
+  "disabled": false
+}

--- a/test/Integration/test-powershell/AddProductWithSlashInColumnName/run.ps1
+++ b/test/Integration/test-powershell/AddProductWithSlashInColumnName/run.ps1
@@ -11,7 +11,7 @@ Write-Host "PowerShell function with SQL Output Binding processed a request."
 
 # Note that this expects the body to be a JSON object or array of objects 
 # which have a property matching each of the columns in the table to upsert to.
-$req_body = @{
+$req_body = $Request.Body ? $Request.Body : @{
     "ProductId"="1";
     "Name/Test"="Test";
     "Cost\Test"="1"

--- a/test/Integration/test-powershell/AddProductWithSlashInColumnName/run.ps1
+++ b/test/Integration/test-powershell/AddProductWithSlashInColumnName/run.ps1
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+
+using namespace System.Net
+
+# Trigger binding data passed in via param block
+param($Request, $TriggerMetadata)
+
+# Write to the Azure Functions log stream.
+Write-Host "PowerShell function with SQL Output Binding processed a request."
+
+# Note that this expects the body to be a JSON object or array of objects 
+# which have a property matching each of the columns in the table to upsert to.
+$req_body = @{
+    "ProductId"="1";
+    "Name/Test"="Test";
+    "Cost/Test"="1"
+};
+
+# Assign the value we want to pass to the SQL Output binding. 
+# The -Name value corresponds to the name property in the function.json for the binding
+Push-OutputBinding -Name product -Value $req_body
+
+# Assign the value to return as the HTTP response. 
+# The -Name value matches the name property in the function.json for the binding
+Push-OutputBinding -Name response -Value ([HttpResponseContext]@{
+    StatusCode = [HttpStatusCode]::OK
+    Body = $req_body
+})

--- a/test/Integration/test-powershell/AddProductWithSlashInColumnName/run.ps1
+++ b/test/Integration/test-powershell/AddProductWithSlashInColumnName/run.ps1
@@ -14,7 +14,7 @@ Write-Host "PowerShell function with SQL Output Binding processed a request."
 $req_body = @{
     "ProductId"="1";
     "Name/Test"="Test";
-    "Cost/Test"="1"
+    "Cost\Test"="1"
 };
 
 # Assign the value we want to pass to the SQL Output binding. 

--- a/test/Integration/test-python/AddProductWithSlashInColumnName/__init__.py
+++ b/test/Integration/test-python/AddProductWithSlashInColumnName/__init__.py
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import json
 import azure.functions as func
 from Common.productWithSlash import ProductWithSlash
 
 # This output binding should successfully add the productMissingColumns object
 # to the SQL table.
 def main(req: func.HttpRequest, product: func.Out[func.SqlRow]) -> func.HttpResponse:
-    productWithSlash = func.SqlRow(ProductWithSlash(1, "Test", 1))
+    productWithSlash = func.SqlRow.from_dict(json.loads(req.get_body())) if req.get_body() else func.SqlRow(ProductWithSlash(1, "Test", 1))
     product.set(productWithSlash)
 
     return func.HttpResponse(

--- a/test/Integration/test-python/AddProductWithSlashInColumnName/__init__.py
+++ b/test/Integration/test-python/AddProductWithSlashInColumnName/__init__.py
@@ -7,7 +7,7 @@ from Common.productWithSlash import ProductWithSlash
 # This output binding should successfully add the productMissingColumns object
 # to the SQL table.
 def main(req: func.HttpRequest, product: func.Out[func.SqlRow]) -> func.HttpResponse:
-    productWithSlash = func.SqlRow(ProductWithSlash(1, "test", 1))
+    productWithSlash = func.SqlRow(ProductWithSlash(1, "Test", 1))
     product.set(productWithSlash)
 
     return func.HttpResponse(

--- a/test/Integration/test-python/AddProductWithSlashInColumnName/__init__.py
+++ b/test/Integration/test-python/AddProductWithSlashInColumnName/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import azure.functions as func
+from Common.productWithSlash import ProductWithSlash
+
+# This output binding should successfully add the productMissingColumns object
+# to the SQL table.
+def main(req: func.HttpRequest, product: func.Out[func.SqlRow]) -> func.HttpResponse:
+    productWithSlash = func.SqlRow(ProductWithSlash(1, "test", 1))
+    product.set(productWithSlash)
+
+    return func.HttpResponse(
+        body=productWithSlash.to_json(),
+        status_code=201,
+        mimetype="application/json"
+    )

--- a/test/Integration/test-python/AddProductWithSlashInColumnName/function.json
+++ b/test/Integration/test-python/AddProductWithSlashInColumnName/function.json
@@ -1,0 +1,27 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "name": "req",
+      "direction": "in",
+      "type": "httpTrigger",
+      "methods": [
+        "post"
+      ],
+      "route": "addproduct-slashcolumns"
+    },
+    {
+      "name": "$return",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "product",
+      "type": "sql",
+      "direction": "out",
+      "commandText": "[dbo].[ProductsWithSlashInColumnNames]",
+      "connectionStringSetting": "SqlConnectionString"
+    }
+  ],
+  "disabled": false
+}

--- a/test/Integration/test-python/Common/productWithSlash.py
+++ b/test/Integration/test-python/Common/productWithSlash.py
@@ -8,4 +8,4 @@ class ProductWithSlash(collections.UserDict):
         super().__init__()
         self['ProductId'] = productId
         self['Name/Test'] = name
-        self['Cost/Test'] = cost
+        self['Cost\Test'] = cost

--- a/test/Integration/test-python/Common/productWithSlash.py
+++ b/test/Integration/test-python/Common/productWithSlash.py
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import collections
+
+class ProductWithSlash(collections.UserDict):
+    def __init__(self, productId, name, cost):
+        super().__init__()
+        self['ProductId'] = productId
+        self['Name/Test'] = name
+        self['Cost/Test'] = cost


### PR DESCRIPTION
Replace the / slash while building the query for inserting the items.

Fixes #1026 