### PR TITLE
Remove morelinq

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="morelinq" Version="3.4.2" />
     <PackageVersion Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="161.9135.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.1" />

--- a/performance/packages.lock.json
+++ b/performance/packages.lock.json
@@ -1792,8 +1792,7 @@
           "Microsoft.SqlServer.TransactSql.ScriptDom": "[161.9135.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Runtime.Caching": "[8.0.1, )",
-          "System.Security.AccessControl": "[6.0.1, )",
-          "morelinq": "[3.4.2, )"
+          "System.Security.AccessControl": "[6.0.1, )"
         }
       },
       "microsoft.azure.webjobs.extensions.sql.samples": {
@@ -2043,12 +2042,6 @@
         "dependencies": {
           "Castle.Core": "5.1.1"
         }
-      },
-      "morelinq": {
-        "type": "CentralTransitive",
-        "requested": "[3.4.2, )",
-        "resolved": "3.4.2",
-        "contentHash": "nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q=="
       },
       "Newtonsoft.Json": {
         "type": "CentralTransitive",

--- a/samples/samples-csharp/packages.lock.json
+++ b/samples/samples-csharp/packages.lock.json
@@ -1666,8 +1666,7 @@
           "Microsoft.SqlServer.TransactSql.ScriptDom": "[161.9135.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Runtime.Caching": "[8.0.1, )",
-          "System.Security.AccessControl": "[6.0.1, )",
-          "morelinq": "[3.4.2, )"
+          "System.Security.AccessControl": "[6.0.1, )"
         }
       },
       "Microsoft.ApplicationInsights": {
@@ -1782,12 +1781,6 @@
         "requested": "[161.9135.0, )",
         "resolved": "161.9135.0",
         "contentHash": "Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g=="
-      },
-      "morelinq": {
-        "type": "CentralTransitive",
-        "requested": "[3.4.2, )",
-        "resolved": "3.4.2",
-        "contentHash": "nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q=="
       },
       "System.Runtime.Caching": {
         "type": "CentralTransitive",

--- a/src/Common/IEnumerableExtensions.cs
+++ b/src/Common/IEnumerableExtensions.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Common
+{
+    public static class IEnumerableExtensions
+    {
+        /// <summary>
+        /// Batches the source sequence into sized buckets and applies a projection to each bucket.
+        /// </summary>
+        /// <typeparam name="TSource">Type of elements in <paramref name="source"/> sequence.</typeparam>
+        /// <param name="source">The source sequence.</param>
+        /// <param name="size">Size of buckets.</param>
+        public static IEnumerable<IEnumerable<TSource>> Batch<TSource>(
+                  this IEnumerable<TSource> source, int size)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (size <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size));
+            }
+
+            TSource[] bucket = null;
+            int count = 0;
+
+            foreach (TSource item in source)
+            {
+                if (bucket == null)
+                {
+                    bucket = new TSource[size];
+                }
+
+                bucket[count++] = item;
+                if (count != size)
+                {
+                    continue;
+                }
+
+                yield return bucket;
+
+                bucket = null;
+                count = 0;
+            }
+
+            if (bucket != null && count > 0)
+            {
+                yield return bucket.Take(count).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Returns a specified number of contiguous elements from the end of
+        /// a sequence.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/>.</typeparam>
+        /// <param name="source">The sequence to return the last element of.</param>
+        /// <param name="count">The number of elements to return.</param>
+        /// <returns>
+        /// An <see cref="IEnumerable{T}"/> that contains the specified number of
+        /// elements from the end of the input sequence.
+        /// </returns>
+        public static IEnumerable<TSource> TakeLast<TSource>(this IEnumerable<TSource> source, int count)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            return source.Skip(Math.Max(0, source.Count() - count));
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Sql.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SqlServer.TransactSql.ScriptDom" />
-    <PackageReference Include="morelinq" />
     <PackageReference Include="System.Runtime.Caching" />
     <!-- This isn't directly needed, but pinning it to v6 since v5 is deprecated and our transitive dependencies currently only ask for v5 -->
     <PackageReference Include="System.Security.AccessControl" />

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using MoreLinq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry;
@@ -23,6 +22,7 @@ using Newtonsoft.Json.Linq;
 using static Microsoft.Azure.WebJobs.Extensions.Sql.SqlBindingConstants;
 using static Microsoft.Azure.WebJobs.Extensions.Sql.SqlBindingUtilities;
 using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Common;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {

--- a/src/TriggerBinding/SqlTriggerScaleMonitor.cs
+++ b/src/TriggerBinding/SqlTriggerScaleMonitor.cs
@@ -9,7 +9,7 @@ using Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry;
 using static Microsoft.Azure.WebJobs.Extensions.Sql.Telemetry.Telemetry;
 using Microsoft.Azure.WebJobs.Host.Scale;
 using Microsoft.Extensions.Logging;
-using MoreLinq;
+using Microsoft.Azure.WebJobs.Extensions.Sql.Common;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -115,12 +115,6 @@
         "resolved": "161.9135.0",
         "contentHash": "Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g=="
       },
-      "morelinq": {
-        "type": "Direct",
-        "requested": "[3.4.2, )",
-        "resolved": "3.4.2",
-        "contentHash": "nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q=="
-      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "azurite",
-                    Arguments = "--skipVersionCheck",
                     WindowStyle = ProcessWindowStyle.Hidden,
                     UseShellExecute = true
                 }

--- a/test/Common/TestUtils.cs
+++ b/test/Common/TestUtils.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Common
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "azurite",
+                    Arguments = "--skipVersionCheck",
                     WindowStyle = ProcessWindowStyle.Hidden,
                     UseShellExecute = true
                 }

--- a/test/Unit/Common/IEnumerableExtensionsTests.cs
+++ b/test/Unit/Common/IEnumerableExtensionsTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.WebJobs.Extensions.Sql.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
+{
+    public class IEnumerableExtensionsTests
+    {
+        public static readonly TheoryData<int[], int> BatchData = new()
+        {
+            { new int[] { 1, 2, 3, 4, 5 }, 1 }, // One by one
+            { new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 3 }, // Bigger non-single batch
+            { new int[] { 1, 2, 3, 4, 5 } , 5 }, // All one batch
+            { new int[] { 1 }, 2 }, // Batch size greater than array
+        };
+
+        [Theory]
+        [MemberData(nameof(BatchData))]
+        public void Batch(IEnumerable<int> array, int batchSize)
+        {
+            int totalCount = 0;
+            foreach (IEnumerable<int> batch in array.Batch(batchSize))
+            {
+                int batchCount = batch.Count();
+                totalCount += batchCount;
+                Assert.True(batch.Count() <= batchSize);
+            }
+            Assert.Equal(totalCount, array.Count());
+        }
+
+        [Fact]
+        public void Batch_Invalid()
+        {
+            // Array must be non-null
+            Assert.ThrowsAny<Exception>(() => IEnumerableExtensions.Batch<int>(null, 0).Count());
+
+            // Size must be >= 1
+            Assert.ThrowsAny<Exception>(() => IEnumerableExtensions.Batch(new int[] { 1, 2, 3 }, 0).Count());
+            Assert.ThrowsAny<Exception>(() => IEnumerableExtensions.Batch(new int[] { 1, 2, 3 }, -1).Count());
+        }
+
+        public static readonly TheoryData<int[], int, int[]> TakeLastData = new()
+        {
+            { new int[] { 1, 2, 3, 4, 5 }, 1 , new int[] { 5 } }, // Take only last number
+            { new int[] { 1, 2, 3, 4, 5 }, 3 , new int[] { 3, 4, 5 } }, // Take some middle set of numbers
+            { new int[] { 1, 2, 3, 4, 5 }, 6 , new int[] { 1, 2, 3, 4, 5 } }, // Take more than exists in array
+            { new int[] { 1, 2, 3, 4, 5 }, 0 , Array.Empty<int>() }, // No numbers
+            { new int[] { 1, 2, 3, 4, 5 }, 0 , Array.Empty<int>() }, // Negative numbers (returns empty)
+        };
+
+        [Theory]
+        [MemberData(nameof(TakeLastData))]
+        public void TakeLast(IEnumerable<int> array, int takeCount, IEnumerable<int> expectedValues)
+        {
+            IEnumerable<int> taken = IEnumerableExtensions.TakeLast(array, takeCount);
+            Assert.Equal(taken, expectedValues);
+        }
+
+        [Fact]
+        public void TakeLast_Invalid()
+        {
+            // IEnumerable must be non-null
+            Assert.ThrowsAny<Exception>(() => { IEnumerableExtensions.TakeLast<int>(null, 0); });
+        }
+    }
+}

--- a/test/packages.lock.json
+++ b/test/packages.lock.json
@@ -1815,8 +1815,7 @@
           "Microsoft.SqlServer.TransactSql.ScriptDom": "[161.9135.0, )",
           "Newtonsoft.Json": "[13.0.3, )",
           "System.Runtime.Caching": "[8.0.1, )",
-          "System.Security.AccessControl": "[6.0.1, )",
-          "morelinq": "[3.4.2, )"
+          "System.Security.AccessControl": "[6.0.1, )"
         }
       },
       "microsoft.azure.webjobs.extensions.sql.samples": {
@@ -1923,12 +1922,6 @@
         "requested": "[161.9135.0, )",
         "resolved": "161.9135.0",
         "contentHash": "Ayubg3Qijaysyn/fJ0QMhv+ADTl5+nPcqE2KsvcIlMZGmSSRAKMxApVf947bLWNRmBIr2TlAS8cSA+cFQUZz1g=="
-      },
-      "morelinq": {
-        "type": "CentralTransitive",
-        "requested": "[3.4.2, )",
-        "resolved": "3.4.2",
-        "contentHash": "nKdpt7Ai+xQO8PZ0YFTn13INGJcKO0Nx65kO/ut0zaDirRo6d7atedmW2l68YB3x7U4pOqTLdMfYsBys8KxA1Q=="
       },
       "System.Runtime.Caching": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Closes #74 
Fixes #1177 

The functionality used from Morelinq is pretty simplistic, so just writing our own versions to avoid compat issues with the MySql binding.