### PR TITLE
Add startup/connection diagnostic logging

### DIFF
--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             TelemetryInstance.TrackCreate(CreateType.SqlAsyncCollector);
             using (SqlConnection connection = BuildConnection(attribute.ConnectionStringSetting, configuration))
             {
-                connection.OpenAsyncWithSqlErrorHandling(CancellationToken.None).Wait();
+                connection.OpenAsyncWithSqlErrorHandling(logger, CancellationToken.None).Wait();
                 VerifyDatabaseSupported(connection, logger, CancellationToken.None).Wait();
             }
         }
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             var upsertRowsAsyncSw = Stopwatch.StartNew();
             using (SqlConnection connection = BuildConnection(attribute.ConnectionStringSetting, configuration))
             {
-                await connection.OpenAsync();
+                await connection.OpenAsyncWithSqlErrorHandling(this._logger, CancellationToken.None);
                 this._serverProperties = await GetServerTelemetryProperties(connection, this._logger, CancellationToken.None);
                 Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps(this._serverProperties);
 

--- a/src/SqlAsyncCollector.cs
+++ b/src/SqlAsyncCollector.cs
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             var upsertRowsAsyncSw = Stopwatch.StartNew();
             using (SqlConnection connection = BuildConnection(attribute.ConnectionStringSetting, configuration))
             {
-                await connection.OpenAsyncWithSqlErrorHandling(this._logger, CancellationToken.None);
+                await connection.OpenAsyncWithLogging(this._logger, CancellationToken.None);
                 this._serverProperties = await GetServerTelemetryProperties(connection, this._logger, CancellationToken.None);
                 Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps(this._serverProperties);
 

--- a/src/SqlAsyncEnumerable.cs
+++ b/src/SqlAsyncEnumerable.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this._attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
-            this.Connection.OpenAsyncWithSqlErrorHandling(logger, CancellationToken.None).GetAwaiter().GetResult();
+            this.Connection.OpenWithSqlErrorHandling(logger);
         }
         /// <summary>
         /// Returns the enumerator associated with this enumerable. The enumerator will execute the query specified

--- a/src/SqlAsyncEnumerable.cs
+++ b/src/SqlAsyncEnumerable.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using static Microsoft.Azure.WebJobs.Extensions.Sql.SqlBindingConstants;
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
@@ -21,14 +22,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// </summary>
         /// <param name="connection">The SqlConnection to be used by the enumerator</param>
         /// <param name="attribute">The attribute containing the query, parameters, and query type</param>
+        /// <param name="logger">The logger used to record the connection operation</param>
         /// <exception cref="ArgumentNullException">
         /// Thrown if either connection or attribute is null
         /// </exception>
-        public SqlAsyncEnumerable(SqlConnection connection, SqlAttribute attribute)
+        public SqlAsyncEnumerable(SqlConnection connection, SqlAttribute attribute, ILogger logger)
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this._attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
-            this.Connection.Open();
+            this.Connection.OpenAsyncWithSqlErrorHandling(logger, CancellationToken.None).GetAwaiter().GetResult();
         }
         /// <summary>
         /// Returns the enumerator associated with this enumerable. The enumerator will execute the query specified

--- a/src/SqlAsyncEnumerable.cs
+++ b/src/SqlAsyncEnumerable.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             this.Connection = connection ?? throw new ArgumentNullException(nameof(connection));
             this._attribute = attribute ?? throw new ArgumentNullException(nameof(attribute));
-            this.Connection.OpenWithSqlErrorHandling(logger);
+            this.Connection.OpenWithLogging(logger);
         }
         /// <summary>
         /// Returns the enumerator associated with this enumerable. The enumerator will execute the query specified

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -245,31 +245,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
-        /// Opens a connection synchronously and handles some specific errors if they occur.
-        /// </summary>
-        /// <param name="connection">The connection to open</param>
-        /// <param name="logger">The logger used to record the operation</param>
-        /// <exception cref="InvalidOperationException">Thrown if an error occurred that we want to wrap with more information</exception>
-        internal static void OpenWithSqlErrorHandling(this SqlConnection connection, ILogger logger)
-        {
-            try
-            {
-                connection.OpenWithLogging(logger);
-            }
-            catch (Exception e)
-            {
-                SqlException sqlEx = e is AggregateException a ? a.InnerExceptions.OfType<SqlException>().First() :
-                    e is SqlException s ? s :
-                    null;
-                if (sqlEx?.Number == -2146893019)
-                {
-                    throw new InvalidOperationException("The default values for encryption on connections have been changed, please review your configuration to ensure you have the correct values for your server. See https://aka.ms/afsqlext-connection for more details.", e);
-                }
-                throw;
-            }
-        }
-
-        /// <summary>
         /// Opens a connection and logs the start and completion of the operation.
         /// </summary>
         /// <param name="connection">The connection to open</param>
