### PR TITLE
Skip empty where clause execution on trigger

### DIFF
--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -441,6 +441,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         UpsertRollback,
         GetServerTelemetryProperties,
         GetLeaseLockedOrMaxAttemptRowCount,
+        BuildRenewLeasesWithEmptyMatchCondtion
     }
 
     internal class ServerProperties

--- a/src/Telemetry/Telemetry.cs
+++ b/src/Telemetry/Telemetry.cs
@@ -349,7 +349,8 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         TriggerFunction,
         TriggerMonitorStart,
         Upsert,
-        InsertGlobalStateTableRow
+        InsertGlobalStateTableRow,
+        BuildRenewLeasesWithEmptyMatchCondtion
     }
 
     /// <summary>
@@ -440,8 +441,7 @@ To learn more about our Privacy Statement visit this link: https://go.microsoft.
         Upsert,
         UpsertRollback,
         GetServerTelemetryProperties,
-        GetLeaseLockedOrMaxAttemptRowCount,
-        BuildRenewLeasesWithEmptyMatchCondtion
+        GetLeaseLockedOrMaxAttemptRowCount
     }
 
     internal class ServerProperties

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -525,28 +525,30 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 {
                     try
                     {
-                        using (SqlCommand renewLeasesCommand = this.BuildRenewLeasesCommand(connection, transaction))
+                        SqlCommand renewLeasesCommand = this.BuildRenewLeasesCommand(connection, transaction);
+                        if (renewLeasesCommand != null)
                         {
-                            var stopwatch = Stopwatch.StartNew();
-
-                            int rowsAffected = await renewLeasesCommand.ExecuteNonQueryAsyncWithLogging(this._logger, token, true);
-
-                            long durationMs = stopwatch.ElapsedMilliseconds;
-
-                            if (rowsAffected > 0)
+                            using (renewLeasesCommand)
                             {
-                                this._logger.LogDebug($"Renewed leases for {rowsAffected} rows");
-                                // Only send an event if we actually updated rows to reduce the overall number of events we send
-                                var measures = new Dictionary<TelemetryMeasureName, double>
+                                var stopwatch = Stopwatch.StartNew();
+
+                                int rowsAffected = await renewLeasesCommand.ExecuteNonQueryAsyncWithLogging(this._logger, token, true);
+
+                                long durationMs = stopwatch.ElapsedMilliseconds;
+
+                                if (rowsAffected > 0)
                                 {
-                                    [TelemetryMeasureName.DurationMs] = durationMs,
-                                };
+                                    this._logger.LogDebug($"Renewed leases for {rowsAffected} rows");
+                                    // Only send an event if we actually updated rows to reduce the overall number of events we send
+                                    var measures = new Dictionary<TelemetryMeasureName, double>
+                                    {
+                                        [TelemetryMeasureName.DurationMs] = durationMs,
+                                    };
 
-                                TelemetryInstance.TrackEvent(TelemetryEventName.RenewLeases, this._telemetryProps, measures);
+                                    TelemetryInstance.TrackEvent(TelemetryEventName.RenewLeases, this._telemetryProps, measures);
+                                }
+                                transaction.Commit();
                             }
-
-
-                            transaction.Commit();
                         }
                     }
                     catch (Exception e)
@@ -981,6 +983,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             if (string.IsNullOrEmpty(matchCondition))
             {
                 this._logger.LogError($"MatchCondition resolved to empty with '{this._rowsToProcess.Count}' rowsToProcess.");
+                return null;
             }
             string renewLeasesQuery = $@"
                 {AppLockStatements}

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -980,9 +980,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private SqlCommand BuildRenewLeasesCommand(SqlConnection connection, SqlTransaction transaction)
         {
             string matchCondition = string.Join(" OR ", this._rowMatchConditions.Take(this._rowsToProcess.Count));
+            // If the matchCondition is empty return null to avoid empty where clause query failure.
             if (string.IsNullOrEmpty(matchCondition))
             {
                 this._logger.LogError($"MatchCondition resolved to empty with '{this._rowsToProcess.Count}' rowsToProcess.");
+                TelemetryInstance.TrackException(TelemetryErrorName.BuildRenewLeasesWithEmptyMatchCondtion, null);
                 return null;
             }
             string renewLeasesQuery = $@"

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -984,7 +984,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             if (string.IsNullOrEmpty(matchCondition))
             {
                 this._logger.LogError($"MatchCondition resolved to empty with '{this._rowsToProcess.Count}' rowsToProcess.");
-                TelemetryInstance.TrackException(TelemetryErrorName.BuildRenewLeasesWithEmptyMatchCondtion, null);
+                TelemetryInstance.TrackEvent(TelemetryEventName.BuildRenewLeasesWithEmptyMatchCondtion);
                 return null;
             }
             string renewLeasesQuery = $@"


### PR DESCRIPTION
Return null when match condition resolves to empty instead of sending in the empty where clause.

Fixes #1108 