### PR TITLE
Fix build pipelines

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -9,41 +9,57 @@ pr:
 variables:
   solution: '**/*.sln'
   configuration: 'Debug'
+  nugetVersion: '99.99.99-test'
+  binariesVersion: '99.99.99'
+  oopWorkerSupportedExtensionVersion: '99.99.99-test'
 
 stages:
 - stage: Build
   displayName: 'PR Validation'
 
   jobs:
-  - job: BuildTest
-    displayName: 'Build and Test on'
-
-    # Verifies cross-platform build and test
-    strategy:
-      matrix:
-        mac:
-          imageName: 'macos-latest'
-          testServer: ''
-        windows:
-          imageName: 'windows-latest'
-          testServer: '(LocalDb)\MSSQLLocalDB'
-        linux:
-          imageName: 'ubuntu-latest'
-          testServer: ''
-
+  - job: Mac
+    timeoutInMinutes: 90
     pool:
-      vmImage: '$(imageName)'
-
+      vmImage: macos-latest
     workspace:
       clean: all
-
-    timeoutInMinutes: '90'
-
     steps:
     - template: 'template-steps-build-test.yml'
       parameters:
         solution: '$(solution)'
         configuration: '$(configuration)'
-        nugetVersion: '99.99.99-test'
-        binariesVersion: '99.99.99'
-        oopWorkerSupportedExtensionVersion: '99.99.99-test'
+        testServer: 'localhost'
+        nugetVersion: '$(nugetVersion)'
+        binariesVersion: '$(binariesVersion)'
+        oopWorkerSupportedExtensionVersion: '$(oopWorkerSupportedExtensionVersion)'
+  - job: Linux
+    timeoutInMinutes: 90
+    pool:
+      vmImage: ubuntu-latest
+    workspace:
+      clean: all
+    steps:
+    - template: 'template-steps-build-test.yml'
+      parameters:
+        solution: '$(solution)'
+        configuration: '$(configuration)'
+        testServer: 'localhost'
+        nugetVersion: '$(nugetVersion)'
+        binariesVersion: '$(binariesVersion)'
+        oopWorkerSupportedExtensionVersion: '$(oopWorkerSupportedExtensionVersion)'
+  - job: Windows
+    timeoutInMinutes: 90
+    pool:
+      vmImage: windows-latest
+    workspace:
+      clean: all
+    steps:
+    - template: 'template-steps-build-test.yml'
+      parameters:
+        solution: '$(solution)'
+        configuration: '$(configuration)'
+        testServer: '(LocalDb)\MSSQLLocalDB'
+        nugetVersion: '$(nugetVersion)'
+        binariesVersion: '$(binariesVersion)'
+        oopWorkerSupportedExtensionVersion: '$(oopWorkerSupportedExtensionVersion)'

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -123,14 +123,14 @@ steps:
   displayName: .NET Build
   inputs:
     command: build
-    projects: $(solution)
-    arguments: --configuration $(configuration) -p:Version=$(binariesVersion) -p:OOPWorkerSupportedExtensionVersion=$(oopWorkerSupportedExtensionVersion) -p:PackageVersion=$(nugetVersion) -v d
+    projects: ${{ parameters.solution }}
+    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }} -v d
 
   # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
 - task: CopyFiles@2
   displayName: 'Copy local Sql package to local-packages folder'
   inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/$(configuration)
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
     contents: '*.nupkg'
     targetFolder: $(Build.SourcesDirectory)/local-packages
     overWrite: true
@@ -138,7 +138,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
   inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/$(configuration)/netstandard2.0
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
@@ -146,43 +146,43 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Mac (unit tests only)'
   env:
-    TEST_SERVER: '$(testServer)'
+    TEST_SERVER: ${{ parameters.testServer }}
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
   inputs:
     command: test
-    projects: '$(solution)'
-    arguments: --configuration $(configuration) --filter FullyQualifiedName!~Integration --no-build
+    projects: '${{ parameters.solution }}'
+    arguments: --configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~Integration --no-build
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Windows (unit tests and .NET In-Proc integration tests)'
   env:
-    TEST_SERVER: '$(testServer)'
+    TEST_SERVER: ${{ parameters.testServer }}
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     # Only running CSharp integration tests to get accurate code coverage numbers
     LANGUAGES_TO_TEST: 'CSharp'
   inputs:
     command: test
-    projects: '$(solution)'
+    projects: '${{ parameters.solution }}'
     # Skip any non .NET In-Proc integration tests. Otherwise, the following error will be thrown:
     # System.InvalidOperationException : No data found for Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlOutputBindingIntegrationTests.NoPropertiesThrows
-    arguments: --configuration $(configuration) --filter "FullyQualifiedName!~NoPropertiesThrows & FullyQualifiedName!~AddProductWithSlashInColumnName" --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
+    arguments: --configuration ${{ parameters.configuration }} --filter "FullyQualifiedName!~NoPropertiesThrows & FullyQualifiedName!~AddProductWithSlashInColumnName" --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Windows (Non .NET In-Proc)'
   env:
-    TEST_SERVER: '$(testServer)'
+    TEST_SERVER: ${{ parameters.testServer }}
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     LANGUAGES_TO_TEST: 'Java,JavaScript,OutOfProc,PowerShell,Python,Csx'
   inputs:
     command: test
-    projects: '$(solution)'
+    projects: '${{ parameters.solution }}'
     # Skip any CSharp only integration tests
-    arguments: --configuration $(configuration) --filter "FullyQualifiedName~Integration & FullyQualifiedName!~AddProductsCollectorTest" --no-build
+    arguments: --configuration ${{ parameters.configuration }} --filter "FullyQualifiedName~Integration & FullyQualifiedName!~AddProductsCollectorTest" --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
@@ -193,8 +193,8 @@ steps:
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
   inputs:
     command: test
-    projects: '$(solution)'
-    arguments: --configuration $(configuration) --no-build
+    projects: '${{ parameters.solution }}'
+    arguments: --configuration ${{ parameters.configuration }} --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -123,14 +123,14 @@ steps:
   displayName: .NET Build
   inputs:
     command: build
-    projects: ${{ parameters.solution }}
-    arguments: --configuration ${{ parameters.configuration }} -p:Version=${{ parameters.binariesVersion }} -p:OOPWorkerSupportedExtensionVersion=${{ parameters.oopWorkerSupportedExtensionVersion }} -p:PackageVersion=${{ parameters.nugetVersion }} -v d
+    projects: $(solution)
+    arguments: --configuration $(configuration) -p:Version=$(binariesVersion) -p:OOPWorkerSupportedExtensionVersion=$(oopWorkerSupportedExtensionVersion) -p:PackageVersion=$(nugetVersion) -v d
 
   # Copy the Sql nupkg to ensure it's available for tests since the package copy task is failing occasionally so having this redundancy.
 - task: CopyFiles@2
   displayName: 'Copy local Sql package to local-packages folder'
   inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/$(configuration)
     contents: '*.nupkg'
     targetFolder: $(Build.SourcesDirectory)/local-packages
     overWrite: true
@@ -138,7 +138,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy Sql extension dll to Azure Functions extension bundle'
   inputs:
-    sourceFolder: $(Build.SourcesDirectory)/src/bin/${{ parameters.configuration }}/netstandard2.0
+    sourceFolder: $(Build.SourcesDirectory)/src/bin/$(configuration)/netstandard2.0
     contents: Microsoft.Azure.WebJobs.Extensions.Sql.dll
     targetFolder: $(azureFunctionsExtensionBundlePath)/bin
     overWrite: true
@@ -146,43 +146,43 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Mac (unit tests only)'
   env:
-    TEST_SERVER: ${{ parameters.testServer }}
+    TEST_SERVER: '$(testServer)'
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
   inputs:
     command: test
-    projects: '${{ parameters.solution }}'
-    arguments: --configuration ${{ parameters.configuration }} --filter FullyQualifiedName!~Integration --no-build
+    projects: '$(solution)'
+    arguments: --configuration $(configuration) --filter FullyQualifiedName!~Integration --no-build
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Darwin'))
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Windows (unit tests and .NET In-Proc integration tests)'
   env:
-    TEST_SERVER: ${{ parameters.testServer }}
+    TEST_SERVER: '$(testServer)'
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     # Only running CSharp integration tests to get accurate code coverage numbers
     LANGUAGES_TO_TEST: 'CSharp'
   inputs:
     command: test
-    projects: '${{ parameters.solution }}'
+    projects: '$(solution)'
     # Skip any non .NET In-Proc integration tests. Otherwise, the following error will be thrown:
     # System.InvalidOperationException : No data found for Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration.SqlOutputBindingIntegrationTests.NoPropertiesThrows
-    arguments: --configuration ${{ parameters.configuration }} --filter "FullyQualifiedName!~NoPropertiesThrows & FullyQualifiedName!~AddProductWithSlashInColumnName" --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
+    arguments: --configuration $(configuration) --filter "FullyQualifiedName!~NoPropertiesThrows & FullyQualifiedName!~AddProductWithSlashInColumnName" --collect "Code Coverage" -s $(Build.SourcesDirectory)/test/coverage.runsettings --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Windows (Non .NET In-Proc)'
   env:
-    TEST_SERVER: ${{ parameters.testServer }}
+    TEST_SERVER: '$(testServer)'
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     LANGUAGES_TO_TEST: 'Java,JavaScript,OutOfProc,PowerShell,Python,Csx'
   inputs:
     command: test
-    projects: '${{ parameters.solution }}'
+    projects: '$(solution)'
     # Skip any CSharp only integration tests
-    arguments: --configuration ${{ parameters.configuration }} --filter "FullyQualifiedName~Integration & FullyQualifiedName!~AddProductsCollectorTest" --no-build
+    arguments: --configuration $(configuration) --filter "FullyQualifiedName~Integration & FullyQualifiedName!~AddProductsCollectorTest" --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: DotNetCoreCLI@2
@@ -193,8 +193,8 @@ steps:
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
   inputs:
     command: test
-    projects: '${{ parameters.solution }}'
-    arguments: --configuration ${{ parameters.configuration }} --no-build
+    projects: '$(solution)'
+    arguments: --configuration $(configuration) --no-build
   condition: and(succeededOrFailed(), eq(variables['Agent.OS'], 'linux'))
 
 - script: |

--- a/builds/azure-pipelines/template-steps-build-test.yml
+++ b/builds/azure-pipelines/template-steps-build-test.yml
@@ -146,7 +146,7 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Mac (unit tests only)'
   env:
-    TEST_SERVER: '$(testServer)'
+    TEST_SERVER: ${{ parameters.testServer }}
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
   inputs:
@@ -158,7 +158,7 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Windows (unit tests and .NET In-Proc integration tests)'
   env:
-    TEST_SERVER: '$(testServer)'
+    TEST_SERVER: ${{ parameters.testServer }}
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     # Only running CSharp integration tests to get accurate code coverage numbers
@@ -174,7 +174,7 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: '.NET Test on Windows (Non .NET In-Proc)'
   env:
-    TEST_SERVER: '$(testServer)'
+    TEST_SERVER: ${{ parameters.testServer }}
     NODE_MODULES_PATH: '$(nodeModulesPath)'
     AZUREFUNCTIONS_SQLBINDINGS_TELEMETRY_OPTOUT: '1'
     LANGUAGES_TO_TEST: 'Java,JavaScript,OutOfProc,PowerShell,Python,Csx'


### PR DESCRIPTION
Mixing expressions and runtime values will cause problems - and in this case I was using an expression in the wrapper template in the ADO repo so this template wasn't working as expected.

The PR build doesn't use the wrapper template, which is why this wasn't caught in PR earlier.

Using compile time expressions is clearer and more straightforward so switching to be consistent with using that for testServer.

Changing this then broke the PR pipeline though, since it was using the matrix build options which are evaluated at runtime (so the templates had an empty value when they evaluated the expressions). I briefly tried fixing the templates to use runtime values directly since theoretically those should work, but it was taking too long so I just changed the PR pipeline to not use the matrix build functionality and instead hardcode a job for each platform. This is what we do for the other pipelines anyways so there's some advantage with having all the pipelines be aligned anyways.

Buddy build : https://msdata.visualstudio.com/SQLToolsAndLibraries/_build/results?buildId=148012457&view=results