### PR TITLE
Check for package updates every Wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      # Check for updates on Wednesday
+      # Check for updates on Wednesday https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday
       day: "wednesday"
     ignore:
         # Please do not bump Azure.Identity from 1.10.2, even a minor bump to 1.10.3 is causing a major bump in it's trasitive dependecny Microsoft.Identity.Client.Extensions.Msal which will fail the bundle test.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      # Check for updates on Wednesday
+      day: "wednesday"
     ignore:
         # Please do not bump Azure.Identity from 1.10.2, even a minor bump to 1.10.3 is causing a major bump in it's trasitive dependecny Microsoft.Identity.Client.Extensions.Msal which will fail the bundle test.
       - dependency-name: "Azure.Identity"


### PR DESCRIPTION
Change the dependabot configuration to check for package updates every Wednesday so it's easy for the DRI to have enough time to merge them in.