### PR TITLE
Fallback to Host ID if WEBSITE_SITE_NAME isn't defined

### DIFF
--- a/docs/BindingsOverview.md
+++ b/docs/BindingsOverview.md
@@ -20,6 +20,7 @@
       - [Sql\_Trigger\_MaxBatchSize](#sql_trigger_maxbatchsize)
       - [Sql\_Trigger\_PollingIntervalMs](#sql_trigger_pollingintervalms)
       - [Sql\_Trigger\_MaxChangesPerWorker](#sql_trigger_maxchangesperworker)
+      - [WEBSITE\_SITE\_NAME](#website_site_name)
     - [Scaling for Trigger Bindings](#scaling-for-trigger-bindings)
     - [Retry support for Trigger Bindings](#retry-support-for-trigger-bindings)
       - [Startup retries](#startup-retries)
@@ -154,11 +155,10 @@ The upper limit on the number of pending changes in the user table that are allo
 
 #### WEBSITE_SITE_NAME
 
-The unique name used in creating the lease tables. The local apps depend on this setting for creating unique leases tables, please give a unique name for each app.
+If this setting exists, it will be used to generate a unique identifier for the function that is used for tracking function state. If not specified, this unique identifier will be generated from the [IHostIdProvider.GetHostIdAsync](https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Executors/IHostIdProvider.cs#L14).
 
 > **NOTE:**
 > * If the setting is re-used across apps, having the same function name could cause the functions to use the same lease tables and the function runs to not work as expected.
-> * If you have 2 different SQL trigger functions with same functionName locally, not having WEBSITE_SITE_NAME would mean that the same leasees table would be used for both triggers resulting in only one of the functions being triggered.
 > * This is a read-only variable that is provided by the Azure App service for deployed functions and the user provided value will be overridden. Refer to [Environment variables](https://learn.microsoft.com/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#app-environment) for apps.
 
 ### Scaling for Trigger Bindings

--- a/docs/TriggerBinding.md
+++ b/docs/TriggerBinding.md
@@ -96,11 +96,12 @@ To find the name of the leases table associated with your function, look in the 
 
 This log message is at the `Information` level, so make sure your log level is set correctly.
 
-NOTE: `FunctionId` is generated from a couple of inputs:
-   - The [WEBSITE_SITE_NAME](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name) setting
-   - The name of the function
+NOTE: `FunctionId` is generated from the name of the function and either
 
-If either of these values are changed then a new FunctionId will be generated and result in the function starting over from the beginning, including creating a new Leases table.
+* The [WEBSITE_SITE_NAME](https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name) setting
+* [IHostIdProvider.GetHostIdAsync](https://github.com/Azure/azure-webjobs-sdk/blob/dev/src/Microsoft.Azure.WebJobs.Host/Executors/IHostIdProvider.cs#L14) as a fallback if the WEBSITE_SITE_NAME setting doesn't exist
+
+If either the name of the function or the ID value are changed then a new FunctionId will be generated and result in the function starting over from the beginning, including creating a new Leases table.
 
 This table is used to ensure that all changes are processed and that no change is processed more than once. This table consists of two groups of columns:
 

--- a/samples/samples-csharp/local.settings.json
+++ b/samples/samples-csharp/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesCSharp",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/samples/samples-csx/local.settings.json
+++ b/samples/samples-csx/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesCsx",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/samples/samples-java/local.settings.json
+++ b/samples/samples-java/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "java",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesJava",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/samples/samples-js-v4/local.settings.json
+++ b/samples/samples-js-v4/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
-    "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesNodeV4"
+    "SqlConnectionString": ""
   }
 }

--- a/samples/samples-js/local.settings.json
+++ b/samples/samples-js/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesJavascript",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/samples/samples-outofproc/local.settings.json
+++ b/samples/samples-outofproc/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesOOP",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/samples/samples-powershell/local.settings.json
+++ b/samples/samples-powershell/local.settings.json
@@ -5,7 +5,6 @@
     "FUNCTIONS_WORKER_RUNTIME": "powershell",
     "FUNCTIONS_WORKER_RUNTIME_VERSION" : "~7.2",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesPowershell",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/samples/samples-python-v2/local.settings.json
+++ b/samples/samples-python-v2/local.settings.json
@@ -5,7 +5,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesPythonV2",
     "PYTHON_ISOLATE_WORKER_DEPENDENCIES": "1"
   }
 }

--- a/samples/samples-python/local.settings.json
+++ b/samples/samples-python/local.settings.json
@@ -4,7 +4,6 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "SqlConnectionString": "",
-    "WEBSITE_SITE_NAME": "SamplesPython",
     "Sp_SelectCost": "SelectProductsCost",
     "ProductCost": 100
   }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -54,21 +54,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             return connectionString;
         }
 
-        public static string GetWebSiteName(IConfiguration configuration)
-        {
-            if (configuration == null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-            string websitename = configuration.GetConnectionStringOrSetting(SqlBindingConstants.WEBSITENAME);
-            // We require a WEBSITE_SITE_NAME for avoiding duplicates if users use the same function name accross apps.
-            if (string.IsNullOrEmpty(websitename))
-            {
-                throw new ArgumentException($"WEBSITE_SITE_NAME cannot be null or empty in your function app settings, please update the setting with a string value. Please refer to https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name for more information.");
-            }
-            return websitename;
-        }
-
         /// <summary>
         /// Parses the parameter string into a list of parameters, where each parameter is separated by "," and has the form
         /// "@param1=param2". "@param1" is the parameter name to be used in the query or stored procedure, and param1 is the

--- a/src/TriggerBinding/SqlTriggerBinding.cs
+++ b/src/TriggerBinding/SqlTriggerBinding.cs
@@ -102,11 +102,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// gets a separate view of the table changes.
         /// </summary>
         /// <returns>The function ID, or NULL if there isn't a config value for WEBSITE_SITE_NAME</returns>
+#pragma warning disable CA1822 // Mark members as static
         private string GetWebsiteSiteNameFunctionId()
+#pragma warning restore CA1822 // Mark members as static
         {
             // Using read-only App name for the hash https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#app-environment
-            string websiteName = this._configuration.GetConnectionStringOrSetting(SqlBindingConstants.WEBSITENAME);
-            if (string.IsNullOrEmpty(websiteName))
+            // string websiteName = this._configuration.GetConnectionStringOrSetting(SqlBindingConstants.WEBSITENAME);
+            throw new ArgumentException($"WEBSITE_SITE_NAME cannot be null or empty in your function app settings, please update the setting with a string value. Please refer to https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name for more information.");
+            /*
+             * if (string.IsNullOrEmpty(websiteName))
             {
                 // TODO REVERT
                 this._logger.LogWarning("WEBSITE_SITE_NAME configuration is not set, will fall back to using function ID based on the host ID. This will mean consumption plan scaling will not work as intended.");
@@ -122,6 +126,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(websiteName + functionName));
                 return new Guid(hash.Take(16).ToArray()).ToString("N").Substring(0, 16);
             }
+            */
         }
 
         /// <summary>

--- a/src/TriggerBinding/SqlTriggerBinding.cs
+++ b/src/TriggerBinding/SqlTriggerBinding.cs
@@ -108,8 +108,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             string websiteName = this._configuration.GetConnectionStringOrSetting(SqlBindingConstants.WEBSITENAME);
             if (string.IsNullOrEmpty(websiteName))
             {
+                // TODO REVERT
                 this._logger.LogWarning("WEBSITE_SITE_NAME configuration is not set, will fall back to using function ID based on the host ID. This will mean consumption plan scaling will not work as intended.");
-                return null;
+                throw new ArgumentException($"WEBSITE_SITE_NAME cannot be null or empty in your function app settings, please update the setting with a string value. Please refer to https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name for more information.");
+                // return null;
             }
             var methodInfo = (MethodInfo)this._parameter.Member;
             // Get the function name from FunctionName attribute for .NET functions and methodInfo.Name for non .Net

--- a/src/TriggerBinding/SqlTriggerBinding.cs
+++ b/src/TriggerBinding/SqlTriggerBinding.cs
@@ -102,20 +102,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// gets a separate view of the table changes.
         /// </summary>
         /// <returns>The function ID, or NULL if there isn't a config value for WEBSITE_SITE_NAME</returns>
-#pragma warning disable CA1822 // Mark members as static
         private string GetWebsiteSiteNameFunctionId()
-#pragma warning restore CA1822 // Mark members as static
         {
             // Using read-only App name for the hash https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#app-environment
-            // string websiteName = this._configuration.GetConnectionStringOrSetting(SqlBindingConstants.WEBSITENAME);
-            throw new ArgumentException($"WEBSITE_SITE_NAME cannot be null or empty in your function app settings, please update the setting with a string value. Please refer to https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name for more information.");
-            /*
-             * if (string.IsNullOrEmpty(websiteName))
+            string websiteName = this._configuration.GetConnectionStringOrSetting(SqlBindingConstants.WEBSITENAME);
+            if (string.IsNullOrEmpty(websiteName))
             {
-                // TODO REVERT
                 this._logger.LogWarning("WEBSITE_SITE_NAME configuration is not set, will fall back to using function ID based on the host ID. This will mean consumption plan scaling will not work as intended.");
-                throw new ArgumentException($"WEBSITE_SITE_NAME cannot be null or empty in your function app settings, please update the setting with a string value. Please refer to https://github.com/Azure/azure-functions-sql-extension/blob/main/docs/BindingsOverview.md#website_site_name for more information.");
-                // return null;
+                return null;
             }
             var methodInfo = (MethodInfo)this._parameter.Member;
             // Get the function name from FunctionName attribute for .NET functions and methodInfo.Name for non .Net
@@ -126,7 +120,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 byte[] hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(websiteName + functionName));
                 return new Guid(hash.Take(16).ToArray()).ToString("N").Substring(0, 16);
             }
-            */
         }
 
         /// <summary>

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -141,7 +141,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                     var transactionSw = Stopwatch.StartNew();
                     long createdSchemaDurationMs = 0L, createGlobalStateTableDurationMs = 0L, insertGlobalStateTableRowDurationMs = 0L, createLeasesTableDurationMs = 0L;
-                    this._logger.LogInformation("Creating stuff");
                     using (SqlTransaction transaction = connection.BeginTransaction(System.Data.IsolationLevel.RepeatableRead))
                     {
                         createdSchemaDurationMs = await this.CreateSchemaAsync(connection, transaction, cancellationToken);

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -35,8 +35,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private readonly SqlObject _userTable;
         private readonly string _connectionString;
         private readonly string _userDefinedLeasesTableName;
+        /// <summary>
+        /// The unique ID we'll use to identify this function in our global state tables
+        /// </summary>
         private readonly string _userFunctionId;
-        private readonly string _oldUserFunctionId;
+        /// <summary>
+        /// The unique function ID based on the host ID - this is used for backwards compatibility to
+        /// ensure that users upgrading to the new WEBSITE_SITE_NAME based ID don't lose their state
+        /// </summary>
+        private readonly string _hostIdFunctionId;
         private readonly ITriggeredFunctionExecutor _executor;
         private readonly SqlOptions _sqlOptions;
         private readonly ILogger _logger;
@@ -59,19 +66,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <param name="connectionString">SQL connection string used to connect to user database</param>
         /// <param name="tableName">Name of the user table</param>
         /// <param name="userDefinedLeasesTableName">Optional - Name of the leases table</param>
-        /// <param name="userFunctionId">Unique identifier for the user function</param>
-        /// <param name="oldUserFunctionId">deprecated user function id value created using hostId for the user function</param>
+        /// <param name="websiteSiteNameFunctionId">Unique identifier for the user function based on the WEBSITE_SITE_NAME configuration value</param>
+        /// <param name="hostIdFunctionId">Unique identifier for the user function based on the hostId for the function</param>
         /// <param name="executor">Defines contract for triggering user function</param>
         /// <param name="sqlOptions"></param>
         /// <param name="logger">Facilitates logging of messages</param>
         /// <param name="configuration">Provides configuration values</param>
-        public SqlTriggerListener(string connectionString, string tableName, string userDefinedLeasesTableName, string userFunctionId, string oldUserFunctionId, ITriggeredFunctionExecutor executor, SqlOptions sqlOptions, ILogger logger, IConfiguration configuration)
+        public SqlTriggerListener(string connectionString, string tableName, string userDefinedLeasesTableName, string websiteSiteNameFunctionId, string hostIdFunctionId, ITriggeredFunctionExecutor executor, SqlOptions sqlOptions, ILogger logger, IConfiguration configuration)
         {
             this._connectionString = !string.IsNullOrEmpty(connectionString) ? connectionString : throw new ArgumentNullException(nameof(connectionString));
             this._userTable = !string.IsNullOrEmpty(tableName) ? new SqlObject(tableName) : throw new ArgumentNullException(nameof(tableName));
             this._userDefinedLeasesTableName = userDefinedLeasesTableName;
-            this._userFunctionId = !string.IsNullOrEmpty(userFunctionId) ? userFunctionId : throw new ArgumentNullException(nameof(userFunctionId));
-            this._oldUserFunctionId = oldUserFunctionId;
+            // We'll use the WEBSITE_SITE_NAME based ID if we have it, but some environments (like running locally) may not have it
+            // so we'll just fall back to the host ID version instead
+            this._userFunctionId = string.IsNullOrEmpty(websiteSiteNameFunctionId) ? hostIdFunctionId : websiteSiteNameFunctionId;
+            this._hostIdFunctionId = hostIdFunctionId;
             this._executor = executor ?? throw new ArgumentNullException(nameof(executor));
             this._sqlOptions = sqlOptions ?? throw new ArgumentNullException(nameof(sqlOptions));
             this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -124,7 +133,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     await VerifyDatabaseSupported(connection, this._logger, cancellationToken);
 
                     int userTableId = await GetUserTableIdAsync(connection, this._userTable, this._logger, cancellationToken);
-                    IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumnsAsync(connection, userTableId, this._logger, this._userTable.FullName, cancellationToken);
+                    IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumns(connection, userTableId, this._logger, this._userTable.FullName, cancellationToken);
                     IReadOnlyList<string> userTableColumns = this.GetUserTableColumns(connection, userTableId, cancellationToken);
 
                     string bracketedLeasesTableName = GetBracketedLeasesTableName(this._userDefinedLeasesTableName, this._userFunctionId, userTableId);
@@ -132,7 +141,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                     var transactionSw = Stopwatch.StartNew();
                     long createdSchemaDurationMs = 0L, createGlobalStateTableDurationMs = 0L, insertGlobalStateTableRowDurationMs = 0L, createLeasesTableDurationMs = 0L;
-
+                    this._logger.LogInformation("Creating stuff");
                     using (SqlTransaction transaction = connection.BeginTransaction(System.Data.IsolationLevel.RepeatableRead))
                     {
                         createdSchemaDurationMs = await this.CreateSchemaAsync(connection, transaction, cancellationToken);
@@ -394,7 +403,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
             string insertRowGlobalStateTableQuery = $@"
                 {AppLockStatements}
-                -- For back compatibility copy the lastSyncVersion from _oldUserFunctionId if it exists.
+                -- For back compatibility copy the lastSyncVersion from _hostIdFunctionId if it exists.
                 IF NOT EXISTS (
                     SELECT * FROM {GlobalStateTableName}
                     WHERE UserFunctionID = '{this._userFunctionId}' AND UserTableID = {userTableId}
@@ -402,12 +411,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 BEGIN
                     -- Migrate LastSyncVersion from oldUserFunctionId if it exists and delete the record
                     DECLARE @lastSyncVersion bigint;
-                    SELECT @lastSyncVersion = LastSyncVersion from az_func.GlobalState where UserFunctionID = '{this._oldUserFunctionId}' AND UserTableID = {userTableId}
+                    SELECT @lastSyncVersion = LastSyncVersion from az_func.GlobalState where UserFunctionID = '{this._hostIdFunctionId}' AND UserTableID = {userTableId}
                     IF @lastSyncVersion IS NULL
                         SET @lastSyncVersion = {(long)minValidVersion};
                     ELSE
-                        DELETE FROM az_func.GlobalState WHERE UserFunctionID = '{this._oldUserFunctionId}' AND UserTableID = {userTableId}
-                    
+                        DELETE FROM az_func.GlobalState WHERE UserFunctionID = '{this._hostIdFunctionId}' AND UserTableID = {userTableId}
+
                     INSERT INTO {GlobalStateTableName}
                     VALUES ('{this._userFunctionId}', {userTableId}, @lastSyncVersion, GETUTCDATE());
                 END
@@ -443,20 +452,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             string primaryKeysWithTypes = string.Join(", ", primaryKeyColumns.Select(col => $"{col.name.AsBracketQuotedString()} {col.type}"));
             string primaryKeys = string.Join(", ", primaryKeyColumns.Select(col => col.name.AsBracketQuotedString()));
-            string oldLeasesTableName = leasesTableName.Contains(this._userFunctionId) ? leasesTableName.Replace(this._userFunctionId, this._oldUserFunctionId) : string.Empty;
-
-            string createLeasesTableQuery = string.IsNullOrEmpty(oldLeasesTableName) ? $@"
-                {AppLockStatements}
-
-                IF OBJECT_ID(N'{leasesTableName}', 'U') IS NULL
-                    CREATE TABLE {leasesTableName} (
-                        {primaryKeysWithTypes},
-                        {LeasesTableChangeVersionColumnName} bigint NOT NULL,
-                        {LeasesTableAttemptCountColumnName} int NOT NULL,
-                        {LeasesTableLeaseExpirationTimeColumnName} datetime2,
-                        PRIMARY KEY ({primaryKeys})
-                    );
-            " : $@"
+            string oldLeasesTableName = leasesTableName.Contains(this._userFunctionId) ? leasesTableName.Replace(this._userFunctionId, this._hostIdFunctionId) : string.Empty;
+            // We should only migrate the lease table from the old hostId based one to the newer WEBSITE_SITE_NAME one if
+            // we're actually using the WEBSITE_SITE_NAME one (e.g. leasesTableName is different)
+            bool shouldMigrateOldLeasesTable = !string.IsNullOrEmpty(oldLeasesTableName) && oldLeasesTableName != leasesTableName;
+            string createLeasesTableQuery = shouldMigrateOldLeasesTable ? $@"
                 {AppLockStatements}
 
                 IF OBJECT_ID(N'{leasesTableName}', 'U') IS NULL
@@ -478,6 +478,18 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                         DROP TABLE {oldLeasesTableName};
                     END
                 End
+            " :
+            $@"
+                {AppLockStatements}
+
+                IF OBJECT_ID(N'{leasesTableName}', 'U') IS NULL
+                    CREATE TABLE {leasesTableName} (
+                        {primaryKeysWithTypes},
+                        {LeasesTableChangeVersionColumnName} bigint NOT NULL,
+                        {LeasesTableAttemptCountColumnName} int NOT NULL,
+                        {LeasesTableLeaseExpirationTimeColumnName} datetime2,
+                        PRIMARY KEY ({primaryKeys})
+                    );
             ";
 
             using (var createLeasesTableCommand = new SqlCommand(createLeasesTableQuery, connection, transaction))
@@ -485,7 +497,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 var stopwatch = Stopwatch.StartNew();
                 try
                 {
-                    await createLeasesTableCommand.ExecuteNonQueryAsyncWithLogging(this._logger, cancellationToken);
+                    await createLeasesTableCommand.ExecuteNonQueryAsyncWithLogging(this._logger, cancellationToken, true);
                 }
                 catch (Exception ex)
                 {

--- a/src/TriggerBinding/SqlTriggerMetricsProvider.cs
+++ b/src/TriggerBinding/SqlTriggerMetricsProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     await connection.OpenAsync();
 
                     int userTableId = await GetUserTableIdAsync(connection, this._userTable, this._logger, CancellationToken.None);
-                    IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumnsAsync(connection, userTableId, this._logger, this._userTable.FullName, CancellationToken.None);
+                    IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumns(connection, userTableId, this._logger, this._userTable.FullName, CancellationToken.None);
 
                     // Use a transaction to automatically release the app lock when we're done executing the query
                     using (SqlTransaction transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead))

--- a/src/TriggerBinding/SqlTriggerUtils.cs
+++ b/src/TriggerBinding/SqlTriggerUtils.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// <exception cref="InvalidOperationException">
         /// Thrown if there are no primary key columns present in the user table or if their names conflict with columns in leases table.
         /// </exception>
-        public static IReadOnlyList<(string name, string type)> GetPrimaryKeyColumnsAsync(SqlConnection connection, int userTableId, ILogger logger, string userTableName, CancellationToken cancellationToken)
+        public static IReadOnlyList<(string name, string type)> GetPrimaryKeyColumns(SqlConnection connection, int userTableId, ILogger logger, string userTableName, CancellationToken cancellationToken)
         {
             const int NameIndex = 0, TypeIndex = 1, LengthIndex = 2, PrecisionIndex = 3, ScaleIndex = 4;
             string getPrimaryKeyColumnsQuery = $@"

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData()]
         public async Task SingleOperationTriggerTest(SupportedLanguages lang)
         {
-            await this.SingleOperationTriggerTestImpl(lang, clearWebsiteSiteName: false);
+            await this.SingleOperationTriggerTestImpl(lang);
         }
 
         /// <summary>
@@ -52,17 +52,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         [SqlInlineData()]
         public async Task SingleOperationTriggerTest_NoWebsiteSiteName(SupportedLanguages lang)
         {
-            await this.SingleOperationTriggerTestImpl(lang, clearWebsiteSiteName: true);
+            await this.SingleOperationTriggerTestImpl(lang, new Dictionary<string, string>() { { "WEBSITE_SITE_NAME", string.Empty } });
         }
 
-        private async Task SingleOperationTriggerTestImpl(SupportedLanguages lang, bool clearWebsiteSiteName)
+        private async Task SingleOperationTriggerTestImpl(SupportedLanguages lang, IDictionary<string, string> environmentVariables = null)
         {
             this.SetChangeTrackingForTable("Products");
-            if (clearWebsiteSiteName)
-            {
-                Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", string.Empty);
-            }
-            this.StartFunctionHost(nameof(ProductsTrigger), lang);
+            this.StartFunctionHost(nameof(ProductsTrigger), lang, environmentVariables: environmentVariables);
 
             int firstId = 1;
             int lastId = 30;

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
 
         /// <summary>
         /// Ensures that the user function gets invoked for each of the insert, update and delete operation.
-        /// Does not set a WEBSITE_SITE_NAME to verify functionality without that
+        /// Sets a WEBSITE_SITE_NAME to verify functionality with that being set.
         /// </summary>
         [RetryTheory]
         [SqlInlineData()]

--- a/test/Integration/SqlTriggerBindingIntegrationTests.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTests.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// </summary>
         [RetryTheory]
         [SqlInlineData()]
-        public async Task SingleOperationTriggerTest_NoWebsiteSiteName(SupportedLanguages lang)
+        public async Task SingleOperationTriggerTest_WithWebsiteSiteName(SupportedLanguages lang)
         {
-            await this.SingleOperationTriggerTestImpl(lang, new Dictionary<string, string>() { { "WEBSITE_SITE_NAME", string.Empty } });
+            await this.SingleOperationTriggerTestImpl(lang, new Dictionary<string, string>() { { "WEBSITE_SITE_NAME", "SqlBindingsTriggerTest" } });
         }
 
         private async Task SingleOperationTriggerTestImpl(SupportedLanguages lang, IDictionary<string, string> environmentVariables = null)


### PR DESCRIPTION
We got feedback that requiring WEBSITE_SITE_NAME wasn't very friendly to the local development experience, so instead of throwing an error we'll just fall back to the original `hostIdProvider.GetHostIdAsync` call.

This should be fine, since deployed functions should ALWAYS have a site name (set by the host environment) - and for local functions the only thing being lost is consumption scaling which doesn't apply anyways.

I decided to remove the setting from the samples, since generally we shouldn't expect people to need to define it anymore. And then I added a new test that does specifically set it to make sure that things still work as expected.