### PR TITLE
Address Semaphore leak in SQL trigger renew leases sync

### DIFF
--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -362,9 +362,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                         // Set the rows for processing, now since the leases are acquired.
                         await this._rowsToProcessLock.WaitAsync(token);
-                        this._rowsToProcess = rows;
-                        this._state = State.ProcessingChanges;
-                        this._rowsToProcessLock.Release();
+                        try
+                        {
+                            this._rowsToProcess = rows;
+                            this._state = State.ProcessingChanges;
+                        }
+                        finally
+                        {
+                            this._rowsToProcessLock.Release();
+                        }
                     }
                     catch (Exception)
                     {
@@ -386,8 +392,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 // If there's an exception in any part of the process, we want to clear all of our data in memory and
                 // retry checking for changes again.
                 await this._rowsToProcessLock.WaitAsync(token);
-                this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
-                this._rowsToProcessLock.Release();
+                try
+                {
+                    this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
+                }
+                finally
+                {
+                    this._rowsToProcessLock.Release();
+                }
                 this._logger.LogError($"Failed to check for changes in table '{this._userTable.FullName}' due to exception: {e.GetType()}. Exception message: {e.Message}");
                 TelemetryInstance.TrackException(TelemetryErrorName.GetChanges, e, this._telemetryProps);
                 if (e.IsFatalSqlException() || connection.IsBrokenOrClosed())
@@ -442,9 +454,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                         // We've successfully fully processed these so set them to be released in the cleanup phase
                         await this._rowsToProcessLock.WaitAsync(token);
-                        this._rowsToRelease = this._rowsToProcess;
-                        this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
-                        this._rowsToProcessLock.Release();
+                        try
+                        {
+                            this._rowsToRelease = this._rowsToProcess;
+                            this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
+                        }
+                        finally
+                        {
+                            this._rowsToProcessLock.Release();
+                        }
                     }
                     TelemetryInstance.TrackEvent(
                         TelemetryEventName.TriggerFunction,
@@ -527,84 +545,87 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private async Task RenewLeasesAsync(SqlConnection connection, CancellationToken token)
         {
             await this._rowsToProcessLock.WaitAsync(token);
-
-            if (this._state == State.ProcessingChanges && this._rowsToProcess.Count > 0)
+            try
             {
-                // Use a transaction to automatically release the app lock when we're done executing the query
-                using (SqlTransaction transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead))
+                if (this._state == State.ProcessingChanges && this._rowsToProcess.Count > 0)
                 {
-                    try
+                    // Use a transaction to automatically release the app lock when we're done executing the query
+                    using (SqlTransaction transaction = connection.BeginTransaction(IsolationLevel.RepeatableRead))
                     {
-                        SqlCommand renewLeasesCommand = this.BuildRenewLeasesCommand(connection, transaction);
-                        if (renewLeasesCommand != null)
-                        {
-                            using (renewLeasesCommand)
-                            {
-                                var stopwatch = Stopwatch.StartNew();
-
-                                int rowsAffected = await renewLeasesCommand.ExecuteNonQueryAsyncWithLogging(this._logger, token, true);
-
-                                long durationMs = stopwatch.ElapsedMilliseconds;
-
-                                if (rowsAffected > 0)
-                                {
-                                    this._logger.LogDebug($"Renewed leases for {rowsAffected} rows");
-                                    // Only send an event if we actually updated rows to reduce the overall number of events we send
-                                    var measures = new Dictionary<TelemetryMeasureName, double>
-                                    {
-                                        [TelemetryMeasureName.DurationMs] = durationMs,
-                                    };
-
-                                    TelemetryInstance.TrackEvent(TelemetryEventName.RenewLeases, this._telemetryProps, measures);
-                                }
-                                transaction.Commit();
-                            }
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        // This catch block is necessary so that the finally block is executed even in the case of an exception
-                        // (see https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/try-finally, third
-                        // paragraph). If we fail to renew the leases, multiple workers could be processing the same change
-                        // data, but we have functionality in place to deal with this (see design doc).
-                        this._logger.LogError($"Failed to renew leases due to exception: {e.GetType()}. Exception message: {e.Message}");
-                        TelemetryInstance.TrackException(TelemetryErrorName.RenewLeases, e, this._telemetryProps);
-
                         try
                         {
-                            transaction.Rollback();
-                        }
-                        catch (Exception e2)
-                        {
-                            this._logger.LogError($"RenewLeases - Failed to rollback transaction due to exception: {e2.GetType()}. Exception message: {e2.Message}");
-                            TelemetryInstance.TrackException(TelemetryErrorName.RenewLeasesRollback, e2, this._telemetryProps);
-                        }
-                    }
-                    finally
-                    {
-                        // Do we want to update this count even in the case of a failure to renew the leases? Probably,
-                        // because the count is simply meant to indicate how much time the other thread has spent processing
-                        // changes essentially.
-                        this._leaseRenewalCount += 1;
+                            SqlCommand renewLeasesCommand = this.BuildRenewLeasesCommand(connection, transaction);
+                            if (renewLeasesCommand != null)
+                            {
+                                using (renewLeasesCommand)
+                                {
+                                    var stopwatch = Stopwatch.StartNew();
 
-                        // If this thread has been cancelled, then the _cancellationTokenSourceExecutor could have already
-                        // been disposed so shouldn't cancel it.
-                        if (this._leaseRenewalCount == MaxLeaseRenewalCount && !token.IsCancellationRequested)
-                        {
-                            this._logger.LogWarning("Call to execute the function (TryExecuteAsync) seems to be stuck, so it is being cancelled");
+                                    int rowsAffected = await renewLeasesCommand.ExecuteNonQueryAsyncWithLogging(this._logger, token, true);
 
-                            // If we keep renewing the leases, the thread responsible for processing the changes is stuck.
-                            // If it's stuck, it has to be stuck in the function execution call (I think), so we should
-                            // cancel the call.
-                            this._cancellationTokenSourceExecutor.Cancel();
-                            this._cancellationTokenSourceExecutor = new CancellationTokenSource();
+                                    long durationMs = stopwatch.ElapsedMilliseconds;
+
+                                    if (rowsAffected > 0)
+                                    {
+                                        this._logger.LogDebug($"Renewed leases for {rowsAffected} rows");
+                                        // Only send an event if we actually updated rows to reduce the overall number of events we send
+                                        var measures = new Dictionary<TelemetryMeasureName, double>
+                                        {
+                                            [TelemetryMeasureName.DurationMs] = durationMs,
+                                        };
+
+                                        TelemetryInstance.TrackEvent(TelemetryEventName.RenewLeases, this._telemetryProps, measures);
+                                    }
+                                    transaction.Commit();
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            // This catch block is necessary so that the finally block is executed even in the case of an exception
+                            // (see https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/try-finally, third
+                            // paragraph). If we fail to renew the leases, multiple workers could be processing the same change
+                            // data, but we have functionality in place to deal with this (see design doc).
+                            this._logger.LogError($"Failed to renew leases due to exception: {e.GetType()}. Exception message: {e.Message}");
+                            TelemetryInstance.TrackException(TelemetryErrorName.RenewLeases, e, this._telemetryProps);
+
+                            try
+                            {
+                                transaction.Rollback();
+                            }
+                            catch (Exception e2)
+                            {
+                                this._logger.LogError($"RenewLeases - Failed to rollback transaction due to exception: {e2.GetType()}. Exception message: {e2.Message}");
+                                TelemetryInstance.TrackException(TelemetryErrorName.RenewLeasesRollback, e2, this._telemetryProps);
+                            }
+                        }
+                        finally
+                        {
+                            // Do we want to update this count even in the case of a failure to renew the leases? Probably,
+                            // because the count is simply meant to indicate how much time the other thread has spent processing
+                            // changes essentially.
+                            this._leaseRenewalCount += 1;
+
+                            // If this thread has been cancelled, then the _cancellationTokenSourceExecutor could have already
+                            // been disposed so shouldn't cancel it.
+                            if (this._leaseRenewalCount == MaxLeaseRenewalCount && !token.IsCancellationRequested)
+                            {
+                                this._logger.LogWarning("Call to execute the function (TryExecuteAsync) seems to be stuck, so it is being cancelled");
+
+                                // If we keep renewing the leases, the thread responsible for processing the changes is stuck.
+                                // If it's stuck, it has to be stuck in the function execution call (I think), so we should
+                                // cancel the call.
+                                this._cancellationTokenSourceExecutor.Cancel();
+                                this._cancellationTokenSourceExecutor = new CancellationTokenSource();
+                            }
                         }
                     }
                 }
             }
-
-            // Want to always release the lock at the end, even if renewing the leases failed.
-            this._rowsToProcessLock.Release();
+            finally
+            {
+                this._rowsToProcessLock.Release();
+            }
         }
 
         /// <summary>
@@ -614,14 +635,20 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         private async Task ClearRowsAsync(CancellationToken token)
         {
             await this._rowsToProcessLock.WaitAsync(token);
-            this._leaseRenewalCount = 0;
-            this._state = State.CheckingForChanges;
-            if (this._rowsToProcess.Count > 0)
+            try
             {
-                this._logger.LogDebug($"Clearing internal state for {this._rowsToProcess.Count} rows");
+                this._leaseRenewalCount = 0;
+                this._state = State.CheckingForChanges;
+                if (this._rowsToProcess.Count > 0)
+                {
+                    this._logger.LogDebug($"Clearing internal state for {this._rowsToProcess.Count} rows");
+                }
+                this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
             }
-            this._rowsToProcess = new List<IReadOnlyDictionary<string, object>>();
-            this._rowsToProcessLock.Release();
+            finally
+            {
+                this._rowsToProcessLock.Release();
+            }
         }
 
         /// <summary>

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -622,6 +622,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     }
                 }
             }
