### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,18 @@ updates:
       # Check for updates on Wednesday https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday
       day: "wednesday"
     ignore:
-        # Please do not bump Azure.Identity from 1.10.2, even a minor bump to 1.10.3 is causing a major bump in it's trasitive dependecny Microsoft.Identity.Client.Extensions.Msal which will fail the bundle test.
+      # Please do not bump Azure.Identity from 1.10.2, even a minor bump to 1.10.3 is causing a major bump in it's trasitive dependecny Microsoft.Identity.Client.Extensions.Msal which will fail the bundle test.
       - dependency-name: "Azure.Identity"
         # Ignore all major version bumps for semver.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/