### PR TITLE
Add additional trigger debug logging

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -394,7 +394,6 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         GetColumnDefinitionsDurationMs,
         GetPrimaryKeysDurationMs,
         GetUnprocessedChangesDurationMs,
-        GetLockedRowCountDurationMs,
         InsertGlobalStateTableRowDurationMs,
         MaxBatchSize,
         MaxChangesPerWorker,
@@ -441,7 +440,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         Upsert,
         UpsertRollback,
         GetServerTelemetryProperties,
-        GetLeaseLockedRowCount,
+        GetLeaseLockedOrMaxAttemptRowCount,
     }
 
     internal class ServerProperties

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -978,7 +978,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private SqlCommand BuildRenewLeasesCommand(SqlConnection connection, SqlTransaction transaction)
         {
             string matchCondition = string.Join(" OR ", this._rowMatchConditions.Take(this._rowsToProcess.Count));
-
+            if (string.IsNullOrEmpty(matchCondition))
+            {
+                this._logger.LogError($"MatchCondition resolved to empty with '{this._rowsToProcess.Count}' rowsToProcess.");
+            }
             string renewLeasesQuery = $@"
                 {AppLockStatements}
 


### PR DESCRIPTION
This will help us and users diagnose issues with the trigger function - especially for being able to track when the change version we're looking at changes so we can see what change version the function is looking at for a given point in time.

New messages:

* PreInvocation updated LastSyncVersion
`[PreInvocation] Updated LastSyncVersion from 0 to 121`
* PostInvocation updated LastSyncVersion
`[PostInvocation] Updated LastSyncVersion from 153 to 155 MaxAttemptRowsToBeDeleted=1`
* When leases are renewed for lease locked rows
`Renewed leases for 1 rows`
* When the internal state is cleared (usually due to a previous error)
`Clearing internal state for 1 rows`

Updated messages:

* Added max attempts reached count to the lease locked row count check
`Executed GetChangesCommand in GetTableChangesAsync. 0 available changed rows. (0 found with lease locks and 1 ignored because they've reached the max attempt limit)`

