### PR TITLE
Pin Ubuntu 22.04 for agent version in pipelines

### DIFF
--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -36,17 +36,10 @@ stages:
   - job: Linux
     timeoutInMinutes: 90
     pool:
-      vmImage: ubuntu-latest
+      vmImage: ubuntu-22.04 # Ubuntu 24.04 causes an error about missing libssl - using 22.04 for now
     workspace:
       clean: all
     steps:
-    - script: |
-
-        sudo add-apt-repository 'deb http://security.ubuntu.com/ubuntu jammy-security main'
-        sudo apt-get update
-        sudo apt-get install -y libssl-dev=3.0.2-0ubuntu1.19
-      displayName: 'Install libssl-dev'
-
     - template: 'template-steps-build-test.yml'
       parameters:
         solution: '$(solution)'

--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -41,6 +41,9 @@ stages:
       clean: all
     steps:
     - script: |
+
+        sudo add-apt-repository 'deb http://security.ubuntu.com/ubuntu jammy-security main'
+        sudo apt-get update
         sudo apt-get install -y libssl-dev=3.0.2-0ubuntu1.19
       displayName: 'Install libssl-dev'
 

--- a/builds/azure-pipelines/build-pr.yml
+++ b/builds/azure-pipelines/build-pr.yml
@@ -40,6 +40,10 @@ stages:
     workspace:
       clean: all
     steps:
+    - script: |
+        sudo apt-get install -y libssl-dev=3.0.2-0ubuntu1.19
+      displayName: 'Install libssl-dev'
+
     - template: 'template-steps-build-test.yml'
       parameters:
         solution: '$(solution)'


### PR DESCRIPTION
Recently the "latest" images were updated to 24.04, which are causing build failures with 

`[error]/home/vsts/.nuget/packages/microsoft.azure.webjobs.script.extensionsmetadatagenerator/4.0.1/build/Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator.targets(37,5): Error : Metadata generation failed. Exit code: '134' Error: 'No usable version of libssl was found'`

While we investigate a better solution, I'm pinning us to use 22.04 images for our pipelines to unblock the builds. The version of the agent image isn't something that should affect our produced artifacts.

(note the same will likely have to be done for our ADO pipelines as well - I'll be verifying that and updating those as needed)