@@ -370,7 +345,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         conn.Close();
                     }
-                    await conn.OpenAsyncWithSqlErrorHandling(logger, token);
+                    await conn.OpenAsyncWithLogging(logger, token);
                     logger.LogInformation($"Successfully re-established {connectionName}!");
                     return true;
                 }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -245,6 +245,31 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         }
 
         /// <summary>
+        /// Opens a connection synchronously and handles some specific errors if they occur.
+        /// </summary>
+        /// <param name="connection">The connection to open</param>
+        /// <param name="logger">The logger used to record the operation</param>
+        /// <exception cref="InvalidOperationException">Thrown if an error occurred that we want to wrap with more information</exception>
+        internal static void OpenWithSqlErrorHandling(this SqlConnection connection, ILogger logger)
+        {
+            try
+            {
+                connection.OpenWithLogging(logger);
+            }
+            catch (Exception e)
+            {
+                SqlException sqlEx = e is AggregateException a ? a.InnerExceptions.OfType<SqlException>().First() :
+                    e is SqlException s ? s :
+                    null;
+                if (sqlEx?.Number == -2146893019)
+                {
+                    throw new InvalidOperationException("The default values for encryption on connections have been changed, please review your configuration to ensure you have the correct values for your server. See https://aka.ms/afsqlext-connection for more details.", e);
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
         /// Opens a connection and logs the start and completion of the operation.
         /// </summary>
         /// <param name="connection">The connection to open</param>
@@ -254,9 +279,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         internal static async Task OpenAsyncWithLogging(this SqlConnection connection, ILogger logger, CancellationToken cancellationToken)
         {
             var stopwatch = Stopwatch.StartNew();
-            logger?.LogInformation("Starting to open SQL connection.");
+            logger?.LogDebug("Starting to open SQL connection.");
             await connection.OpenAsync(cancellationToken);
-            logger?.LogInformation($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
+            logger?.LogDebug($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
+        }
+
+        /// <summary>
+        /// Opens a connection synchronously and logs the start and completion of the operation.
+        /// </summary>
+        /// <param name="connection">The connection to open</param>
+        /// <param name="logger">The logger used to record the operation</param>
+        internal static void OpenWithLogging(this SqlConnection connection, ILogger logger)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            logger?.LogDebug("Starting to open SQL connection.");
+            connection.Open();
+            logger?.LogDebug($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
         }
 
         /// <summary>

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Threading;
@@ -216,14 +217,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         /// Opens a connection and handles some specific errors if they occur.
         /// </summary>
         /// <param name="connection">The connection to open</param>
+        /// <param name="logger">The logger used to record the operation</param>
         /// <param name="cancellationToken">The cancellation token to pass to the OpenAsync call</param>
         /// <returns>The task that will be completed when the connection is made</returns>
         /// <exception cref="InvalidOperationException">Thrown if an error occurred that we want to wrap with more information</exception>
-        internal static async Task OpenAsyncWithSqlErrorHandling(this SqlConnection connection, CancellationToken cancellationToken)
+        internal static async Task OpenAsyncWithSqlErrorHandling(this SqlConnection connection, ILogger logger, CancellationToken cancellationToken)
         {
             try
             {
-                await connection.OpenAsync(cancellationToken);
+                await connection.OpenAsyncWithLogging(logger, cancellationToken);
             }
             catch (Exception e)
             {
@@ -240,6 +242,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 }
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Opens a connection and logs the start and completion of the operation.
+        /// </summary>
+        /// <param name="connection">The connection to open</param>
+        /// <param name="logger">The logger used to record the operation</param>
+        /// <param name="cancellationToken">The cancellation token to pass to the OpenAsync call</param>
+        /// <returns>The task that will be completed when the connection is made</returns>
+        internal static async Task OpenAsyncWithLogging(this SqlConnection connection, ILogger logger, CancellationToken cancellationToken)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            logger?.LogInformation("Starting to open SQL connection.");
+            await connection.OpenAsync(cancellationToken);
+            logger?.LogInformation($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
         }
 
         /// <summary>
@@ -315,7 +332,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                     {
                         conn.Close();
                     }
-                    await conn.OpenAsync(token);
+                    await conn.OpenAsyncWithSqlErrorHandling(logger, token);
                     logger.LogInformation($"Successfully re-established {connectionName}!");
                     return true;
                 }

--- a/src/SqlBindingUtilities.cs
+++ b/src/SqlBindingUtilities.cs
@@ -255,8 +255,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             var stopwatch = Stopwatch.StartNew();
             logger?.LogDebug("Starting to open SQL connection.");
-            await connection.OpenAsync(cancellationToken);
-            logger?.LogDebug($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
+            try
+            {
+                await connection.OpenAsync(cancellationToken);
+                logger?.LogDebug($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                logger?.LogDebug($"Canceled opening SQL connection after {stopwatch.ElapsedMilliseconds}ms.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, $"Failed to open SQL connection after {stopwatch.ElapsedMilliseconds}ms.");
+                throw;
+            }
         }
 
         /// <summary>
@@ -268,8 +281,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
         {
             var stopwatch = Stopwatch.StartNew();
             logger?.LogDebug("Starting to open SQL connection.");
-            connection.Open();
-            logger?.LogDebug($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
+            try
+            {
+                connection.Open();
+                logger?.LogDebug($"Completed opening SQL connection in {stopwatch.ElapsedMilliseconds}ms.");
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, $"Failed to open SQL connection after {stopwatch.ElapsedMilliseconds}ms.");
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/SqlConverters.cs
+++ b/src/SqlConverters.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
                 using (SqlCommand command = SqlBindingUtilities.BuildCommand(attribute, connection))
                 {
                     adapter.SelectCommand = command;
-                    await connection.OpenAsyncWithSqlErrorHandling(CancellationToken.None);
+                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, CancellationToken.None);
                     this._serverProperties = await SqlBindingUtilities.GetServerTelemetryProperties(connection, this._logger, CancellationToken.None);
                     Dictionary<TelemetryPropertyName, string> props = connection.AsConnectionProps(this._serverProperties);
                     TelemetryInstance.TrackConvert(type, props);
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 try
                 {
-                    var asyncEnumerable = new SqlAsyncEnumerable<T>(SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, this._configuration), attribute);
+                    var asyncEnumerable = new SqlAsyncEnumerable<T>(SqlBindingUtilities.BuildConnection(attribute.ConnectionStringSetting, this._configuration), attribute, this._logger);
                     Dictionary<TelemetryPropertyName, string> props = asyncEnumerable.Connection.AsConnectionProps(this._serverProperties);
                     TelemetryInstance.TrackConvert(ConvertType.IAsyncEnumerable, props);
                     return asyncEnumerable;

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsync(token);
+                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, token);
 
                     bool forceReconnect = false;
                     // Check for cancellation request only after a cycle of checking and processing of changes completes.
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsync(token);
+                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, token);
 
                     bool forceReconnect = false;
                     while (!token.IsCancellationRequested)

--- a/src/TriggerBinding/SqlTableChangeMonitor.cs
+++ b/src/TriggerBinding/SqlTableChangeMonitor.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, token);
+                    await connection.OpenAsyncWithLogging(this._logger, token);
 
                     bool forceReconnect = false;
                     // Check for cancellation request only after a cycle of checking and processing of changes completes.
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, token);
+                    await connection.OpenAsyncWithLogging(this._logger, token);
 
                     bool forceReconnect = false;
                     while (!token.IsCancellationRequested)

--- a/src/TriggerBinding/SqlTriggerBinding.cs
+++ b/src/TriggerBinding/SqlTriggerBinding.cs
@@ -17,6 +17,7 @@ using Microsoft.Azure.WebJobs.Host.Triggers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+using static Microsoft.Azure.WebJobs.Extensions.Sql.SqlTriggerUtils;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
@@ -79,7 +80,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             _ = context ?? throw new ArgumentNullException(nameof(context), "Missing listener context");
 
             string websiteSiteNameFunctionId = this.GetWebsiteSiteNameFunctionId();
-            string hostIdFunctionId = await this.GetHostIdFunctionIdAsync();
+            string hostIdFunctionId = null;
+            await RunStartupPhaseAsync("ResolveHostId", this._tableName, null, this._logger, async () =>
+            {
+                hostIdFunctionId = await this.GetHostIdFunctionIdAsync();
+            });
             return new SqlTriggerListener<T>(this._connectionString, this._tableName, this._leasesTableName, websiteSiteNameFunctionId, hostIdFunctionId, context.Executor, this._sqlOptions, this._logger, this._configuration);
         }
 

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -133,51 +133,66 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             }
 
             this.InitializeTelemetryProps();
+            var startupStopwatch = Stopwatch.StartNew();
 
             try
             {
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsyncWithSqlErrorHandling(cancellationToken);
-                    ServerProperties serverProperties = await GetServerTelemetryProperties(connection, this._logger, cancellationToken);
-                    this._telemetryProps.AddConnectionProps(connection, serverProperties);
+                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, cancellationToken);
 
-                    await VerifyDatabaseSupported(connection, this._logger, cancellationToken);
+                    int userTableId = 0;
+                    IReadOnlyList<(string name, string type)> primaryKeyColumns = null;
+                    IReadOnlyList<string> userTableColumns = null;
+                    await RunStartupPhaseAsync("ValidateDatabaseMetadata", this._userTable.FullName, this._userFunctionId, this._logger, async () =>
+                    {
+                        ServerProperties serverProperties = await GetServerTelemetryProperties(connection, this._logger, cancellationToken);
+                        this._telemetryProps.AddConnectionProps(connection, serverProperties);
 
-                    int userTableId = await GetUserTableIdAsync(connection, this._userTable, this._logger, cancellationToken);
-                    IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumns(connection, userTableId, this._logger, this._userTable.FullName, cancellationToken);
-                    IReadOnlyList<string> userTableColumns = this.GetUserTableColumns(connection, userTableId, cancellationToken);
+                        await VerifyDatabaseSupported(connection, this._logger, cancellationToken);
+
+                        userTableId = await GetUserTableIdAsync(connection, this._userTable, this._logger, cancellationToken);
+                        primaryKeyColumns = GetPrimaryKeyColumns(connection, userTableId, this._logger, this._userTable.FullName, cancellationToken);
+                        userTableColumns = this.GetUserTableColumns(connection, userTableId, cancellationToken);
+                    });
 
                     string bracketedLeasesTableName = GetBracketedLeasesTableName(this._userDefinedLeasesTableName, this._userFunctionId, userTableId);
                     this._telemetryProps[TelemetryPropertyName.LeasesTableName] = bracketedLeasesTableName;
 
                     var transactionSw = Stopwatch.StartNew();
                     long createdSchemaDurationMs = 0L, createGlobalStateTableDurationMs = 0L, insertGlobalStateTableRowDurationMs = 0L, createLeasesTableDurationMs = 0L;
-                    using (SqlTransaction transaction = connection.BeginTransaction(System.Data.IsolationLevel.RepeatableRead))
+                    await RunStartupPhaseAsync("InitializeTriggerState", this._userTable.FullName, this._userFunctionId, this._logger, async () =>
                     {
-                        createdSchemaDurationMs = await this.CreateSchemaAsync(connection, transaction, cancellationToken);
-                        createGlobalStateTableDurationMs = await this.CreateGlobalStateTableAsync(connection, transaction, cancellationToken);
-                        insertGlobalStateTableRowDurationMs = await this.InsertGlobalStateTableRowAsync(connection, transaction, userTableId, cancellationToken);
-                        createLeasesTableDurationMs = await this.CreateLeasesTableAsync(connection, transaction, bracketedLeasesTableName, primaryKeyColumns, cancellationToken);
-                        transaction.Commit();
-                    }
+                        using (SqlTransaction transaction = connection.BeginTransaction(System.Data.IsolationLevel.RepeatableRead))
+                        {
+                            createdSchemaDurationMs = await this.CreateSchemaAsync(connection, transaction, cancellationToken);
+                            createGlobalStateTableDurationMs = await this.CreateGlobalStateTableAsync(connection, transaction, cancellationToken);
+                            insertGlobalStateTableRowDurationMs = await this.InsertGlobalStateTableRowAsync(connection, transaction, userTableId, cancellationToken);
+                            createLeasesTableDurationMs = await this.CreateLeasesTableAsync(connection, transaction, bracketedLeasesTableName, primaryKeyColumns, cancellationToken);
+                            transaction.Commit();
+                        }
+                    });
 
-                    this._changeMonitor = new SqlTableChangeMonitor<T>(
-                        this._connectionString,
-                        userTableId,
-                        this._userTable,
-                        this._userFunctionId,
-                        bracketedLeasesTableName,
-                        userTableColumns,
-                        primaryKeyColumns,
-                        this._executor,
-                        this._sqlOptions,
-                        this._logger,
-                        this._configuration,
-                        this._telemetryProps);
+                    await RunStartupPhaseAsync("CreateChangeMonitor", this._userTable.FullName, this._userFunctionId, this._logger, () =>
+                    {
+                        this._changeMonitor = new SqlTableChangeMonitor<T>(
+                            this._connectionString,
+                            userTableId,
+                            this._userTable,
+                            this._userFunctionId,
+                            bracketedLeasesTableName,
+                            userTableColumns,
+                            primaryKeyColumns,
+                            this._executor,
+                            this._sqlOptions,
+                            this._logger,
+                            this._configuration,
+                            this._telemetryProps);
+                        return Task.CompletedTask;
+                    });
 
                     this._listenerState = ListenerStarted;
-                    this._logger.LogDebug($"Started SQL trigger listener for table: '{this._userTable.FullName}' (object ID: {userTableId}), function ID: {this._userFunctionId}, leases table: {bracketedLeasesTableName}");
+                    this._logger.LogInformation($"Started SQL trigger listener for table: '{this._userTable.FullName}' (object ID: {userTableId}), function ID: {this._userFunctionId}, leases table: {bracketedLeasesTableName} in {startupStopwatch.ElapsedMilliseconds}ms.");
 
                     var measures = new Dictionary<TelemetryMeasureName, double>
                     {
@@ -202,7 +217,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             catch (Exception ex)
             {
                 this._listenerState = ListenerNotStarted;
-                this._logger.LogError($"Failed to start SQL trigger listener for table: '{this._userTable.FullName}', function ID: '{this._userFunctionId}'. Exception: {ex}");
+                this._logger.LogError($"Failed to start SQL trigger listener for table: '{this._userTable.FullName}', function ID: '{this._userFunctionId}' after {startupStopwatch.ElapsedMilliseconds}ms. Exception: {ex}");
                 TelemetryInstance.TrackException(TelemetryErrorName.StartListener, ex, this._telemetryProps);
 
                 throw;

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             catch (Exception ex)
             {
                 this._listenerState = ListenerNotStarted;
-                this._logger.LogError($"Failed to start SQL trigger listener for table: '{this._userTable.FullName}', function ID: '{this._userFunctionId}' after {startupStopwatch.ElapsedMilliseconds}ms. Exception: {ex}");
+                this._logger.LogError(ex, $"Failed to start SQL trigger listener for table: '{this._userTable.FullName}', function ID: '{this._userFunctionId}' after {startupStopwatch.ElapsedMilliseconds}ms.");
                 TelemetryInstance.TrackException(TelemetryErrorName.StartListener, ex, this._telemetryProps);
 
                 throw;

--- a/src/TriggerBinding/SqlTriggerListener.cs
+++ b/src/TriggerBinding/SqlTriggerListener.cs
@@ -139,7 +139,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, cancellationToken);
+                    await RunStartupPhaseAsync("OpenConnection", this._userTable.FullName, this._userFunctionId, this._logger, async () =>
+                    {
+                        await connection.OpenAsyncWithSqlErrorHandling(this._logger, cancellationToken);
+                    });
 
                     int userTableId = 0;
                     IReadOnlyList<(string name, string type)> primaryKeyColumns = null;

--- a/src/TriggerBinding/SqlTriggerMetricsProvider.cs
+++ b/src/TriggerBinding/SqlTriggerMetricsProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsync();
+                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, CancellationToken.None);
 
                     int userTableId = await GetUserTableIdAsync(connection, this._userTable, this._logger, CancellationToken.None);
                     IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumns(connection, userTableId, this._logger, this._userTable.FullName, CancellationToken.None);

--- a/src/TriggerBinding/SqlTriggerMetricsProvider.cs
+++ b/src/TriggerBinding/SqlTriggerMetricsProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             {
                 using (var connection = new SqlConnection(this._connectionString))
                 {
-                    await connection.OpenAsyncWithSqlErrorHandling(this._logger, CancellationToken.None);
+                    await connection.OpenAsyncWithLogging(this._logger, CancellationToken.None);
 
                     int userTableId = await GetUserTableIdAsync(connection, this._userTable, this._logger, CancellationToken.None);
                     IReadOnlyList<(string name, string type)> primaryKeyColumns = GetPrimaryKeyColumns(connection, userTableId, this._logger, this._userTable.FullName, CancellationToken.None);

--- a/src/TriggerBinding/SqlTriggerUtils.cs
+++ b/src/TriggerBinding/SqlTriggerUtils.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             string getChangeCountCommand = $"SELECT COUNT_BIG(*) FROM CHANGETABLE(CHANGES {userTable.BracketQuotedFullName}, null) AS ChTbl;";
             using (var connection = new SqlConnection(connectionString))
             {
-                await connection.OpenAsyncWithSqlErrorHandling(logger, cancellationToken);
+                await connection.OpenAsyncWithLogging(logger, cancellationToken);
                 using (var getChangesCount = new SqlCommand(getChangeCountCommand, connection))
                 {
                     object result = await getChangesCount.ExecuteScalarAsyncWithLogging(logger, cancellationToken, true);

--- a/src/TriggerBinding/SqlTriggerUtils.cs
+++ b/src/TriggerBinding/SqlTriggerUtils.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -15,6 +16,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
 {
     public static class SqlTriggerUtils
     {
+        internal static async Task RunStartupPhaseAsync(string phaseName, string tableName, string userFunctionId, ILogger logger, Func<Task> action)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            string functionIdLog = string.IsNullOrEmpty(userFunctionId) ? string.Empty : $", function ID: '{userFunctionId}'";
+            logger.LogInformation($"SQL trigger startup phase '{phaseName}' started for table: '{tableName}'{functionIdLog}.");
+            try
+            {
+                await action();
+                logger.LogInformation($"SQL trigger startup phase '{phaseName}' completed for table: '{tableName}'{functionIdLog} in {stopwatch.ElapsedMilliseconds}ms.");
+            }
+            catch (Exception ex)
+            {
+                logger.LogError($"SQL trigger startup phase '{phaseName}' failed for table: '{tableName}'{functionIdLog} after {stopwatch.ElapsedMilliseconds}ms. Exception: {ex}");
+                throw;
+            }
+        }
 
         /// <summary>
         /// Gets the names and types of primary key columns of the user table.
@@ -140,7 +157,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             string getChangeCountCommand = $"SELECT COUNT_BIG(*) FROM CHANGETABLE(CHANGES {userTable.BracketQuotedFullName}, null) AS ChTbl;";
             using (var connection = new SqlConnection(connectionString))
             {
-                connection.Open();
+                await connection.OpenAsyncWithSqlErrorHandling(logger, cancellationToken);
                 using (var getChangesCount = new SqlCommand(getChangeCountCommand, connection))
                 {
                     object result = await getChangesCount.ExecuteScalarAsyncWithLogging(logger, cancellationToken, true);

--- a/src/TriggerBinding/SqlTriggerUtils.cs
+++ b/src/TriggerBinding/SqlTriggerUtils.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql
             }
             catch (Exception ex)
             {
-                logger.LogError($"SQL trigger startup phase '{phaseName}' failed for table: '{tableName}'{functionIdLog} after {stopwatch.ElapsedMilliseconds}ms. Exception: {ex}");
+                logger.LogError(ex, $"SQL trigger startup phase '{phaseName}' failed for table: '{tableName}'{functionIdLog} after {stopwatch.ElapsedMilliseconds}ms.");
                 throw;
             }
         }

--- a/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
+++ b/test/Integration/SqlTriggerBindingIntegrationTestBase.cs
@@ -147,20 +147,22 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
         /// <param name="expectedErrorMessage">Expected error message string</param>
         protected void StartFunctionHostAndWaitForError(string functionName, SupportedLanguages lang, bool useTestFolder, string expectedErrorMessage)
         {
-            string errorMessage = null;
+            bool listenerFailureLogged = false;
+            bool expectedErrorLogged = false;
             var tcs = new TaskCompletionSource<bool>();
 
             void OutputHandler(object sender, DataReceivedEventArgs e)
             {
-                if (errorMessage == null && e.Data?.Contains("Failed to start SQL trigger listener") == true)
+                if (e.Data == null)
                 {
-                    // SQL trigger listener throws exception of type InvalidOperationException for all error conditions.
-                    string exceptionPrefix = "Exception: System.InvalidOperationException: ";
-                    int index = e.Data.IndexOf(exceptionPrefix, StringComparison.Ordinal);
-                    Assert.NotEqual(-1, index);
+                    return;
+                }
 
-                    errorMessage = e.Data[(index + exceptionPrefix.Length)..];
-                    tcs.SetResult(true);
+                listenerFailureLogged |= e.Data.Contains("Failed to start SQL trigger listener", StringComparison.Ordinal);
+                expectedErrorLogged |= e.Data.Contains(expectedErrorMessage, StringComparison.Ordinal);
+                if (listenerFailureLogged && expectedErrorLogged)
+                {
+                    tcs.TrySetResult(true);
                 }
             }
             ;
@@ -175,8 +177,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Integration
             this.FunctionHost.OutputDataReceived -= OutputHandler;
             this.FunctionHost.Kill(true);
 
-            Assert.True(isCompleted, "Functions host did not log failure to start SQL trigger listener within specified time.");
-            Assert.Equal(expectedErrorMessage, errorMessage);
+            Assert.True(isCompleted, $"Functions host did not log expected failure to start SQL trigger listener within specified time. Expected error: {expectedErrorMessage}");
         }
 
         /// <summary>

--- a/test/Unit/SqlInputBindingTests.cs
+++ b/test/Unit/SqlInputBindingTests.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public void TestNullArgumentsSqlAsyncEnumerableConstructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(connection, null));
-            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(null, new SqlAttribute("", "SqlConnectionString")));
+            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(connection, null, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new SqlAsyncEnumerable<string>(null, new SqlAttribute("", "SqlConnectionString"), logger.Object));
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public void TestInvalidOperationSqlAsyncEnumerableConstructor()
         {
-            Assert.Throws<InvalidOperationException>(() => new SqlAsyncEnumerable<string>(connection, new SqlAttribute("", "SqlConnectionString")));
+            Assert.Throws<InvalidOperationException>(() => new SqlAsyncEnumerable<string>(connection, new SqlAttribute("", "SqlConnectionString"), logger.Object));
         }
 
         [Fact]

--- a/test/Unit/TriggerBinding/SqlTriggerUtilsTests.cs
+++ b/test/Unit/TriggerBinding/SqlTriggerUtilsTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
         [Fact]
         public async Task RunStartupPhaseAsync_RunsActionAndLogsPhase()
         {
-            (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
+            (Mock<ILogger> mockLogger, List<string> logMessages, List<Exception> logExceptions) = CreateMockLogger();
             bool actionRun = false;
 
             await SqlTriggerUtils.RunStartupPhaseAsync("TestPhase", "dbo.Products", "testFunctionId", mockLogger.Object, () =>
@@ -30,12 +30,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             Assert.Equal("SQL trigger startup phase 'TestPhase' started for table: 'dbo.Products', function ID: 'testFunctionId'.", logMessages[0]);
             Assert.StartsWith("SQL trigger startup phase 'TestPhase' completed for table: 'dbo.Products', function ID: 'testFunctionId' in ", logMessages[1]);
             Assert.EndsWith("ms.", logMessages[1]);
+            Assert.All(logExceptions, Assert.Null);
         }
 
         [Fact]
         public async Task RunStartupPhaseAsync_LogsPhaseFailureAndRethrows()
         {
-            (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
+            (Mock<ILogger> mockLogger, List<string> logMessages, List<Exception> logExceptions) = CreateMockLogger();
             var expectedException = new InvalidOperationException("Test failure");
 
             InvalidOperationException actualException = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -45,21 +46,24 @@ namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
             Assert.Equal(2, logMessages.Count);
             Assert.Equal("SQL trigger startup phase 'FailingPhase' started for table: 'dbo.Products', function ID: 'testFunctionId'.", logMessages[0]);
             Assert.StartsWith("SQL trigger startup phase 'FailingPhase' failed for table: 'dbo.Products', function ID: 'testFunctionId' after ", logMessages[1]);
-            Assert.Contains("Test failure", logMessages[1]);
+            Assert.Null(logExceptions[0]);
+            Assert.Same(expectedException, logExceptions[1]);
         }
 
-        private static (Mock<ILogger> logger, List<string> logMessages) CreateMockLogger()
+        private static (Mock<ILogger> logger, List<string> logMessages, List<Exception> logExceptions) CreateMockLogger()
         {
             var logMessages = new List<string>();
+            var logExceptions = new List<Exception>();
             var mockLogger = new Mock<ILogger>();
             mockLogger
-                .Setup(logger => logger.Log(It.IsAny<LogLevel>(), 0, It.IsAny<FormattedLogValues>(), null, It.IsAny<Func<object, Exception, string>>()))
+                .Setup(logger => logger.Log(It.IsAny<LogLevel>(), 0, It.IsAny<FormattedLogValues>(), It.IsAny<Exception>(), It.IsAny<Func<object, Exception, string>>()))
                 .Callback((LogLevel logLevel, EventId eventId, object state, Exception exception, Func<object, Exception, string> formatter) =>
                 {
                     logMessages.Add(state.ToString());
+                    logExceptions.Add(exception);
                 });
 
-            return (mockLogger, logMessages);
+            return (mockLogger, logMessages, logExceptions);
         }
     }
 }

--- a/test/Unit/TriggerBinding/SqlTriggerUtilsTests.cs
+++ b/test/Unit/TriggerBinding/SqlTriggerUtilsTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Sql.Tests.Unit
+{
+    public class SqlTriggerUtilsTests
+    {
+        [Fact]
+        public async Task RunStartupPhaseAsync_RunsActionAndLogsPhase()
+        {
+            (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
+            bool actionRun = false;
+
+            await SqlTriggerUtils.RunStartupPhaseAsync("TestPhase", "dbo.Products", "testFunctionId", mockLogger.Object, () =>
+            {
+                actionRun = true;
+                return Task.CompletedTask;
+            });
+
+            Assert.True(actionRun);
+            Assert.Equal(2, logMessages.Count);
+            Assert.Equal("SQL trigger startup phase 'TestPhase' started for table: 'dbo.Products', function ID: 'testFunctionId'.", logMessages[0]);
+            Assert.StartsWith("SQL trigger startup phase 'TestPhase' completed for table: 'dbo.Products', function ID: 'testFunctionId' in ", logMessages[1]);
+            Assert.EndsWith("ms.", logMessages[1]);
+        }
+
+        [Fact]
+        public async Task RunStartupPhaseAsync_LogsPhaseFailureAndRethrows()
+        {
+            (Mock<ILogger> mockLogger, List<string> logMessages) = CreateMockLogger();
+            var expectedException = new InvalidOperationException("Test failure");
+
+            InvalidOperationException actualException = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                SqlTriggerUtils.RunStartupPhaseAsync("FailingPhase", "dbo.Products", "testFunctionId", mockLogger.Object, () => throw expectedException));
+
+            Assert.Same(expectedException, actualException);
+            Assert.Equal(2, logMessages.Count);
+            Assert.Equal("SQL trigger startup phase 'FailingPhase' started for table: 'dbo.Products', function ID: 'testFunctionId'.", logMessages[0]);
+            Assert.StartsWith("SQL trigger startup phase 'FailingPhase' failed for table: 'dbo.Products', function ID: 'testFunctionId' after ", logMessages[1]);
+            Assert.Contains("Test failure", logMessages[1]);
+        }
+
+        private static (Mock<ILogger> logger, List<string> logMessages) CreateMockLogger()
+        {
+            var logMessages = new List<string>();
+            var mockLogger = new Mock<ILogger>();
+            mockLogger
+                .Setup(logger => logger.Log(It.IsAny<LogLevel>(), 0, It.IsAny<FormattedLogValues>(), null, It.IsAny<Func<object, Exception, string>>()))
+                .Callback((LogLevel logLevel, EventId eventId, object state, Exception exception, Func<object, Exception, string> formatter) =>
+                {
+                    logMessages.Add(state.ToString());
+                });
+
+            return (mockLogger, logMessages);
+        }
+    }
+}


### PR DESCRIPTION
# Description

Add more logging around startup phases and connections to help troubleshoot binding issues. Right now if the binding gets stuck early on it can be difficult to diagnose with the logs we currently have, so these should help understand where things are getting stuck.

# Code Changes

- [x] [Unit tests](https://github.com/Azure/azure-functions-sql-extension/tree/main/test/Unit) are added, if possible
- [ ] [Integration tests](https://github.com/Azure/azure-functions-sql-extension/tree/main/test/Integration)  are added if the change is modifying existing behavior of one or more of the bindings
- [x] New or changed code follows the C# style guidelines defined in .editorconfig
- [x] All changes MUST be backwards compatible and changes to the shared `az_func.GlobalState` table must be compatible with all prior versions of the extension
- [x] Use the `ILogger` instance to log relevant information, especially information useful for debugging or troubleshooting
- [x] Use `async` and `await` for all long-running operations
- [x] Ensure proper usage and propagation of `CancellationToken`
- [ ] T-SQL is safe from SQL Injection attacks through the use of [SqlParameters](https://learn.microsoft.com/dotnet/api/microsoft.data.sqlclient.sqlparameter) and proper escaping/sanitization of input

# Dependencies

- [ ] If updating dependencies, run `dotnet restore --force-evaluate` to update the lock files and ensure that there are NO major versions updates in either [src/packages.lock.json](https://github.com/Azure/azure-functions-sql-extension/blob/main/src/packages.lock.json) or [Worker.Extensions.Sql/src/packages.lock.json](https://github.com/Azure/azure-functions-sql-extension/blob/main/Worker.Extensions.Sql/src/packages.lock.json). If there are, contact the dev team for instructions.

# Documentation

- [ ] Add [samples](https://github.com/Azure/azure-functions-sql-extension/tree/main/samples) if the change is modifying or adding functionality
- [ ] Update relevant documentation in the [docs](https://github.com/Azure/azure-functions-sql-extension/tree/main/docs)