+            catch (Exception e)
+            {
+                this._logger.LogError($"Failed to begin transaction for lease renewal due to exception: {e.GetType()}. Exception message: {e.Message}");
+                TelemetryInstance.TrackException(TelemetryErrorName.RenewLeases, e, this._telemetryProps);
+            }
             finally
             {
                 this._rowsToProcessLock.Release();


### PR DESCRIPTION
# Description

## Problem

When a SQL trigger's lease renewal connection breaks (transient SQL availability issue), `RenewLeasesAsync` can permanently leak the `_rowsToProcessLock` semaphore. `BeginTransaction()` throws after the semaphore is acquired, but `Release()` is not in a `finally` block — so it's never called. Both the change consumption loop and lease renewal loop then deadlock permanently on the next semaphore acquisition. The trigger silently stops processing with no error logs, while the host appears healthy.

**Customer impact:** Trigger on table `ReceiptImport` was dead for ~3.5 days (ICM 51000000966606). Only a host restart resolved it.

## Root Cause

In `RenewLeasesAsync`, `_rowsToProcessLock.Release()` was placed after the `if` block rather than in a `finally` — meaning any exception between `WaitAsync` and `Release` (e.g., `BeginTransaction` throwing on a broken connection) permanently leaks the semaphore.

The same pattern existed in 4 other sites: `GetTableChangesAsync` (2 sites), `ProcessTableChangesAsync`, and `ClearRowsAsync`. Only `ProcessChanges` correctly used `try/finally`.

## Fix

Wrap all `_rowsToProcessLock` acquire/release pairs in `try/finally`:

- `RenewLeasesAsync` — **primary fix** (the site that caused the customer incident)
- `GetTableChangesAsync` — commit path and error-handling path
- `ProcessTableChangesAsync` — success path
- `ClearRowsAsync` — state reset

No behavioral changes — just ensures the semaphore is always released.

In addition, go through the checklist below and check each item as you validate it is either handled or not applicable to this change.

# Code Changes

- [ ] [Unit tests](https://github.com/Azure/azure-functions-sql-extension/tree/main/test/Unit) are added, if possible
- [ ] [Integration tests](https://github.com/Azure/azure-functions-sql-extension/tree/main/test/Integration)  are added if the change is modifying existing behavior of one or more of the bindings
- [x] New or changed code follows the C# style guidelines defined in .editorconfig
- [x] All changes MUST be backwards compatible and changes to the shared `az_func.GlobalState` table must be compatible with all prior versions of the extension
- [x] Use the `ILogger` instance to log relevant information, especially information useful for debugging or troubleshooting
- [x] Use `async` and `await` for all long-running operations
- [x] Ensure proper usage and propagation of `CancellationToken`
- [x] T-SQL is safe from SQL Injection attacks through the use of [SqlParameters](https://learn.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlparameter) and proper escaping/sanitization of input

# Dependencies

- [x] If updating dependencies, run `dotnet restore --force-evaluate` to update the lock files and ensure that there are NO major versions updates in either [src/packages.lock.json](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/packages.lock.json) or [Worker.Extensions.Sql/src/packages.lock.json](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/packages.lock.json). If there are, contact the dev team for instructions.

# Documentation

- [ ] Add [samples](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples) if the change is modifying or adding functionality
- [ ] Update relevant documentation in the [docs](https://github.com/Azure/azure-functions-sql-extension/tree/main/docs)
