### PR TITLE
Update Microsoft.Azure.Functions.Worker.Sdk package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.2" />
     <PackageVersion Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />

--- a/samples/samples-outofproc/packages.lock.json
+++ b/samples/samples-outofproc/packages.lock.json
@@ -71,11 +71,11 @@
       },
       "Microsoft.Azure.Functions.Worker.Sdk": {
         "type": "Direct",
-        "requested": "[1.18.1, )",
-        "resolved": "1.18.1",
-        "contentHash": "1wpn70uKpc5/xD5bn9n9/mW9uYmshsRloCqnzLhI6UOy5+PAJUhF5JUobn5GPrs8ZTbj4i6h8lOCUPPXX8sNhg==",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "QCe7C9fLKKjttv7LCDMoI5rm3EUZCZzmGON07efFF85qkn8hMgtTKVvZ7uM4773aUe+AtrvigHLOXaL8hT2u7w==",
         "dependencies": {
-          "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": "1.2.1",
+          "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": "1.2.2",
           "Microsoft.Azure.Functions.Worker.Sdk.Generators": "1.3.4"
         }
       },
@@ -186,8 +186,8 @@
       },
       "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "EOZqyNc718vKJAg4/cgmDqnQg3wYoNKE14NjskBrDAINMBKfujQqHRn4McSFfSHgCXUE0F/Yc4+sh7i6HhbPbg=="
+        "resolved": "1.2.2",
+        "contentHash": "v+GWIfC2Or3nxriew6JLT0yRGmhqYI84ALLqbQSyj/j9Z6ZQi2dh9iO9i3jmHAqiVFmIC2Aing/0eYQ0pObU4w=="
       },
       "Microsoft.Azure.Functions.Worker.Sdk.Generators": {
         "type": "Transitive",

--- a/test-outofproc/packages.lock.json
+++ b/test-outofproc/packages.lock.json
@@ -50,11 +50,11 @@
       },
       "Microsoft.Azure.Functions.Worker.Sdk": {
         "type": "Direct",
-        "requested": "[1.18.1, )",
-        "resolved": "1.18.1",
-        "contentHash": "1wpn70uKpc5/xD5bn9n9/mW9uYmshsRloCqnzLhI6UOy5+PAJUhF5JUobn5GPrs8ZTbj4i6h8lOCUPPXX8sNhg==",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "QCe7C9fLKKjttv7LCDMoI5rm3EUZCZzmGON07efFF85qkn8hMgtTKVvZ7uM4773aUe+AtrvigHLOXaL8hT2u7w==",
         "dependencies": {
-          "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": "1.2.1",
+          "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": "1.2.2",
           "Microsoft.Azure.Functions.Worker.Sdk.Generators": "1.3.4"
         }
       },
@@ -167,8 +167,8 @@
       },
       "Microsoft.Azure.Functions.Worker.Sdk.Analyzers": {
         "type": "Transitive",
-        "resolved": "1.2.1",
-        "contentHash": "EOZqyNc718vKJAg4/cgmDqnQg3wYoNKE14NjskBrDAINMBKfujQqHRn4McSFfSHgCXUE0F/Yc4+sh7i6HhbPbg=="
+        "resolved": "1.2.2",
+        "contentHash": "v+GWIfC2Or3nxriew6JLT0yRGmhqYI84ALLqbQSyj/j9Z6ZQi2dh9iO9i3jmHAqiVFmIC2Aing/0eYQ0pObU4w=="
       },
       "Microsoft.Azure.Functions.Worker.Sdk.Generators": {
         "type": "Transitive",


### PR DESCRIPTION
This change began due to #1171. The user wants to update to 2.0.2 (but that is on .Net 8) which we currently do not support.

Updating to https://github.com/Azure/azure-functions-dotnet-worker/releases/tag/sdk-2.0.1

If we did 2.0.2 then we get errors below:
```
C:\Program Files\dotnet\sdk\6.0.411\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET 6.0 or lower, or use  
a version of the .NET SDK that supports .NET 8.0. [C:\Git\azfnsql\azure-functions-sql-extension\samples\samples-outofproc\obj\Debug\net6\WorkerExtensions\WorkerExtensions.csproj]
C:\Program Files\dotnet\sdk\6.0.411\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET 6.0 or lower, or use  
a version of the .NET SDK that supports .NET 8.0. [C:\Git\azfnsql\azure-functions-sql-extension\test-outofproc\obj\Debug\net6\WorkerExtensions\WorkerExtensions.csproj]
```